### PR TITLE
Add cache_control_normalize — pin marker at canonical position to stop per-turn drift

### DIFF
--- a/preload.mjs
+++ b/preload.mjs
@@ -388,6 +388,70 @@ function normalizeSessionStartText(text) {
   return [out, count];
 }
 
+// --------------------------------------------------------------------------
+// cache_control marker position-normalizer
+// --------------------------------------------------------------------------
+//
+// Anthropic's prompt-cache uses `cache_control: {type: "ephemeral", ttl: ...}`
+// markers on content blocks as cache breakpoints. CC places this marker on
+// "the last block of the last user message" each turn — which shifts as new
+// turns arrive. When the marker moves, the PREVIOUS last-block's JSON loses
+// the cache_control field → that block's bytes differ from the server's
+// cached version → partial re-cache on top of the stable system-prompt
+// cache.
+//
+// Enforce a canonical position on every outbound body:
+//   1. Strip every existing cache_control marker from user-message content
+//      blocks.
+//   2. Place a single {type: "ephemeral", ttl: "1h"} marker on the LAST
+//      content block of the LAST user message.
+//
+// Fast path: if the canonical block already has the correct marker AND it's
+// the only user-side marker, the body is left untouched — ensures the pass
+// is a true no-op when nothing changed.
+//
+// System-side markers (e.g., on `system[2]` for the global prompt) are NOT
+// touched — they're CC's stable breakpoint for the system prompt and work
+// correctly.
+// --------------------------------------------------------------------------
+
+const CACHE_CONTROL_CANONICAL_MARKER = { type: "ephemeral", ttl: "1h" };
+
+/**
+ * Strip every cache_control marker from a single user message's content
+ * blocks. Returns the number stripped. Mutates the message's content array
+ * in place.
+ */
+function stripCacheControlMarkers(msg) {
+  if (!msg || msg.role !== "user" || !Array.isArray(msg.content)) return 0;
+  let n = 0;
+  for (let i = 0; i < msg.content.length; i++) {
+    const block = msg.content[i];
+    if (block && typeof block === "object" && block.cache_control) {
+      const { cache_control, ...rest } = block;
+      msg.content[i] = rest;
+      n++;
+    }
+  }
+  return n;
+}
+
+/**
+ * Count cache_control markers across all user-message content blocks.
+ * Exported so the call-site's fast-path check has a tested helper.
+ */
+function countUserCacheControlMarkers(body) {
+  if (!body || !Array.isArray(body.messages)) return 0;
+  let n = 0;
+  for (const msg of body.messages) {
+    if (msg?.role !== "user" || !Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      if (block && typeof block === "object" && block.cache_control) n++;
+    }
+  }
+  return n;
+}
+
 /**
  * Core fix: on EVERY call, scan the entire message array for the LATEST
  * relocatable blocks (skills, MCP, deferred tools, hooks) and ensure they
@@ -787,6 +851,7 @@ const _STATS_SCHEMA = {
   smoosh_normalize: { applied: 0, skipped: 0, lastApplied: null },
   smoosh_split: { applied: 0, skipped: 0, lastApplied: null },
   session_start_normalize: { applied: 0, skipped: 0, lastApplied: null },
+  cache_control_normalize: { applied: 0, skipped: 0, lastApplied: null },
 };
 
 function _createEmptyStats() {
@@ -1571,6 +1636,57 @@ globalThis.fetch = async function (url, options) {
         }
       }
 
+      // Extension: cache_control_normalize — pin the cache_control marker at
+      // a canonical position (last block of last user message) on every
+      // outbound body. Prevents marker-shuffle drift between turns from
+      // invalidating the previous-last-block's cached bytes. Runs LAST
+      // (after smoosh_split and any other content-mutating pass) so the
+      // canonical position is calculated against the final content array.
+      // Fast path: if canonical position already holds the correct marker
+      // and it's the only user-side marker, body passes through untouched.
+      // Opt-out via CACHE_FIX_SKIP_CACHE_CONTROL_NORMALIZE=1 (defaults ON).
+      if (shouldApplyFix("cache_control_normalize") && payload.messages && payload.messages.length > 0) {
+        // Locate canonical position: last block of last user message with an
+        // array content. If no valid target, skip.
+        let targetMsgIdx = -1;
+        let targetBlockIdx = -1;
+        for (let i = payload.messages.length - 1; i >= 0; i--) {
+          const m = payload.messages[i];
+          if (m?.role !== "user") continue;
+          if (!Array.isArray(m.content) || m.content.length === 0) break;
+          targetMsgIdx = i;
+          targetBlockIdx = m.content.length - 1;
+          break;
+        }
+
+        let ccMutated = false;
+        if (targetMsgIdx !== -1) {
+          const targetBlock = payload.messages[targetMsgIdx].content[targetBlockIdx];
+          const existingCC = targetBlock?.cache_control;
+          const canonicalAlreadyCorrect =
+            existingCC &&
+            existingCC.type === CACHE_CONTROL_CANONICAL_MARKER.type &&
+            existingCC.ttl === CACHE_CONTROL_CANONICAL_MARKER.ttl;
+
+          if (!(canonicalAlreadyCorrect && countUserCacheControlMarkers(payload) === 1)) {
+            // Strip all markers from user messages, then place canonical.
+            for (const msg of payload.messages) stripCacheControlMarkers(msg);
+            const tm = payload.messages[targetMsgIdx];
+            const newContent = tm.content.slice();
+            newContent[targetBlockIdx] = { ...newContent[targetBlockIdx], cache_control: { ...CACHE_CONTROL_CANONICAL_MARKER } };
+            payload.messages[targetMsgIdx] = { ...tm, content: newContent };
+            ccMutated = true;
+          }
+        }
+        if (ccMutated) {
+          modified = true;
+          debugLog(`APPLIED: cache_control_normalize pinned marker at msg[${targetMsgIdx}].content[${targetBlockIdx}]`);
+          recordFixResult("cache_control_normalize", "applied");
+        } else {
+          recordFixResult("cache_control_normalize", "skipped");
+        }
+      }
+
       // Bug 5: TTL enforcement (configurable per request type)
       // The client gates 1h cache TTL behind a GrowthBook allowlist that checks
       // querySource against patterns like "repl_main_thread*", "sdk", "auto_mode".
@@ -1997,5 +2113,8 @@ export {
   rewriteOutputEfficiencyInstruction,
   normalizeOutputEfficiencyReplacement,
   normalizeSessionStartText,
+  stripCacheControlMarkers,
+  countUserCacheControlMarkers,
+  CACHE_CONTROL_CANONICAL_MARKER,
   _pinnedBlocks,  // exported so tests can reset between runs
 };

--- a/test/cacheControlNormalize.test.mjs
+++ b/test/cacheControlNormalize.test.mjs
@@ -1,0 +1,157 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  stripCacheControlMarkers,
+  countUserCacheControlMarkers,
+  CACHE_CONTROL_CANONICAL_MARKER,
+} from "../preload.mjs";
+
+// -- stripCacheControlMarkers -----------------------------------------------
+
+test("stripCacheControlMarkers: removes marker from a user-msg content block", () => {
+  const msg = {
+    role: "user",
+    content: [
+      { type: "text", text: "hello", cache_control: { type: "ephemeral", ttl: "1h" } },
+    ],
+  };
+  const n = stripCacheControlMarkers(msg);
+  assert.equal(n, 1);
+  assert.equal(msg.content[0].cache_control, undefined);
+  assert.equal(msg.content[0].text, "hello");
+});
+
+test("stripCacheControlMarkers: returns 0 when no markers present", () => {
+  const msg = { role: "user", content: [{ type: "text", text: "x" }] };
+  assert.equal(stripCacheControlMarkers(msg), 0);
+});
+
+test("stripCacheControlMarkers: strips multiple markers in the same message", () => {
+  const msg = {
+    role: "user",
+    content: [
+      { type: "text", text: "a", cache_control: { type: "ephemeral", ttl: "1h" } },
+      { type: "text", text: "b" },
+      { type: "text", text: "c", cache_control: { type: "ephemeral", ttl: "5m" } },
+    ],
+  };
+  const n = stripCacheControlMarkers(msg);
+  assert.equal(n, 2);
+  for (const block of msg.content) {
+    assert.equal(block.cache_control, undefined);
+  }
+});
+
+test("stripCacheControlMarkers: non-user roles are skipped", () => {
+  const assistantMsg = {
+    role: "assistant",
+    content: [
+      { type: "text", text: "reply", cache_control: { type: "ephemeral", ttl: "1h" } },
+    ],
+  };
+  assert.equal(stripCacheControlMarkers(assistantMsg), 0);
+  // marker still present
+  assert.ok(assistantMsg.content[0].cache_control);
+});
+
+test("stripCacheControlMarkers: non-array content is skipped", () => {
+  const stringMsg = { role: "user", content: "plain string" };
+  assert.equal(stripCacheControlMarkers(stringMsg), 0);
+  assert.equal(stringMsg.content, "plain string");
+});
+
+test("stripCacheControlMarkers: null / empty / missing msg returns 0 without throwing", () => {
+  assert.equal(stripCacheControlMarkers(null), 0);
+  assert.equal(stripCacheControlMarkers(undefined), 0);
+  assert.equal(stripCacheControlMarkers({}), 0);
+  assert.equal(stripCacheControlMarkers({ role: "user" }), 0);
+  assert.equal(stripCacheControlMarkers({ role: "user", content: [] }), 0);
+});
+
+test("stripCacheControlMarkers: other block fields are preserved", () => {
+  const msg = {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: "abc",
+        content: "output",
+        is_error: false,
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      },
+    ],
+  };
+  stripCacheControlMarkers(msg);
+  const b = msg.content[0];
+  assert.equal(b.cache_control, undefined);
+  assert.equal(b.type, "tool_result");
+  assert.equal(b.tool_use_id, "abc");
+  assert.equal(b.content, "output");
+  assert.equal(b.is_error, false);
+});
+
+// -- countUserCacheControlMarkers ------------------------------------------
+
+test("countUserCacheControlMarkers: counts markers across user messages only", () => {
+  const body = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "a", cache_control: { type: "ephemeral", ttl: "1h" } },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "b", cache_control: { type: "ephemeral", ttl: "1h" } },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "c", cache_control: { type: "ephemeral", ttl: "1h" } },
+          { type: "text", text: "d", cache_control: { type: "ephemeral", ttl: "5m" } },
+        ],
+      },
+    ],
+  };
+  // 1 on msg[0], 0 on assistant msg[1], 2 on msg[2] → 3 user-side total
+  assert.equal(countUserCacheControlMarkers(body), 3);
+});
+
+test("countUserCacheControlMarkers: 0 when no markers present", () => {
+  const body = {
+    messages: [
+      { role: "user", content: [{ type: "text", text: "x" }] },
+    ],
+  };
+  assert.equal(countUserCacheControlMarkers(body), 0);
+});
+
+test("countUserCacheControlMarkers: null / empty body returns 0", () => {
+  assert.equal(countUserCacheControlMarkers(null), 0);
+  assert.equal(countUserCacheControlMarkers({}), 0);
+  assert.equal(countUserCacheControlMarkers({ messages: [] }), 0);
+  assert.equal(countUserCacheControlMarkers({ messages: null }), 0);
+});
+
+test("countUserCacheControlMarkers: string-content user message doesn't crash", () => {
+  const body = {
+    messages: [
+      { role: "user", content: "string" },
+      {
+        role: "user",
+        content: [{ type: "text", text: "x", cache_control: { type: "ephemeral", ttl: "1h" } }],
+      },
+    ],
+  };
+  assert.equal(countUserCacheControlMarkers(body), 1);
+});
+
+// -- CACHE_CONTROL_CANONICAL_MARKER ----------------------------------------
+
+test("CACHE_CONTROL_CANONICAL_MARKER is the expected shape", () => {
+  assert.equal(CACHE_CONTROL_CANONICAL_MARKER.type, "ephemeral");
+  assert.equal(CACHE_CONTROL_CANONICAL_MARKER.ttl, "1h");
+});


### PR DESCRIPTION
Pin the `cache_control` marker at a single canonical position so CC's natural marker-shuffle between turns stops invalidating the previous-last-block's cached bytes.

## Problem

Anthropic's prompt-cache uses `cache_control: {type: "ephemeral", ttl: ...}` markers on content blocks as cache breakpoints. CC places this marker on "the last block of the last user message" each turn — which shifts as new turns arrive.

Turn N:
```json
{"type": "tool_result", "content": "...", "tool_use_id": "a",
 "cache_control": {"type": "ephemeral", "ttl": "1h"}}
```

Turn N+1 (same message, now earlier in history):
```json
{"type": "tool_result", "content": "...", "tool_use_id": "a"}
```

The `cache_control` field silently disappears from what WAS the last-block last turn. 53 bytes of drift in that block's JSON → server can't partial-hit against its cached version of the prefix ending at that block. On a 200+ message session this is a few thousand to tens of thousands of cache-creation tokens per turn, depending on what other drift compounds at the same position.

## Fix

Enforce a canonical position on every outbound body:

1. Strip every existing `cache_control` marker from user-message content blocks
2. Place a single `{type: "ephemeral", ttl: "1h"}` marker on the LAST block of the LAST user message

Idempotent. Fast path: if the canonical block already has the correct marker AND it's the only user-side marker, the body is left byte-untouched.

## What's NOT touched

System-side markers (e.g., on `system[2]` for the global prompt) pass through — they're CC's stable breakpoint for the system prompt and work correctly as-is.

## Conventions matched

- Inline in `preload.mjs`, no side effects outside the call site
- `stripCacheControlMarkers(msg)` → number — pure helper, exported
- `countUserCacheControlMarkers(body)` → number — pure helper, exported
- `CACHE_CONTROL_CANONICAL_MARKER` — exported constant
- `shouldApplyFix("cache_control_normalize")` gate
- `recordFixResult("cache_control_normalize", "applied"|"skipped")`
- `_STATS_SCHEMA` entry: `{ applied: 0, skipped: 0, lastApplied: null }`
- Default ON; opt-out via `CACHE_FIX_SKIP_CACHE_CONTROL_NORMALIZE=1`
- **Runs LAST** in the extension pipeline so the canonical position is calculated against the final content array (after `smoosh_split`, `reminder_strip` etc. potentially mutate block counts)

## Tests

12 new cases in `test/cacheControlNormalize.test.mjs`:

**`stripCacheControlMarkers`:**
- Single marker stripped, text/type preserved
- No markers → returns 0
- Multiple markers in same message stripped
- Assistant role: skipped (marker preserved)
- String content: skipped
- Null/empty/missing inputs: 0 without throwing
- Non-`cache_control` block fields preserved

**`countUserCacheControlMarkers`:**
- Counts across user messages only (assistant markers ignored)
- Zero when none present
- Null/empty safety
- String-content user message doesn't crash

**`CACHE_CONTROL_CANONICAL_MARKER`:**
- Constant shape: `{type: "ephemeral", ttl: "1h"}`

Full suite: **87 passing, 0 failing** (12 new + 75 existing).

## Empirical validation

In our long-running resume-heavy session, the fast path hits ~100% of the time — CC places its own marker at the same canonical position, so this pass is a no-op on every request. It's a **safety net**: when CC diverges (first post-resume request, post-compaction, or edge cases in specific tool-use shapes), the pin kicks in and the previous-last-block's bytes stay stable.

Part of the stack contributing to the 940K → 1.7K first-request `cache_creation_input_tokens` reduction on `--continue`.

## A note on my earlier A/B

During development I saw a pid with consistent ~200K cw-per-request where this extension was active. Offline repro on captured bodies proved it was not the cause — the pipeline was fully idempotent and reported zero mutations. The misses correlated with rapid-fire request bursts within 13 seconds of each other and resolved autonomously after a short idle period, pointing to transient Anthropic-side cache-write propagation latency rather than an extension bug. Flagging here in case you've seen similar during your own validation.

Related: cnighswonger/claude-code-cache-fix#49585 (discussion thread).