### PR TITLE
Add reminder_strip — remove bookkeeping system-reminder blocks entirely

### DIFF
--- a/preload.mjs
+++ b/preload.mjs
@@ -388,6 +388,65 @@ function normalizeSessionStartText(text) {
   return [out, count];
 }
 
+// --------------------------------------------------------------------------
+// Bookkeeping-reminder strip
+// --------------------------------------------------------------------------
+//
+// Complements `smoosh_normalize` / `smoosh_split`: where normalize stabilizes
+// bytes in-place and split peels smooshed reminders back into standalone
+// text blocks, this pass REMOVES purely-bookkeeping reminder blocks entirely
+// from the outbound body. Zero model visibility, zero drift.
+//
+// Targeted patterns (all CC-internal, per-turn values the agent doesn't need
+// to condition behavior on):
+//   - `Token usage: <N>/<M>; <K> remaining`
+//   - `Output tokens — turn: <X> · session: <Y>`
+//   - `USD budget: $<X>/$<Y>; $<Z> remaining`
+//   - `The task tools haven't been used recently. …`
+//   - `The TodoWrite tool hasn't been used recently. …`
+//   - `Remaining conversation turns: <N>`
+//   - `Messages until auto-compact: <N>`
+//
+// Hook-injected reminders (thinking-enrichment, action-tracker,
+// PreToolUse/PostToolUse blocking errors, UserPromptSubmit additional
+// context, custom user hooks) are deliberately NOT stripped here — the
+// agent needs that feedback visible in the turn it fires, and attempting a
+// history-only filter creates per-turn drift of its own (the "last user
+// message" shifts each turn, so a reminder preserved at turn N gets
+// stripped at N+1 when its host message falls into history). Leaving hook
+// reminders untouched is the safer choice; their residual drift is small
+// compared to bookkeeping churn.
+// --------------------------------------------------------------------------
+
+const REMINDER_WRAP_REGEX =
+  /^<system-reminder>\n([\s\S]*?)\n<\/system-reminder>\s*$/;
+
+const BOOKKEEPING_REMINDER_PATTERNS = [
+  /^Token usage: \d+\/\d+; \d+ remaining\s*$/,
+  /^Output tokens \u2014 turn: [^\n]+ \u00b7 session: [^\n]+\s*$/,
+  /^USD budget: \$[\d.]+\/\$[\d.]+; \$[\d.]+ remaining\s*$/,
+  /^The task tools haven't been used recently\./,
+  /^The TodoWrite tool hasn't been used recently\./,
+  /^Remaining conversation turns: /,
+  /^Messages? until auto-compact: /,
+];
+
+/**
+ * Returns true iff the text is a `<system-reminder>`-wrapped block whose
+ * inner content matches a bookkeeping pattern. Pure predicate, exported
+ * for unit tests.
+ */
+function isBookkeepingReminder(text) {
+  if (typeof text !== "string") return false;
+  const m = text.match(REMINDER_WRAP_REGEX);
+  if (!m) return false;
+  const inner = m[1];
+  for (const rx of BOOKKEEPING_REMINDER_PATTERNS) {
+    if (rx.test(inner)) return true;
+  }
+  return false;
+}
+
 /**
  * Core fix: on EVERY call, scan the entire message array for the LATEST
  * relocatable blocks (skills, MCP, deferred tools, hooks) and ensure they
@@ -787,6 +846,7 @@ const _STATS_SCHEMA = {
   smoosh_normalize: { applied: 0, skipped: 0, lastApplied: null },
   smoosh_split: { applied: 0, skipped: 0, lastApplied: null },
   session_start_normalize: { applied: 0, skipped: 0, lastApplied: null },
+  reminder_strip: { applied: 0, skipped: 0, lastApplied: null },
 };
 
 function _createEmptyStats() {
@@ -1571,6 +1631,36 @@ globalThis.fetch = async function (url, options) {
         }
       }
 
+      // Extension: reminder_strip — remove bookkeeping system-reminder blocks
+      // (Token usage / USD budget / Output tokens / TodoWrite nudge / turn
+      // counters) entirely from user messages. Runs AFTER smoosh_split so
+      // blocks peeled out of tool_result.content are visible as standalone
+      // text and can be matched by isBookkeepingReminder.
+      // Zero model visibility, zero drift.
+      // Opt-out via CACHE_FIX_SKIP_REMINDER_STRIP=1 (defaults ON).
+      if (shouldApplyFix("reminder_strip") && payload.messages) {
+        let reminderStripped = 0;
+        for (const msg of payload.messages) {
+          if (msg?.role !== "user" || !Array.isArray(msg.content)) continue;
+          const kept = msg.content.filter((block) => {
+            if (block?.type !== "text") return true;
+            if (isBookkeepingReminder(block.text)) {
+              reminderStripped++;
+              return false;
+            }
+            return true;
+          });
+          if (kept.length !== msg.content.length) msg.content = kept;
+        }
+        if (reminderStripped > 0) {
+          modified = true;
+          debugLog(`APPLIED: reminder-strip removed ${reminderStripped} bookkeeping reminder block(s)`);
+          recordFixResult("reminder_strip", "applied");
+        } else {
+          recordFixResult("reminder_strip", "skipped");
+        }
+      }
+
       // Bug 5: TTL enforcement (configurable per request type)
       // The client gates 1h cache TTL behind a GrowthBook allowlist that checks
       // querySource against patterns like "repl_main_thread*", "sdk", "auto_mode".
@@ -1997,5 +2087,6 @@ export {
   rewriteOutputEfficiencyInstruction,
   normalizeOutputEfficiencyReplacement,
   normalizeSessionStartText,
+  isBookkeepingReminder,
   _pinnedBlocks,  // exported so tests can reset between runs
 };

--- a/test/isBookkeepingReminder.test.mjs
+++ b/test/isBookkeepingReminder.test.mjs
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isBookkeepingReminder } from "../preload.mjs";
+
+function wrap(inner) {
+  return `<system-reminder>\n${inner}\n</system-reminder>`;
+}
+
+test("isBookkeepingReminder: Token usage reminder matches", () => {
+  assert.equal(isBookkeepingReminder(wrap("Token usage: 150/200; 50 remaining")), true);
+});
+
+test("isBookkeepingReminder: USD budget reminder matches", () => {
+  assert.equal(
+    isBookkeepingReminder(wrap("USD budget: $1.50/$10.00; $8.50 remaining")),
+    true
+  );
+});
+
+test("isBookkeepingReminder: Output tokens reminder matches (em-dash + middot format)", () => {
+  assert.equal(
+    isBookkeepingReminder(wrap("Output tokens \u2014 turn: 500 \u00b7 session: 3200")),
+    true
+  );
+});
+
+test("isBookkeepingReminder: TodoWrite nudge matches", () => {
+  const body = "The TodoWrite tool hasn't been used recently. Consider using it...";
+  assert.equal(isBookkeepingReminder(wrap(body)), true);
+});
+
+test("isBookkeepingReminder: task-tools nudge matches", () => {
+  const body = "The task tools haven't been used recently. Consider creating tasks...";
+  assert.equal(isBookkeepingReminder(wrap(body)), true);
+});
+
+test("isBookkeepingReminder: Remaining conversation turns counter matches", () => {
+  assert.equal(isBookkeepingReminder(wrap("Remaining conversation turns: 12")), true);
+});
+
+test("isBookkeepingReminder: Messages until auto-compact counter matches", () => {
+  assert.equal(isBookkeepingReminder(wrap("Messages until auto-compact: 24")), true);
+  assert.equal(isBookkeepingReminder(wrap("Message until auto-compact: 1")), true);
+});
+
+test("isBookkeepingReminder: hook-injected reminders are NOT matched", () => {
+  const hookReminders = [
+    "PreToolUse:Edit hook blocking error from command: blocked",
+    "PostToolUse:Bash hook additional context: [thinking-enrichment] hint",
+    "UserPromptSubmit hook additional context: [classify-user-intent.py] intent",
+    "SessionStart:startup hook success: reload done",
+    "The user sent a new message while you were working: hello",
+  ];
+  for (const inner of hookReminders) {
+    assert.equal(isBookkeepingReminder(wrap(inner)), false, `should not match: ${inner}`);
+  }
+});
+
+test("isBookkeepingReminder: claudeMd preamble is NOT matched", () => {
+  const inner = "As you answer the user's questions, you can use the following context:\n# claudeMd\nSome user memory...";
+  assert.equal(isBookkeepingReminder(wrap(inner)), false);
+});
+
+test("isBookkeepingReminder: deferred-tools attachment is NOT matched", () => {
+  const inner = "The following deferred tools are now available via ToolSearch:\nBash\nEdit";
+  assert.equal(isBookkeepingReminder(wrap(inner)), false);
+});
+
+test("isBookkeepingReminder: plain user text is NOT matched", () => {
+  assert.equal(isBookkeepingReminder("Hi, what's up?"), false);
+  assert.equal(isBookkeepingReminder("Token usage: 1/1"), false); // missing wrapper
+});
+
+test("isBookkeepingReminder: non-string inputs return false without throwing", () => {
+  assert.equal(isBookkeepingReminder(null), false);
+  assert.equal(isBookkeepingReminder(undefined), false);
+  assert.equal(isBookkeepingReminder(42), false);
+  assert.equal(isBookkeepingReminder({}), false);
+  assert.equal(isBookkeepingReminder([]), false);
+});
+
+test("isBookkeepingReminder: partial pattern match inside longer inner body is rejected (anchored)", () => {
+  // Patterns are anchored with ^ — a bookkeeping phrase embedded inside a
+  // larger reminder body must NOT be stripped, because the surrounding
+  // content is semantic.
+  const inner = "Here is some report. Token usage: 1/1; 0 remaining. More content after.";
+  assert.equal(isBookkeepingReminder(wrap(inner)), false);
+});
+
+test("isBookkeepingReminder: Token usage with slightly off format is rejected", () => {
+  assert.equal(
+    isBookkeepingReminder(wrap("Token usage: 150/200 remaining")), // missing semicolon count
+    false
+  );
+  assert.equal(
+    isBookkeepingReminder(wrap("Token usage: abc/xyz; foo remaining")),
+    false
+  );
+});


### PR DESCRIPTION
Complements `smoosh_normalize` / `smoosh_split` by **removing** purely-bookkeeping system-reminder blocks from user messages entirely, instead of stabilizing them in place.

## What it targets

Per-turn CC-internal reminders whose values the agent doesn't need to condition behavior on:

- `Token usage: <N>/<M>; <K> remaining`
- `Output tokens — turn: <X> · session: <Y>`
- `USD budget: $<X>/$<Y>; $<Z> remaining`
- `The task tools haven't been used recently. …`
- `The TodoWrite tool hasn't been used recently. …`
- `Remaining conversation turns: <N>`
- `Messages until auto-compact: <N>`

Each pattern is anchored with `^` so bookkeeping phrases embedded inside a larger semantic reminder are NOT stripped (false-positive guard — e.g., if a user discusses the concept mid-sentence or an agent report echoes the phrase).

## How it composes with the existing passes

- `smoosh_normalize` stabilizes dynamic values in-place for 4 known patterns → agent still sees them
- `smoosh_split` peels smooshed reminders back into standalone text blocks
- `reminder_strip` (this) runs AFTER `smoosh_split` and removes the matched blocks outright

The order matters: split makes the blocks visible as standalone text; strip then drops the bookkeeping subset.

## What it deliberately does NOT touch

Hook-injected reminders pass through untouched:

- `PreToolUse:X hook blocking error …`
- `PostToolUse:X hook additional context …`
- `UserPromptSubmit hook additional context …`
- `SessionStart:X hook success …` (handled by separate `session_start_normalize` extension PR)
- `The user sent a new message while you were working …`
- `thinking-enrichment`, `action-tracker`, `classify-user-intent`, custom user hooks

The agent genuinely needs these visible on the turn they fire. I tried a history-only-strip approach earlier and abandoned it — shifting "last user message" semantics create new drift at the message boundary every turn. Leaving hook reminders untouched is the safer choice, and their residual drift is small compared to bookkeeping churn.

## Conventions matched

- Inline filter in `preload.mjs`, no side effects outside the content array
- `isBookkeepingReminder(text): boolean` — pure predicate, exported for unit tests
- `shouldApplyFix("reminder_strip")` gate
- `recordFixResult("reminder_strip", "applied"|"skipped")`
- `_STATS_SCHEMA` entry: `{ applied: 0, skipped: 0, lastApplied: null }`
- Default ON; opt-out via `CACHE_FIX_SKIP_REMINDER_STRIP=1`

## Tests

14 new cases in `test/isBookkeepingReminder.test.mjs`:

- All 7 enumerated patterns match (including em-dash + middot format for output tokens, both `Message` and `Messages` for auto-compact counter)
- Hook-injected reminders (5 variants) are NOT matched
- claudeMd preamble is NOT matched
- Deferred-tools attachment is NOT matched
- Plain user text / missing wrapper is NOT matched
- Non-string inputs return false without throwing
- Partial-body pattern match is rejected (anchor check)
- Off-format values (missing semicolon, non-numeric counts) are rejected

Full suite: **89 passing, 0 failing** (14 new + 75 existing).

## Empirical validation

Part of the stack that took first-request `cache_creation_input_tokens` on `--continue` from **940,251** → **1,704** in a long-running resume-heavy session. On that session it fires 20–60+ times per request as bookkeeping blocks accumulate in history.

Related: cnighswonger/claude-code-cache-fix#49585 (discussion thread).