### PR TITLE
fix(windows): URL-encode npm root in claude-fixed.bat so paths with spaces work

### DIFF
--- a/claude-fixed.bat
+++ b/claude-fixed.bat
@@ -17,6 +17,10 @@ REM
 REM Credit: @TomTheMenace (https://github.com/anthropics/claude-code/issues/38335)
 REM Part of claude-code-cache-fix: https://github.com/cnighswonger/claude-code-cache-fix
 
+REM Resolve npm global root and URL-encode it so spaces (e.g. "C:\Program Files\nodejs")
+REM don't break NODE_OPTIONS parsing. Without encoding, Node splits --import file:/// on
+REM the literal space and fails with ERR_MODULE_NOT_FOUND: Cannot find module 'C:\Program'.
 for /f "delims=" %%G in ('npm root -g') do set "NPM_GLOBAL=%%G"
-set NODE_OPTIONS=--import file:///%NPM_GLOBAL:\=/%/claude-code-cache-fix/preload.mjs
+for /f "delims=" %%U in ('powershell -NoProfile -Command "[System.Uri]::EscapeUriString(('%NPM_GLOBAL:\=/%' + '/claude-code-cache-fix/preload.mjs'))"') do set "PRELOAD_URL=%%U"
+set NODE_OPTIONS=--import file:///%PRELOAD_URL%
 node "%NPM_GLOBAL%\@anthropic-ai\claude-code\cli.js" %*


### PR DESCRIPTION
## Summary

`claude-fixed.bat` fails on default Node.js installs where npm's global root contains a space (e.g. the installer-default `C:\Program Files\nodejs\node_modules`).

The wrapper currently builds:

```
NODE_OPTIONS=--import file:///C:/Program Files/nodejs/node_modules/claude-code-cache-fix/preload.mjs
```

Node parses `NODE_OPTIONS` as argv and splits on whitespace, so only `file:///C:/Program` reaches the ESM resolver:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'C:\Program' imported from C:\Users\<user>\
  url: 'file:///C:/Program'
```

Users on scoop / nvm-windows / pnpm-managed Node aren't affected because those prefixes are space-free, so the bug only surfaces for the most common install path.

## Fix

Pass the path through `[System.Uri]::EscapeUriString` via an inline PowerShell call before embedding it in the `file:///` URL. Spaces become `%20`; paths without spaces round-trip unchanged.

```bat
for /f "delims=" %%G in ('npm root -g') do set "NPM_GLOBAL=%%G"
for /f "delims=" %%U in ('powershell -NoProfile -Command "[System.Uri]::EscapeUriString(('%NPM_GLOBAL:\=/%' + '/claude-code-cache-fix/preload.mjs'))"') do set "PRELOAD_URL=%%U"
set NODE_OPTIONS=--import file:///%PRELOAD_URL%
```

Added a short comment above the block explaining the rationale so the next person touching this doesn't re-introduce the bug.

## Test plan

- [x] `C:\Program Files\nodejs\node_modules` (space in path) — `claude-fixed --help` now resolves the preload and prints Claude Code help (no more `ERR_MODULE_NOT_FOUND: Cannot find module 'C:\Program'`). I did not exercise a real API call, so I can't personally confirm the `CACHE_FIX_DEBUG=1` health line here — worth a reviewer eyeball on that.
- [x] Space-free npm root — verified `[System.Uri]::EscapeUriString` is a no-op on ASCII-only paths: `C:/Users/Jaros/AppData/Roaming/npm/...` round-trips byte-identical, so behavior on scoop/nvm/pnpm installs is unchanged.
- [x] Args forwarding via `%*` — `claude-fixed --help` forwards through to `cli.js` and prints the usage text.