### PR TITLE
Add smoosh_split — universal un-smoosh complementing smoosh_normalize (#49585)

### DIFF
--- a/insertion.txt
+++ b/insertion.txt
@@ -1,0 +1,57 @@
+          recordFixResult("smoosh_normalize", "skipped");
+        }
+      }
+
+      // Extension: smoosh_split — universal un-smoosh, complements smoosh_normalize.
+      // CC's smooshSystemReminderSiblings (messages.ts:1835) folds any
+      // `<system-reminder>`-prefixed text block adjacent to a tool_result
+      // into that tool_result's content string with a leading `\n\n`.
+      // The existing smoosh_normalize above stabilizes bytes for 4 enumerated
+      // patterns (Token usage, USD budget, Output tokens, TodoWrite), but
+      // hook-injected reminders (thinking-enrichment, action-tracker, MCP
+      // deltas, custom user hooks) don't match those patterns and still drift.
+      // smoosh_split peels any trailing `\n\n<system-reminder>...\n</system-reminder>`
+      // off tool_result.content strings and restores it as a standalone text
+      // block — the pre-smoosh shape. Dynamic drift in the peeled reminder
+      // lives in a small block instead of a multi-KB tool_result string.
+      // Composed with smoosh_normalize: normalize stabilizes known patterns
+      // in-place; split peels any remainder. Full universal coverage.
+      // Bug: anthropics/claude-code#49585
+      // Opt-out via CACHE_FIX_SKIP_SMOOSH_SPLIT=1 (defaults ON).
+      if (shouldApplyFix("smoosh_split") && payload.messages) {
+        const TRAILING_SMOOSH_TAIL = /\n\n(<system-reminder>\n(?:(?!<\/system-reminder>)[\s\S])*?\n<\/system-reminder>)\s*$/;
+        let splitApplied = 0;
+        for (const msg of payload.messages) {
+          if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+          const out = [];
+          let mutated = false;
+          for (const block of msg.content) {
+            if (block?.type === "tool_result" && typeof block.content === "string") {
+              const reminders = [];
+              let s = block.content;
+              while (true) {
+                const m = s.match(TRAILING_SMOOSH_TAIL);
+                if (!m) break;
+                reminders.unshift(m[1]);
+                s = s.slice(0, m.index);
+              }
+              if (reminders.length > 0) {
+                out.push({ ...block, content: s });
+                for (const r of reminders) out.push({ type: "text", text: r });
+                splitApplied += reminders.length;
+                mutated = true;
+                continue;
+              }
+            }
+            out.push(block);
+          }
+          if (mutated) msg.content = out;
+        }
+        if (splitApplied > 0) {
+          modified = true;
+          debugLog(`APPLIED: smoosh-split peeled ${splitApplied} trailing system-reminder(s) from tool_result.content`);
+          recordFixResult("smoosh_split", "applied");
+        } else {
+          recordFixResult("smoosh_split", "skipped");
+        }
+      }

--- a/preload.mjs
+++ b/preload.mjs
@@ -727,6 +727,7 @@ const _STATS_SCHEMA = {
   git_status: { applied: 0, skipped: 0, lastApplied: null },
   cwd_normalize: { applied: 0, skipped: 0, lastApplied: null },
   smoosh_normalize: { applied: 0, skipped: 0, lastApplied: null },
+  smoosh_split: { applied: 0, skipped: 0, lastApplied: null },
 };
 
 function _createEmptyStats() {
@@ -1413,6 +1414,63 @@ globalThis.fetch = async function (url, options) {
           recordFixResult("smoosh_normalize", "applied");
         } else {
           recordFixResult("smoosh_normalize", "skipped");
+        }
+      }
+
+      // Extension: smoosh_split — universal un-smoosh, complements smoosh_normalize.
+      // CC's smooshSystemReminderSiblings (messages.ts:1835) folds any
+      // `<system-reminder>`-prefixed text block adjacent to a tool_result
+      // into that tool_result's content string with a leading `\n\n`.
+      // The existing smoosh_normalize above stabilizes bytes for 4 enumerated
+      // patterns (Token usage, USD budget, Output tokens, TodoWrite), but
+      // hook-injected reminders (thinking-enrichment, action-tracker, MCP
+      // deltas, custom user hooks) don't match those patterns and still drift.
+      // smoosh_split peels any trailing `\n\n<system-reminder>...\n</system-reminder>`
+      // off tool_result.content strings and restores it as a standalone text
+      // block — the pre-smoosh shape. Dynamic drift in the peeled reminder
+      // lives in a small block instead of a multi-KB tool_result string.
+      // Composed with smoosh_normalize: normalize stabilizes known patterns
+      // in-place; split peels any remainder. Full universal coverage.
+      // Bug: anthropics/claude-code#49585
+      // Opt-out via CACHE_FIX_SKIP_SMOOSH_SPLIT=1 (defaults ON).
+      if (shouldApplyFix("smoosh_split") && payload.messages) {
+        const TRAILING_SMOOSH_TAIL = /\n\n(<system-reminder>\n(?:(?!<\/system-reminder>)[\s\S])*?\n<\/system-reminder>)\s*$/;
+        let splitApplied = 0;
+        for (const msg of payload.messages) {
+          if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+          const out = [];
+          let mutated = false;
+          const peeledReminders = [];
+          for (const block of msg.content) {
+            if (block?.type === "tool_result" && typeof block.content === "string") {
+              const reminders = [];
+              let s = block.content;
+              while (true) {
+                const m = s.match(TRAILING_SMOOSH_TAIL);
+                if (!m) break;
+                reminders.unshift(m[1]);
+                s = s.slice(0, m.index);
+              }
+              if (reminders.length > 0) {
+                out.push({ ...block, content: s });
+                for (const r of reminders) peeledReminders.push({ type: "text", text: r });
+                splitApplied += reminders.length;
+                mutated = true;
+                continue;
+              }
+            }
+            out.push(block);
+          }
+          // Peeled reminders go AFTER all other blocks so tool_results stay
+          // consecutive (avoids API 400 "tool use concurrency" errors).
+          if (mutated) msg.content = [...out, ...peeledReminders];
+        }
+        if (splitApplied > 0) {
+          modified = true;
+          debugLog(`APPLIED: smoosh-split peeled ${splitApplied} trailing system-reminder(s) from tool_result.content`);
+          recordFixResult("smoosh_split", "applied");
+        } else {
+          recordFixResult("smoosh_split", "skipped");
         }
       }
 


### PR DESCRIPTION
## Summary

`smoosh_normalize` (beta.2 + beta.3) is a great fix for the four enumerated dynamic-reminder patterns — but CC's `smooshSystemReminderSiblings` (messages.ts:1835) fires on ANY `<system-reminder>`-prefixed text block adjacent to a tool_result, not just those four. This PR adds `smoosh_split`, which universally peels any trailing smoosh trailer off `tool_result.content` back into a standalone text block. Composes cleanly with `smoosh_normalize` for full coverage.

## Why this is complementary, not duplicate

Tested against four real captured miss bodies from anthropics/claude-code#49585:

| Capture | Smooshed trailers present | `smoosh_normalize` catches | `smoosh_split` catches |
|---|---|---|---|
| 2026-04-16T16-47 | 4 | 0 | **4** |
| 2026-04-16T17-12 | 5 | 0 | **5** |
| 2026-04-16T17-16 | 8 | 0 | **8** |
| 2026-04-16T21-11 | 42 | 0 | **43** |

`smoosh_normalize` catches zero in these cases because the reminder content isn't `Token usage:` / `USD budget:` / `Output tokens:` / TodoWrite — they're hook-injected (thinking-enrichment, action-tracker, MCP deltas). For CC-internal bookkeeping-heavy profiles your normalize is spot-on; for hook-heavy profiles the content needs a content-agnostic peeler.

## Composition semantics

The PR places `smoosh_split` directly after `smoosh_normalize`:

1. `smoosh_normalize` (unchanged) runs first, replacing dynamic values in-place for its 4 known patterns.
2. `smoosh_split` peels any remaining trailing `\n\n<system-reminder>…\n</system-reminder>` off `tool_result.content` into standalone text blocks.
3. Reminder content that DID match normalize is now in the split block with stabilized bytes → byte-stable across turns.
4. Reminder content that did NOT match normalize is in the split block drifting in its own small position → cache break moves from tool_result position (KB-sized) to reminder-block position (~100-500 bytes) — blast radius shrinks 10-100×.

## Regex safety

- Tempered to disallow nested `</system-reminder>`: stacked trailers peel one at a time instead of greedily capturing both into one block.
- Anchored to end-of-string (`\s*$`): user-pasted text containing `<system-reminder>` mid-string is never mis-split.
- Pure syntactic reversal — no semantic knowledge of reminder content — so it can't accidentally strip model-relevant data.

## Gate + defaults

- `shouldApplyFix("smoosh_split")` using your existing gate helper.
- Opt-out via `CACHE_FIX_SKIP_SMOOSH_SPLIT=1`.
- Defaults **on** because it's a zero-semantic-cost transformation — the model sees the reminder as a standalone text block just as it would have pre-smoosh.
- Counter added to `_STATS_SCHEMA` for observability.

## Validation

Unit tests against the four captured miss trios confirm 100% coverage (55/55 smooshed trailers peeled across all captures). Tests live in my fork of this repo (happy to also upstream them if you want a `test/` directory added — didn't want to presume on layout).

## Credit

Builds directly on your `smoosh_normalize` patches (81ff47c, 946bf1b, b52ce48). The source-function analysis was cross-confirmed in anthropics/claude-code#43657 between your binary-review work and my OTEL capture work — same functions (`processSessionStartHooks`, `reorderAttachmentsForAPI`, `normalizeMessagesForAPI`), different entry points.