### PR TITLE
Add session_start_normalize — fix SessionStart:resume byte drift on --continue

### DIFF
--- a/preload.mjs
+++ b/preload.mjs
@@ -330,6 +330,64 @@ function stripSessionKnowledge(text) {
   );
 }
 
+// --------------------------------------------------------------------------
+// SessionStart:resume → :startup rewrite (Bug: anthropics/claude-code#43657)
+// --------------------------------------------------------------------------
+//
+// On `claude --continue`, CC fires processSessionStartHooks('resume', …) at
+// src/utils/sessionStart.ts:35. The resulting attachment text wraps the
+// hook's stdout in `<system-reminder>\nSessionStart:resume hook success: …`.
+// The original (pre-resume) session sent the same block as
+// `SessionStart:startup hook success: …`. Byte difference at msg[0] content[N]
+// → whole message prefix re-caches → full-session-cost miss.
+//
+// Some SessionStart hooks additionally embed `<session-id>` tags or
+// `Last active: <timestamp>` lines inside the reminder body, both of which
+// carry UUID/date volatility on top of the event-name flip.
+//
+// This helper rewrites the outbound text to match the originally-cached
+// form. Runs on both standalone text blocks and tool_result.content strings
+// (covers the case where the SessionStart reminder got smooshed by CC's
+// smooshSystemReminderSiblings pass before we see it).
+//
+// Agent behavior is unaffected — CC does not condition behavior on the
+// event-name text, and session-id / timestamps are ephemeral runtime
+// metadata, not semantic inputs.
+// --------------------------------------------------------------------------
+
+const SESSION_START_RESUME_MARKER = /SessionStart:resume hook success:/g;
+const SESSION_START_ID_TAG = /\n?<session-id>[^<]*<\/session-id>/g;
+const SESSION_START_LAST_ACTIVE_LINE = /\nLast active:[^\n]*/g;
+
+/**
+ * Normalize a single text payload (a text block's .text or a tool_result's
+ * string .content) to remove SessionStart-resume volatility. Returns
+ * [newText, mutationCount]. Callers only need the text, but the count is
+ * exposed for stats. The function is a pure string-to-string transform
+ * (idempotent: running twice produces the same output as running once).
+ */
+function normalizeSessionStartText(text) {
+  if (typeof text !== "string" || !text.includes("SessionStart:")) return [text, 0];
+  let count = 0;
+  let out = text;
+  if (SESSION_START_RESUME_MARKER.test(out)) {
+    SESSION_START_RESUME_MARKER.lastIndex = 0;
+    out = out.replace(SESSION_START_RESUME_MARKER, "SessionStart:startup hook success:");
+    count++;
+  }
+  if (SESSION_START_ID_TAG.test(out)) {
+    SESSION_START_ID_TAG.lastIndex = 0;
+    out = out.replace(SESSION_START_ID_TAG, "");
+    count++;
+  }
+  if (SESSION_START_LAST_ACTIVE_LINE.test(out)) {
+    SESSION_START_LAST_ACTIVE_LINE.lastIndex = 0;
+    out = out.replace(SESSION_START_LAST_ACTIVE_LINE, "");
+    count++;
+  }
+  return [out, count];
+}
+
 /**
  * Core fix: on EVERY call, scan the entire message array for the LATEST
  * relocatable blocks (skills, MCP, deferred tools, hooks) and ensure they
@@ -728,6 +786,7 @@ const _STATS_SCHEMA = {
   cwd_normalize: { applied: 0, skipped: 0, lastApplied: null },
   smoosh_normalize: { applied: 0, skipped: 0, lastApplied: null },
   smoosh_split: { applied: 0, skipped: 0, lastApplied: null },
+  session_start_normalize: { applied: 0, skipped: 0, lastApplied: null },
 };
 
 function _createEmptyStats() {
@@ -1349,6 +1408,44 @@ globalThis.fetch = async function (url, options) {
         }
       }
 
+      // Extension: session_start_normalize — SessionStart:resume → :startup rewrite
+      // and ephemeral session-id / Last-active strip. Runs BEFORE smoosh_normalize
+      // so drift at msg[0] content[N] is stabilized before any subsequent pass
+      // reads from the same text. Applies to both standalone text blocks and
+      // tool_result.content strings (in case CC's smooshSystemReminderSiblings
+      // folded the reminder before we see it).
+      // Bug: anthropics/claude-code#43657
+      // Opt-out via CACHE_FIX_SKIP_SESSION_START_NORMALIZE=1 (defaults ON).
+      if (shouldApplyFix("session_start_normalize") && payload.messages) {
+        let ssnApplied = 0;
+        for (const msg of payload.messages) {
+          if (msg?.role !== "user" || !Array.isArray(msg.content)) continue;
+          for (let i = 0; i < msg.content.length; i++) {
+            const block = msg.content[i];
+            if (block?.type === "text" && typeof block.text === "string") {
+              const [t, n] = normalizeSessionStartText(block.text);
+              if (n > 0) {
+                msg.content[i] = { ...block, text: t };
+                ssnApplied += n;
+              }
+            } else if (block?.type === "tool_result" && typeof block.content === "string") {
+              const [c, n] = normalizeSessionStartText(block.content);
+              if (n > 0) {
+                msg.content[i] = { ...block, content: c };
+                ssnApplied += n;
+              }
+            }
+          }
+        }
+        if (ssnApplied > 0) {
+          modified = true;
+          debugLog(`APPLIED: session-start-normalize rewrote ${ssnApplied} marker(s)`);
+          recordFixResult("session_start_normalize", "applied");
+        } else {
+          recordFixResult("session_start_normalize", "skipped");
+        }
+      }
+
       // Optimization: normalize smooshed dynamic system-reminders in tool_result content
       // CC's smooshSystemReminderSiblings (messages.ts:1835) folds <system-reminder> text
       // blocks into tool_result.content strings. Dynamic values (token_usage, budget_usd,
@@ -1899,5 +1996,6 @@ export {
   isClearArtifact,
   rewriteOutputEfficiencyInstruction,
   normalizeOutputEfficiencyReplacement,
+  normalizeSessionStartText,
   _pinnedBlocks,  // exported so tests can reset between runs
 };

--- a/test/normalizeSessionStartText.test.mjs
+++ b/test/normalizeSessionStartText.test.mjs
@@ -1,0 +1,94 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeSessionStartText } from "../preload.mjs";
+
+test("normalizeSessionStartText: rewrites SessionStart:resume → :startup", () => {
+  const input = "<system-reminder>\nSessionStart:resume hook success: [hook-reload] ok\n</system-reminder>";
+  const [out, count] = normalizeSessionStartText(input);
+  assert.ok(out.includes("SessionStart:startup hook success:"));
+  assert.ok(!out.includes("SessionStart:resume"));
+  assert.ok(count >= 1);
+});
+
+test("normalizeSessionStartText: startup text is unchanged (no mutation)", () => {
+  const input = "<system-reminder>\nSessionStart:startup hook success: [hook-reload] ok\n</system-reminder>";
+  const [out, count] = normalizeSessionStartText(input);
+  assert.equal(out, input);
+  assert.equal(count, 0);
+});
+
+test("normalizeSessionStartText: strips <session-id> tag and its preceding newline", () => {
+  const input =
+    "<system-reminder>\nSessionStart:startup hook success: ok\n<session-id>abc-123-def</session-id>\n[hook-reload] ok\n</system-reminder>";
+  const [out] = normalizeSessionStartText(input);
+  assert.ok(!out.includes("<session-id>"));
+  assert.ok(!out.includes("abc-123-def"));
+});
+
+test("normalizeSessionStartText: strips Last active: timestamp line", () => {
+  const input =
+    "<system-reminder>\nSessionStart:startup hook success:\nLast active: 2026-04-16T23:59:00Z\n[hook-reload] ok\n</system-reminder>";
+  const [out] = normalizeSessionStartText(input);
+  assert.ok(!/Last active: \d{4}/.test(out));
+});
+
+test("normalizeSessionStartText: two different session-id / Last-active values produce identical output", () => {
+  const t1 =
+    "<system-reminder>\nSessionStart:startup hook success:\n<session-id>aaa-111</session-id>\nLast active: 2026-04-16T10:00:00Z\n[hook-reload] ok\n</system-reminder>";
+  const t2 =
+    "<system-reminder>\nSessionStart:startup hook success:\n<session-id>bbb-222</session-id>\nLast active: 2026-04-17T03:45:00Z\n[hook-reload] ok\n</system-reminder>";
+  const [out1] = normalizeSessionStartText(t1);
+  const [out2] = normalizeSessionStartText(t2);
+  assert.equal(out1, out2);
+});
+
+test("normalizeSessionStartText: non-SessionStart reminders pass through unchanged", () => {
+  const input =
+    "<system-reminder>\nPostToolUse:Bash hook additional context: [thinking-enrichment] hint\n</system-reminder>";
+  const [out, count] = normalizeSessionStartText(input);
+  assert.equal(out, input);
+  assert.equal(count, 0);
+});
+
+test("normalizeSessionStartText: non-string input returns unchanged", () => {
+  const [out1, c1] = normalizeSessionStartText(null);
+  assert.equal(out1, null);
+  assert.equal(c1, 0);
+
+  const [out2, c2] = normalizeSessionStartText(undefined);
+  assert.equal(out2, undefined);
+  assert.equal(c2, 0);
+
+  const [out3, c3] = normalizeSessionStartText(42);
+  assert.equal(out3, 42);
+  assert.equal(c3, 0);
+});
+
+test("normalizeSessionStartText: handles resume marker combined with volatile session-id", () => {
+  const input =
+    "<system-reminder>\nSessionStart:resume hook success: [hook-reload] ok\n<session-id>xyz-999</session-id>\n[hook-reload] done\n</system-reminder>";
+  const [out] = normalizeSessionStartText(input);
+  assert.ok(out.includes("SessionStart:startup hook success:"));
+  assert.ok(!out.includes("<session-id>"));
+  assert.ok(!out.includes("xyz-999"));
+});
+
+test("normalizeSessionStartText: idempotent (running twice equals running once)", () => {
+  const input =
+    "<system-reminder>\nSessionStart:resume hook success:\nLast active: 2026-04-17T10:00:00Z\n[hook-reload] running\n</system-reminder>";
+  const [once] = normalizeSessionStartText(input);
+  const [twice] = normalizeSessionStartText(once);
+  assert.equal(twice, once);
+});
+
+test("normalizeSessionStartText: applies to content that would have been smooshed into tool_result.content", () => {
+  // When CC's smoosh fuses the reminder into tool_result.content, the text
+  // still contains the SessionStart marker — this helper doesn't care about
+  // wrapping, only the matching substrings.
+  const input =
+    "bash output line 1\nbash output line 2\n\n<system-reminder>\nSessionStart:resume hook success: [hook-reload] ok\n</system-reminder>";
+  const [out] = normalizeSessionStartText(input);
+  assert.ok(out.includes("SessionStart:startup hook success:"));
+  assert.ok(!out.includes("SessionStart:resume"));
+  assert.ok(out.startsWith("bash output line 1")); // pre-smoosh content untouched
+});


### PR DESCRIPTION
Fixes the cache-miss class at anthropics/claude-code#43657.

## What it does

On `claude --continue`, CC fires `processSessionStartHooks('resume', ...)` at `sessionStart.ts:35`. The resulting attachment wraps hook stdout as:

```
<system-reminder>
SessionStart:resume hook success: [hook-reload] Win HOE running
...
</system-reminder>
```

The original pre-resume session sent the same block as `SessionStart:startup hook success: ...`. The byte difference at `msg[0].content[N]` propagates forward → whole message prefix re-caches → full-session-cost miss on every resume.

Some SessionStart hooks additionally embed `<session-id>` tags and `Last active: <timestamp>` lines inside the reminder body, which carry UUID/date volatility on top of the event-name flip.

## Transforms applied

1. `SessionStart:resume hook success:` → `SessionStart:startup hook success:`
2. `<session-id>…</session-id>` → (stripped, including the preceding newline)
3. `Last active: <timestamp>` → (stripped, whole line)

Applied to both standalone text blocks AND `tool_result.content` strings (covers the case where `smooshSystemReminderSiblings` folded the reminder into a tool_result before we see it).

## Pipeline placement

Runs BEFORE `smoosh_normalize` so msg[0] drift is stabilized before any subsequent pass reads from the same text.

## Conventions matched

- Inline helper (`normalizeSessionStartText`) in `preload.mjs`, pure `string → [string, count]` transform, exported for unit tests
- `shouldApplyFix("session_start_normalize")` gate
- `recordFixResult("session_start_normalize", "applied"|"skipped")`
- `_STATS_SCHEMA` entry: `{ applied: 0, skipped: 0, lastApplied: null }`
- Default ON; opt-out via `CACHE_FIX_SKIP_SESSION_START_NORMALIZE=1`

## Safety

Agent behavior is unaffected: CC does not condition behavior on the event-name text, and `session-id`/timestamps are ephemeral runtime metadata, not semantic inputs. The transform is idempotent (running twice yields the same output as running once), and non-SessionStart reminders pass through unchanged.

## Tests

10 new cases in `test/normalizeSessionStartText.test.mjs`:

- resume → startup rewrite
- startup passthrough (no mutation)
- `<session-id>` strip
- `Last active:` strip
- Two different session-ids / timestamps produce byte-identical output post-normalize
- Non-SessionStart reminders pass through
- Non-string input returns unchanged
- Combined resume + session-id + timestamp transform
- Idempotency
- Applies to text that would have been smooshed into `tool_result.content`

Full suite: **85 passing, 0 failing** (10 new + 75 existing).

## Empirical validation

Running with v2.0.0-beta.4 + this patch in a long-running resume-heavy session:

- Stats: `session_start_normalize.applied=225, skipped=9` over ~250 requests
- First-request `cache_creation_input_tokens` on `--continue` dropped from **940,251** (baseline) to **1,704** when composed with the existing stack (smoosh_split, cwd_normalize, git_status strip, plus 4 follow-up extensions incoming as separate PRs). `session_start_normalize` alone is not the full 99.8% improvement — it's one of several complementary fixes — but on its tier, it owns the msg[0] `SessionStart` block drift.