### PR TITLE
Add deferred_tools_restore — survive MCP reconnect race on --continue

### DIFF
--- a/preload.mjs
+++ b/preload.mjs
@@ -388,6 +388,85 @@ function normalizeSessionStartText(text) {
   return [out, count];
 }
 
+// --------------------------------------------------------------------------
+// Deferred-tools restore (MCP reconnect race)
+// --------------------------------------------------------------------------
+//
+// Observed empirically: on `claude --continue`, if MCP servers haven't
+// finished reconnecting by the time CC fires the first post-resume
+// request, the `<system-reminder>The following deferred tools are now
+// available via ToolSearch…` block at msg[0] (or wherever the attachment
+// lands post-compaction) shrinks dramatically. A full list of ~40 tools
+// collapses to a handful of CC built-ins (AskUserQuestion, EnterPlanMode,
+// ExitPlanMode, PushNotification) and CC injects a trailing
+// `The following deferred tools are no longer available (their MCP server
+// disconnected). Do not search for them — ToolSearch will return no match:`
+// notice.
+//
+// That block change at the root of the message array breaks cache at the
+// very top — the entire ~940K prompt re-caches. By the time the second
+// post-resume request fires, MCPs are usually reconnected and the block is
+// full again, but the cache is already committed to the shrunk version
+// for this session.
+//
+// This extension snapshots the block to
+// `~/.claude/cache-fix-state/deferred-tools-<sha1(key)>.txt` every time
+// it's sent in its full form (no UNAVAILABLE marker), keyed by a caller-
+// supplied project key (default: cwd). On a subsequent request where the
+// block is shorter AND contains the UNAVAILABLE marker, the persisted
+// full bytes are substituted so the on-wire body matches the server's
+// cached prefix.
+//
+// Trade-off: the restored block may reference MCP tools that haven't
+// actually reconnected yet. Agent calls ToolSearch → no match → one retry.
+// Tiny cost versus a full-prompt cache miss on every resume.
+// --------------------------------------------------------------------------
+
+const DEFERRED_TOOLS_AVAILABLE_MARKER =
+  "The following deferred tools are now available via ToolSearch";
+const DEFERRED_TOOLS_UNAVAILABLE_MARKER =
+  "The following deferred tools are no longer available";
+const DEFERRED_TOOLS_SNAPSHOT_DIR = join(homedir(), ".claude", "cache-fix-state");
+
+/**
+ * Build the absolute snapshot path for a given key. Exported for tests so
+ * they can assert on path derivation without duplicating the hash logic.
+ */
+function deferredToolsSnapshotPath(key) {
+  const hash = createHash("sha1").update(String(key)).digest("hex").slice(0, 16);
+  return join(DEFERRED_TOOLS_SNAPSHOT_DIR, `deferred-tools-${hash}.txt`);
+}
+
+/**
+ * Locate the deferred-tools reminder block anywhere in `body.messages`.
+ * The block's position varies by session shape (pre-compaction it often
+ * sits at `msg[0].content[0]`; post-compaction it can land at
+ * `msg[1].content[N]` next to other attachments). Returns
+ * `{ msgIdx, blockIdx, text } | null`.
+ *
+ * Assistant messages are skipped so that if the agent happens to mention
+ * the AVAILABLE_MARKER phrase verbatim in its own output, we don't
+ * misidentify it as a real deferred-tools block.
+ */
+function findDeferredToolsBlockInBody(body) {
+  if (!body || !Array.isArray(body.messages)) return null;
+  for (let m = 0; m < body.messages.length; m++) {
+    const msg = body.messages[m];
+    if (msg?.role !== "user" || !Array.isArray(msg.content)) continue;
+    for (let i = 0; i < msg.content.length; i++) {
+      const b = msg.content[i];
+      if (
+        b?.type === "text" &&
+        typeof b.text === "string" &&
+        b.text.includes(DEFERRED_TOOLS_AVAILABLE_MARKER)
+      ) {
+        return { msgIdx: m, blockIdx: i, text: b.text };
+      }
+    }
+  }
+  return null;
+}
+
 /**
  * Core fix: on EVERY call, scan the entire message array for the LATEST
  * relocatable blocks (skills, MCP, deferred tools, hooks) and ensure they
@@ -787,6 +866,7 @@ const _STATS_SCHEMA = {
   smoosh_normalize: { applied: 0, skipped: 0, lastApplied: null },
   smoosh_split: { applied: 0, skipped: 0, lastApplied: null },
   session_start_normalize: { applied: 0, skipped: 0, lastApplied: null },
+  deferred_tools_restore: { applied: 0, skipped: 0, lastApplied: null },
 };
 
 function _createEmptyStats() {
@@ -1571,6 +1651,48 @@ globalThis.fetch = async function (url, options) {
         }
       }
 
+      // Extension: deferred_tools_restore — persist-and-restore the
+      // deferred-tools attachment block across sessions so MCP reconnect
+      // race at resume-time doesn't shrink msg[0] and bust the whole cache.
+      // Snapshot key defaults to process.cwd() (one snapshot per project).
+      // Opt-out via CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1 (defaults ON).
+      if (shouldApplyFix("deferred_tools_restore") && payload.messages) {
+        let dtrRestored = 0;
+        const found = findDeferredToolsBlockInBody(payload);
+        if (found) {
+          const hasUnavail = found.text.includes(DEFERRED_TOOLS_UNAVAILABLE_MARKER);
+          const snapshotPath = deferredToolsSnapshotPath(process.cwd());
+          if (!hasUnavail) {
+            // Clean baseline — persist it for future resumes. Silent on
+            // any I/O error; snapshot is best-effort.
+            try {
+              mkdirSync(DEFERRED_TOOLS_SNAPSHOT_DIR, { recursive: true });
+              writeFileSync(snapshotPath, found.text, "utf-8");
+            } catch {}
+          } else {
+            // Shrunk block with explicit "no longer available" signal →
+            // attempt restore. Only substitute if the persisted version is
+            // strictly longer (never downgrade to a stale shorter snapshot).
+            let snapshot = null;
+            try { snapshot = readFileSync(snapshotPath, "utf-8"); } catch {}
+            if (snapshot && snapshot.length > found.text.length) {
+              const targetMsg = payload.messages[found.msgIdx];
+              const newContent = targetMsg.content.slice();
+              newContent[found.blockIdx] = { ...newContent[found.blockIdx], text: snapshot };
+              payload.messages[found.msgIdx] = { ...targetMsg, content: newContent };
+              dtrRestored = 1;
+            }
+          }
+        }
+        if (dtrRestored > 0) {
+          modified = true;
+          debugLog(`APPLIED: deferred-tools-restore substituted full block at msg[${found.msgIdx}].content[${found.blockIdx}]`);
+          recordFixResult("deferred_tools_restore", "applied");
+        } else {
+          recordFixResult("deferred_tools_restore", "skipped");
+        }
+      }
+
       // Bug 5: TTL enforcement (configurable per request type)
       // The client gates 1h cache TTL behind a GrowthBook allowlist that checks
       // querySource against patterns like "repl_main_thread*", "sdk", "auto_mode".
@@ -1997,5 +2119,9 @@ export {
   rewriteOutputEfficiencyInstruction,
   normalizeOutputEfficiencyReplacement,
   normalizeSessionStartText,
+  findDeferredToolsBlockInBody,
+  deferredToolsSnapshotPath,
+  DEFERRED_TOOLS_AVAILABLE_MARKER,
+  DEFERRED_TOOLS_UNAVAILABLE_MARKER,
   _pinnedBlocks,  // exported so tests can reset between runs
 };

--- a/test/findDeferredToolsBlockInBody.test.mjs
+++ b/test/findDeferredToolsBlockInBody.test.mjs
@@ -1,0 +1,150 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  findDeferredToolsBlockInBody,
+  deferredToolsSnapshotPath,
+  DEFERRED_TOOLS_AVAILABLE_MARKER,
+  DEFERRED_TOOLS_UNAVAILABLE_MARKER,
+} from "../preload.mjs";
+
+function fullBlock(tools = ["Bash", "Edit", "Read", "mcp__server__tool1"]) {
+  return (
+    "<system-reminder>\n" +
+    `${DEFERRED_TOOLS_AVAILABLE_MARKER}. Their schemas are NOT loaded — calling them directly will fail with InputValidationError. Use ToolSearch with query "select:<name>[,<name>...]" to load tool schemas before calling them:\n` +
+    tools.join("\n") + "\n" +
+    "</system-reminder>"
+  );
+}
+
+function reducedBlock() {
+  return (
+    "<system-reminder>\n" +
+    `${DEFERRED_TOOLS_AVAILABLE_MARKER}. Their schemas are NOT loaded — calling them directly will fail with InputValidationError. Use ToolSearch with query "select:<name>[,<name>...]" to load tool schemas before calling them:\n` +
+    "AskUserQuestion\nEnterPlanMode\nExitPlanMode\nPushNotification\n" +
+    `${DEFERRED_TOOLS_UNAVAILABLE_MARKER} (their MCP server disconnected). Do not search for them — ToolSearch will return no match:\n` +
+    "</system-reminder>"
+  );
+}
+
+test("findDeferredToolsBlockInBody: locates block at msg[0].content[0]", () => {
+  const body = {
+    messages: [
+      { role: "user", content: [{ type: "text", text: fullBlock() }] },
+    ],
+  };
+  const found = findDeferredToolsBlockInBody(body);
+  assert.ok(found);
+  assert.equal(found.msgIdx, 0);
+  assert.equal(found.blockIdx, 0);
+  assert.ok(found.text.includes(DEFERRED_TOOLS_AVAILABLE_MARKER));
+});
+
+test("findDeferredToolsBlockInBody: finds block at msg[N].content[M] (post-compaction shape)", () => {
+  // After compaction, msg[0] is often a bare tool-echo string and the
+  // attachment bundle — including the deferred-tools block — lands at
+  // msg[1].content[N] where N > 0.
+  const body = {
+    messages: [
+      { role: "user", content: "<system-reminder>\nCalled the Read tool...\n</system-reminder>" },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "preamble A" },
+          { type: "text", text: "preamble B" },
+          { type: "text", text: fullBlock() },
+        ],
+      },
+    ],
+  };
+  const found = findDeferredToolsBlockInBody(body);
+  assert.ok(found);
+  assert.equal(found.msgIdx, 1);
+  assert.equal(found.blockIdx, 2);
+});
+
+test("findDeferredToolsBlockInBody: returns null when block is absent", () => {
+  const body = {
+    messages: [
+      { role: "user", content: [{ type: "text", text: "just a user prompt" }] },
+    ],
+  };
+  assert.equal(findDeferredToolsBlockInBody(body), null);
+});
+
+test("findDeferredToolsBlockInBody: skips assistant messages (false-positive guard)", () => {
+  // If the agent discusses the deferred-tools mechanism in its own output,
+  // its text MUST NOT be misidentified as a real user-side attachment block.
+  const body = {
+    messages: [
+      { role: "assistant", content: [{ type: "text", text: fullBlock() }] },
+      { role: "user", content: [{ type: "text", text: "plain user prompt" }] },
+    ],
+  };
+  assert.equal(findDeferredToolsBlockInBody(body), null);
+});
+
+test("findDeferredToolsBlockInBody: null / empty body returns null without throwing", () => {
+  assert.equal(findDeferredToolsBlockInBody(null), null);
+  assert.equal(findDeferredToolsBlockInBody(undefined), null);
+  assert.equal(findDeferredToolsBlockInBody({}), null);
+  assert.equal(findDeferredToolsBlockInBody({ messages: [] }), null);
+  assert.equal(findDeferredToolsBlockInBody({ messages: null }), null);
+});
+
+test("findDeferredToolsBlockInBody: user messages with string content are skipped (no content array to scan)", () => {
+  const body = {
+    messages: [
+      { role: "user", content: "bare string content" },
+      { role: "user", content: [{ type: "text", text: fullBlock() }] },
+    ],
+  };
+  const found = findDeferredToolsBlockInBody(body);
+  assert.ok(found);
+  assert.equal(found.msgIdx, 1);
+});
+
+test("findDeferredToolsBlockInBody: reduced block with UNAVAILABLE marker is still detected", () => {
+  // The reduced/shrunk form carries the AVAILABLE marker at the top and
+  // the UNAVAILABLE marker at the bottom. We locate by AVAILABLE; the
+  // UNAVAILABLE check happens in the caller to decide restore-vs-snapshot.
+  const body = {
+    messages: [{ role: "user", content: [{ type: "text", text: reducedBlock() }] }],
+  };
+  const found = findDeferredToolsBlockInBody(body);
+  assert.ok(found);
+  assert.ok(found.text.includes(DEFERRED_TOOLS_AVAILABLE_MARKER));
+  assert.ok(found.text.includes(DEFERRED_TOOLS_UNAVAILABLE_MARKER));
+});
+
+test("findDeferredToolsBlockInBody: returns first match when multiple user messages contain the marker", () => {
+  // Shouldn't happen in practice — CC emits the attachment once — but
+  // make the behavior explicit: first user-side occurrence wins.
+  const body = {
+    messages: [
+      { role: "user", content: [{ type: "text", text: fullBlock(["Bash"]) }] },
+      { role: "user", content: [{ type: "text", text: fullBlock(["Edit"]) }] },
+    ],
+  };
+  const found = findDeferredToolsBlockInBody(body);
+  assert.ok(found);
+  assert.equal(found.msgIdx, 0);
+});
+
+test("deferredToolsSnapshotPath: deterministic — same key yields same path", () => {
+  const a = deferredToolsSnapshotPath("/home/test/project");
+  const b = deferredToolsSnapshotPath("/home/test/project");
+  assert.equal(a, b);
+});
+
+test("deferredToolsSnapshotPath: different keys yield different paths", () => {
+  const a = deferredToolsSnapshotPath("/home/test/project-a");
+  const b = deferredToolsSnapshotPath("/home/test/project-b");
+  assert.notEqual(a, b);
+});
+
+test("deferredToolsSnapshotPath: path contains the fixed prefix/suffix", () => {
+  const p = deferredToolsSnapshotPath("whatever");
+  assert.ok(p.includes("cache-fix-state"));
+  assert.ok(p.includes("deferred-tools-"));
+  assert.ok(p.endsWith(".txt"));
+});


### PR DESCRIPTION
Fixes the ~940K `cache_creation_input_tokens` full-prompt miss on first post-resume request when MCP servers haven't finished reconnecting yet.

## What happens without this fix

On `claude --continue`, if MCP servers haven't finished reconnecting by the time CC fires the first post-resume request, the deferred-tools attachment block at the root of the message array shrinks from ~40 tool names (~3.9KB) to a handful of CC built-ins (~500B) and CC injects an UNAVAILABLE notice:

**Pre-exit (cached):**
```
<system-reminder>
The following deferred tools are now available via ToolSearch. ...:
CronCreate
CronDelete
TaskCreate
mcp__server__tool1
... (40+ entries)
</system-reminder>
```

**Post-resume (first request):**
```
<system-reminder>
The following deferred tools are now available via ToolSearch. ...:
AskUserQuestion
EnterPlanMode
ExitPlanMode
PushNotification
The following deferred tools are no longer available (their MCP server disconnected). Do not search for them — ToolSearch will return no match:
</system-reminder>
```

The ~3.4KB block change at msg[0] (or wherever the attachment lands after compaction) breaks cache at the very top → the entire ~940K prompt re-caches. By the second post-resume request, MCPs are reconnected and the block is full again — but the damage is done for this session.

## Fix

Persist the block to `~/.claude/cache-fix-state/deferred-tools-<sha1(cwd)>.txt` every time it's sent in full form. On a subsequent request where the block is shorter AND carries the UNAVAILABLE marker, substitute the persisted bytes so the on-wire body matches the server's cached prefix.

Disk I/O is **best-effort** — read/write failures are silently ignored so a missing directory or read-only filesystem never blocks the request.

## Block position

Varies by session shape:
- Pre-compaction: typically `msg[0].content[0]`
- Post-compaction: `msg[1].content[N]` (next to other attachments; msg[0] is often a bare tool-echo string)

The finder walks all **user** messages and returns the first match. Assistant messages are skipped as a false-positive guard — if the agent discusses the deferred-tools mechanism in its own output, that text is NOT misidentified as a real attachment block.

## Trade-off

The restored block may reference MCP tools that haven't actually reconnected by the time the request is processed. Agent calls ToolSearch → no match → one retry cycle. Tiny cost vs. a full-prompt cache miss on every resume.

## Conventions matched

- Inline helper in `preload.mjs`, disk I/O in the gated call site, pure helper exported
- `findDeferredToolsBlockInBody(body)` → `{msgIdx, blockIdx, text} | null` — pure, exported
- `deferredToolsSnapshotPath(key)` → deterministic path builder, exported
- `DEFERRED_TOOLS_AVAILABLE_MARKER` / `DEFERRED_TOOLS_UNAVAILABLE_MARKER` — exported constants
- `shouldApplyFix("deferred_tools_restore")` gate
- `recordFixResult("deferred_tools_restore", "applied"|"skipped")`
- `_STATS_SCHEMA` entry: `{ applied: 0, skipped: 0, lastApplied: null }`
- Default ON; opt-out via `CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1`
- Reuses existing `mkdirSync`/`readFileSync`/`writeFileSync` from `node:fs` and `createHash` from `node:crypto` — no new dependencies

## Tests

11 new cases in `test/findDeferredToolsBlockInBody.test.mjs`:

- Locates block at `msg[0].content[0]`
- Finds block at `msg[N].content[M]` (post-compaction shape)
- Returns null when block absent
- Skips assistant messages (false-positive guard)
- Null/empty/undefined body returns null without throwing
- User messages with string content are skipped
- Reduced block (with UNAVAILABLE marker) is still detected
- Returns first match when multiple blocks exist
- Snapshot path: determinism, uniqueness per key, format

Full suite: **86 passing, 0 failing** (11 new + 75 existing).

## Empirical validation

Part of the stack that took first-request `cache_creation_input_tokens` on `--continue` from **940,251** → **1,704** in a long-running resume-heavy session. This extension specifically owns the MCP-reconnect-race-induced msg[0] drift.

Related: cnighswonger/claude-code-cache-fix#49585 (discussion thread).