### PR TITLE
Add continue_trailer_strip — remove the --continue resume-nudge text block

### DIFF
--- a/preload.mjs
+++ b/preload.mjs
@@ -388,6 +388,43 @@ function normalizeSessionStartText(text) {
   return [out, count];
 }
 
+// --------------------------------------------------------------------------
+// Continue-trailer strip (Bug: anthropics/claude-code#12 / resume UX)
+// --------------------------------------------------------------------------
+//
+// On `claude --continue`, CC appends a text block whose text is EXACTLY
+// "Continue from where you left off." to the last user message before
+// firing the first post-resume request. The pre-exit body did not carry
+// that block, so its presence in the resumed body creates a tail-of-last-
+// user-message drift (~40 bytes plus JSON framing) that breaks cache at
+// that position.
+//
+// The trailer is a semantic no-op — the agent already has the full prior
+// conversation as context. Removing it makes the post-resume body byte-
+// match what the pre-exit body cached at the tail.
+//
+// Match is intentionally narrow (exact string equality on the block's
+// .text) so mentions of the phrase inside a longer user sentence don't
+// get caught.
+// --------------------------------------------------------------------------
+
+const CONTINUE_TRAILER_TEXT = "Continue from where you left off.";
+
+/**
+ * Returns true iff the block is an exact-match Continue-trailer text block
+ * (a `{type: "text", text: "Continue from where you left off."}` shape —
+ * cache_control field on the same block is allowed and ignored). Pure
+ * predicate; exported for unit tests.
+ */
+function isContinueTrailerBlock(block) {
+  return (
+    !!block &&
+    typeof block === "object" &&
+    block.type === "text" &&
+    block.text === CONTINUE_TRAILER_TEXT
+  );
+}
+
 /**
  * Core fix: on EVERY call, scan the entire message array for the LATEST
  * relocatable blocks (skills, MCP, deferred tools, hooks) and ensure they
@@ -787,6 +824,7 @@ const _STATS_SCHEMA = {
   smoosh_normalize: { applied: 0, skipped: 0, lastApplied: null },
   smoosh_split: { applied: 0, skipped: 0, lastApplied: null },
   session_start_normalize: { applied: 0, skipped: 0, lastApplied: null },
+  continue_trailer_strip: { applied: 0, skipped: 0, lastApplied: null },
 };
 
 function _createEmptyStats() {
@@ -1571,6 +1609,36 @@ globalThis.fetch = async function (url, options) {
         }
       }
 
+      // Extension: continue_trailer_strip — remove the "Continue from where
+      // you left off." text block CC appends to the last user message on
+      // --continue. Pre-exit bodies didn't carry it, so its presence in the
+      // resumed body creates tail-of-last-msg drift that breaks cache.
+      // Exact-match string equality on `.text` — user sentences mentioning
+      // the phrase inside longer content are not touched.
+      // Bug: anthropics/claude-code#12 (resume UX), observed empirically.
+      // Opt-out via CACHE_FIX_SKIP_CONTINUE_TRAILER_STRIP=1 (defaults ON).
+      if (shouldApplyFix("continue_trailer_strip") && payload.messages) {
+        let trailerStripped = 0;
+        for (const msg of payload.messages) {
+          if (msg?.role !== "user" || !Array.isArray(msg.content)) continue;
+          const kept = msg.content.filter((block) => {
+            if (isContinueTrailerBlock(block)) {
+              trailerStripped++;
+              return false;
+            }
+            return true;
+          });
+          if (kept.length !== msg.content.length) msg.content = kept;
+        }
+        if (trailerStripped > 0) {
+          modified = true;
+          debugLog(`APPLIED: continue-trailer-strip removed ${trailerStripped} trailer block(s)`);
+          recordFixResult("continue_trailer_strip", "applied");
+        } else {
+          recordFixResult("continue_trailer_strip", "skipped");
+        }
+      }
+
       // Bug 5: TTL enforcement (configurable per request type)
       // The client gates 1h cache TTL behind a GrowthBook allowlist that checks
       // querySource against patterns like "repl_main_thread*", "sdk", "auto_mode".
@@ -1997,5 +2065,7 @@ export {
   rewriteOutputEfficiencyInstruction,
   normalizeOutputEfficiencyReplacement,
   normalizeSessionStartText,
+  isContinueTrailerBlock,
+  CONTINUE_TRAILER_TEXT,
   _pinnedBlocks,  // exported so tests can reset between runs
 };

--- a/test/isContinueTrailerBlock.test.mjs
+++ b/test/isContinueTrailerBlock.test.mjs
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isContinueTrailerBlock, CONTINUE_TRAILER_TEXT } from "../preload.mjs";
+
+test("CONTINUE_TRAILER_TEXT is the exact phrase CC appends on --continue", () => {
+  assert.equal(CONTINUE_TRAILER_TEXT, "Continue from where you left off.");
+});
+
+test("isContinueTrailerBlock: exact-match trailer text block returns true", () => {
+  assert.equal(
+    isContinueTrailerBlock({ type: "text", text: CONTINUE_TRAILER_TEXT }),
+    true
+  );
+});
+
+test("isContinueTrailerBlock: same phrase with cache_control marker attached still matches", () => {
+  assert.equal(
+    isContinueTrailerBlock({
+      type: "text",
+      text: CONTINUE_TRAILER_TEXT,
+      cache_control: { type: "ephemeral", ttl: "1h" },
+    }),
+    true
+  );
+});
+
+test("isContinueTrailerBlock: phrase inside a longer sentence is NOT a match", () => {
+  assert.equal(
+    isContinueTrailerBlock({
+      type: "text",
+      text: "Please say 'Continue from where you left off.' at the end of your report.",
+    }),
+    false
+  );
+});
+
+test("isContinueTrailerBlock: trailing/leading whitespace is NOT a match", () => {
+  assert.equal(
+    isContinueTrailerBlock({ type: "text", text: "Continue from where you left off. " }),
+    false
+  );
+  assert.equal(
+    isContinueTrailerBlock({ type: "text", text: " Continue from where you left off." }),
+    false
+  );
+});
+
+test("isContinueTrailerBlock: tool_result blocks are NOT matched (type mismatch)", () => {
+  assert.equal(
+    isContinueTrailerBlock({ type: "tool_result", content: CONTINUE_TRAILER_TEXT, tool_use_id: "t" }),
+    false
+  );
+});
+
+test("isContinueTrailerBlock: tool_use blocks are NOT matched", () => {
+  assert.equal(isContinueTrailerBlock({ type: "tool_use", id: "t", name: "Read", input: {} }), false);
+});
+
+test("isContinueTrailerBlock: thinking blocks are NOT matched", () => {
+  assert.equal(
+    isContinueTrailerBlock({ type: "thinking", thinking: CONTINUE_TRAILER_TEXT }),
+    false
+  );
+});
+
+test("isContinueTrailerBlock: null / undefined / non-object returns false", () => {
+  assert.equal(isContinueTrailerBlock(null), false);
+  assert.equal(isContinueTrailerBlock(undefined), false);
+  assert.equal(isContinueTrailerBlock("string"), false);
+  assert.equal(isContinueTrailerBlock(42), false);
+  assert.equal(isContinueTrailerBlock([]), false);
+});
+
+test("isContinueTrailerBlock: empty object / missing type returns false", () => {
+  assert.equal(isContinueTrailerBlock({}), false);
+  assert.equal(isContinueTrailerBlock({ text: CONTINUE_TRAILER_TEXT }), false);
+});
+
+test("isContinueTrailerBlock: type text but different phrasing returns false", () => {
+  const variants = [
+    "Continue",
+    "continue from where you left off.",
+    "CONTINUE FROM WHERE YOU LEFT OFF.",
+    "Continue from where you left off",
+    "Pick up where you left off.",
+    "",
+  ];
+  for (const text of variants) {
+    assert.equal(isContinueTrailerBlock({ type: "text", text }), false, `text=${JSON.stringify(text)}`);
+  }
+});


### PR DESCRIPTION
Removes a tail-of-last-user-message byte drift that triggers on every `claude --continue` call.

## What it does

On `--continue`, CC appends a text block whose text is EXACTLY `"Continue from where you left off."` to the last user message before firing the first post-resume request:

```json
{
  "role": "user",
  "content": [
    { "type": "tool_result", "content": "...", "tool_use_id": "..." },
    { "type": "text", "text": "Continue from where you left off." }
  ]
}
```

The pre-exit body did not carry that block, so its presence in the resumed body creates tail-of-last-user-message drift (~40 bytes plus JSON framing) that breaks cache at that position — on every resume, every session.

## Why it's safe

- The agent already has the full prior conversation as context
- The trailer is a semantic no-op duplicating what resume already implies
- Match is intentionally narrow: **exact string equality** on `.text`, so user sentences mentioning the phrase inside longer content are NOT touched (see tests)
- `cache_control` field on the same block (if CC attached one) is allowed and ignored

## Conventions matched

- Inline predicate + filter in `preload.mjs`, no side effects outside the block loop
- `isContinueTrailerBlock(block): boolean` — pure predicate, exported for unit tests
- `CONTINUE_TRAILER_TEXT` — exported as the canonical phrase constant
- `shouldApplyFix("continue_trailer_strip")` gate
- `recordFixResult("continue_trailer_strip", "applied"|"skipped")`
- `_STATS_SCHEMA` entry: `{ applied: 0, skipped: 0, lastApplied: null }`
- Default ON; opt-out via `CACHE_FIX_SKIP_CONTINUE_TRAILER_STRIP=1`

## Tests

11 new cases in `test/isContinueTrailerBlock.test.mjs`:

- Exact-match trailer returns true
- Same phrase with `cache_control` marker attached still matches
- Phrase mid-sentence is NOT matched (false-positive guard)
- Trailing/leading whitespace is NOT matched
- Non-text block types (`tool_result`, `tool_use`, `thinking`) not matched
- Null/undefined/non-object returns false
- Empty object / missing type returns false
- Casing and punctuation variants return false
- `CONTINUE_TRAILER_TEXT` constant matches the observed phrase

Full suite: **86 passing, 0 failing** (11 new + 75 existing).

## Empirical validation

Running alongside the existing stack (smoosh_normalize, smoosh_split, `session_start_normalize` in a separate PR, and others), first-request `cache_creation_input_tokens` on `--continue` dropped from **940,251** to **1,704** in a long-running resume-heavy session. `continue_trailer_strip` owns the tail-of-last-user-msg block drift; it's one of several complementary fixes composing to the observed 99.8% reduction.

Related: cnighswonger/claude-code-cache-fix#49585 (discussion thread).