### PR TITLE
fix: fingerprint verification for CC v2.1.108+ (isMeta filter change)

### DIFF
--- a/preload.mjs
+++ b/preload.mjs
@@ -128,14 +128,37 @@ function stabilizeFingerprint(system, messages) {
 
   // --- SAFETY: Round-trip verification ---
   // Verify our salt/indices reproduce CC's fingerprint for the ORIGINAL
-  // message text (messages[0] content, which is what CC used).
-  // If our computation doesn't match, our constants are stale — skip rewrite.
-  const originalText = extractFirstMessageText(messages);
-  const verification = computeFingerprint(originalText, baseVersion);
-  if (verification !== oldFingerprint) {
+  // message text that CC used.
+  //
+  // Prior to v2.1.108, CC computed the fingerprint from messages[0] content
+  // (including meta/attachment blocks). Starting in v2.1.108, CC switched to
+  // an internal `!isMeta` filter (HoY function), which skips synthetic
+  // system-reminder blocks. In the API payload, this is equivalent to finding
+  // the first text block that doesn't start with "<system-reminder>".
+  //
+  // We try both extraction methods: the new "real user message" first (v2.1.108+),
+  // then fall back to the legacy "first message text" for older versions.
+  // This keeps the safety check working across CC versions.
+  //
+  // Discovered by @ArkNill via mitmproxy + CC source analysis on v2.1.108.
+  const realText = extractRealUserMessageText(messages);
+  const realVerification = computeFingerprint(realText, baseVersion);
+  const legacyText = extractFirstMessageText(messages);
+  const legacyVerification = computeFingerprint(legacyText, baseVersion);
+
+  let verificationPassed = false;
+  if (realVerification === oldFingerprint) {
+    verificationPassed = true;
+    debugLog("FINGERPRINT VERIFY: matched via real user message text (v2.1.108+ path)");
+  } else if (legacyVerification === oldFingerprint) {
+    verificationPassed = true;
+    debugLog("FINGERPRINT VERIFY: matched via legacy messages[0] text (pre-v2.1.108 path)");
+  }
+
+  if (!verificationPassed) {
     debugLog(
       "FINGERPRINT SAFETY: round-trip verification failed.",
-      `CC sent '${oldFingerprint}', we computed '${verification}'.`,
+      `CC sent '${oldFingerprint}', real='${realVerification}', legacy='${legacyVerification}'.`,
       "Salt/indices may have changed in this CC version. Skipping rewrite."
     );
     recordFixResult("fingerprint", "safety_blocked");
@@ -143,8 +166,7 @@ function stabilizeFingerprint(system, messages) {
   }
   // --- END SAFETY ---
 
-  // Compute stable fingerprint from real user text
-  const realText = extractRealUserMessageText(messages);
+  // Compute stable fingerprint from real user text (already extracted above)
   const stableFingerprint = computeFingerprint(realText, baseVersion);
 
   if (stableFingerprint === oldFingerprint) return null; // already correct


### PR DESCRIPTION
## Summary

- **Problem**: Fingerprint stabilization fix is fully disabled on CC v2.1.108+ due to safety check failure. Every API call logs `FINGERPRINT SAFETY: round-trip verification failed` and records `safety_blocked`.

- **Root cause**: CC v2.1.108 changed how it computes `cc_version` fingerprint. The internal `HoY()` function now filters by `!isMeta` before extracting text for fingerprint computation, skipping synthetic `<system-reminder>` blocks. The existing `extractFirstMessageText()` used in the safety check includes these blocks, producing a different fingerprint than CC computed.

- **Fix**: Try both extraction methods in the safety check — the new "real user message" path first (matches v2.1.108+ behavior), then fall back to the legacy "first message text" path (matches pre-v2.1.108 behavior). This keeps the safety check working across CC versions without any configuration changes.

## Evidence

**Before (v1.10.0 on CC v2.1.108):**
```
FINGERPRINT SAFETY: round-trip verification failed.
CC sent '4b7', we computed '037'.
Salt/indices may have changed in this CC version. Skipping rewrite.
```
Stats: `fingerprint.safetyBlocked: 5` across all calls.

**After (this PR on CC v2.1.108):**
```
FINGERPRINT VERIFY: matched via real user message text (v2.1.108+ path)
```
Stats: `fingerprint.safetyBlocked: 0`, `fingerprint.skipped: 2` (correct — fingerprint already stable).

## CC source analysis

CC v2.1.108 `cli.js` (minified):
```javascript
function HoY(q) {
  let K = q.find((z) => z.type === "user" && !z.isMeta);
  if (!K) return "";
  let _ = K.message.content;
  // ...
}
```

The `!z.isMeta` filter maps to skipping `<system-reminder>` blocks in the API payload — exactly what `extractRealUserMessageText()` already does.

Salt (`59cf53e54c78`) and indices (`[4, 7, 20]`) are unchanged in v2.1.108.

## Test plan

- [x] Verified on Windows 11 + CC v2.1.108 + Node.js 24
- [x] `CACHE_FIX_DEBUG=1` confirms `FINGERPRINT VERIFY: matched via real user message text (v2.1.108+ path)`
- [x] `cache-fix-stats.json` shows `safetyBlocked: 0`
- [ ] Verify backward compatibility on pre-v2.1.108 (legacy path should activate)
- [ ] Run existing test suite (`npm test`)