### PR TITLE
Add cache_control_sticky extension — preserve historical marker positions

### DIFF
--- a/preload.mjs
+++ b/preload.mjs
@@ -504,6 +504,262 @@ function findDeferredToolsBlockInBody(body) {
   return null;
 }
 
+// --------------------------------------------------------------------------
+// cache_control_sticky — preserve historical marker positions across turns
+// --------------------------------------------------------------------------
+//
+// Covers a cache-miss class that cache_control_normalize can't reach by
+// itself. CC maintains at most one user-side cache_control marker at a time:
+// as conversation grows, CC moves the marker from the tail of one user turn
+// to the tail of the next, DROPPING it from the previous position. The
+// dropped position's block loses the ~43 bytes of `"cache_control":{"type":
+// "ephemeral","ttl":"1h"}` framing — a tail-of-message byte diff that
+// invalidates every downstream cached block (~600K tokens' worth on a
+// long-running session).
+//
+// Observed instance: at 16:27:13 UTC today, a 1284-message session emitted
+// cw=804,428 (hit=2.3%). Diff of main-session bodies 585 → 587 showed ONE
+// message diverged — msg[1281] — which lost its cache_control marker (43
+// bytes) because CC had moved the marker to the new last user msg[1283].
+//
+// cache_control_normalize places exactly ONE canonical marker at the last
+// block of the last user message on every outbound body. That solves the
+// current-marker-drift class but cannot preserve historical markers — CC
+// has already dropped them by the time the payload reaches this extension.
+//
+// This sticky extension maintains per-session state tracking where markers
+// have appeared in prior turns, and reinstates them on future turns as
+// additive preservation. Up to 3 historical message-level markers are
+// tracked (Anthropic's hard limit is 4 cache_control markers total — 1 for
+// system[2] + 3 for message-level breakpoints). When a historical position
+// would exceed the cap, the oldest tracked entry is dropped (LRU).
+//
+// Messages are identified by a stable hash so that compaction rewrites /
+// index shifts don't confuse the tracker:
+//   - If the message has a tool_use or tool_result block with an `id` or
+//     `tool_use_id`, hash `role|id`.
+//   - Otherwise hash `role|firstTextContent.slice(0, 256)`.
+//
+// Pipeline order: runs AFTER cache_control_normalize (when it's present) so
+// normalize first pins the canonical marker at the last user msg, then
+// sticky re-adds historical markers on their hashed messages. Skips any
+// message already carrying a marker (fast no-op when sticky fires first).
+//
+// Opt-out via CACHE_FIX_SKIP_CACHE_CONTROL_STICKY=1 (defaults ON).
+// --------------------------------------------------------------------------
+
+const CACHE_CONTROL_STICKY_DIR = join(homedir(), ".claude", "cache-fix-state");
+const CACHE_CONTROL_STICKY_MAX_POSITIONS = 3;
+const CACHE_CONTROL_STICKY_DEFAULT_MARKER = { type: "ephemeral", ttl: "1h" };
+
+/**
+ * Build the absolute state-file path for a given project key. Exported so
+ * tests can assert on path derivation without duplicating hash logic.
+ */
+function cacheControlStickyStatePath(key) {
+  const hash = createHash("sha1").update(String(key)).digest("hex").slice(0, 16);
+  return join(CACHE_CONTROL_STICKY_DIR, `cache-control-sticky-${hash}.json`);
+}
+
+/**
+ * Compute a stable hash identifier for a message that survives content-
+ * block insertions (e.g. smoosh_split peeling a reminder into a new block
+ * but the first text block's first 256 bytes don't change) and index shifts
+ * (e.g. compaction). Returns null if the message has no identifiable
+ * content. Pure; exported for unit tests.
+ */
+function computeStickyMessageHash(msg) {
+  if (!msg || typeof msg !== "object") return null;
+  const role = typeof msg.role === "string" ? msg.role : "";
+  if (!Array.isArray(msg.content) || msg.content.length === 0) return null;
+  // Prefer tool_use/tool_result identifiers when present — they're the
+  // most stable anchors.
+  for (const b of msg.content) {
+    if (!b || typeof b !== "object") continue;
+    if (b.type === "tool_use" && typeof b.id === "string" && b.id) {
+      return createHash("sha1").update(`${role}|tool_use|${b.id}`).digest("hex").slice(0, 16);
+    }
+    if (b.type === "tool_result" && typeof b.tool_use_id === "string" && b.tool_use_id) {
+      return createHash("sha1").update(`${role}|tool_result|${b.tool_use_id}`).digest("hex").slice(0, 16);
+    }
+  }
+  // Fallback: first text block's first 256 bytes.
+  for (const b of msg.content) {
+    if (!b || typeof b !== "object") continue;
+    if (b.type === "text" && typeof b.text === "string") {
+      const prefix = b.text.slice(0, 256);
+      return createHash("sha1").update(`${role}|text|${prefix}`).digest("hex").slice(0, 16);
+    }
+  }
+  return null;
+}
+
+/**
+ * Read persisted sticky state for a project key. Returns a fresh empty
+ * state on missing file, unreadable file, or corrupt JSON — never throws.
+ * Shape: `{ version: 1, positions: [{msg_hash, position_hint, marker}] }`.
+ */
+function readCacheControlStickyState(key) {
+  const path = cacheControlStickyStatePath(key);
+  let raw;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return { version: 1, positions: [] };
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.positions)) {
+      debugLog("cache_control_sticky: state file malformed shape — resetting");
+      return { version: 1, positions: [] };
+    }
+    const positions = [];
+    for (const p of parsed.positions) {
+      if (!p || typeof p !== "object") continue;
+      if (typeof p.msg_hash !== "string" || !p.msg_hash) continue;
+      positions.push({
+        msg_hash: p.msg_hash,
+        position_hint: p.position_hint === "last_block" ? "last_block" : "last_block",
+        marker:
+          p.marker && typeof p.marker === "object" && typeof p.marker.type === "string"
+            ? { ...p.marker }
+            : { ...CACHE_CONTROL_STICKY_DEFAULT_MARKER },
+      });
+    }
+    return { version: 1, positions };
+  } catch (e) {
+    debugLog(`cache_control_sticky: state JSON parse error (${e?.message}) — resetting`);
+    return { version: 1, positions: [] };
+  }
+}
+
+/**
+ * Atomic-write persisted sticky state. Best-effort; silent on I/O errors.
+ */
+function writeCacheControlStickyState(key, state) {
+  const path = cacheControlStickyStatePath(key);
+  try {
+    mkdirSync(CACHE_CONTROL_STICKY_DIR, { recursive: true });
+    const tmp = path + ".tmp";
+    writeFileSync(tmp, JSON.stringify(state, null, 2), "utf-8");
+    renameSync(tmp, path);
+  } catch (e) {
+    debugLog(`cache_control_sticky: state write error (${e?.message})`);
+  }
+}
+
+/**
+ * Pure core: given a body and the currently-persisted state, compute the
+ * next state and the list of marker mutations to apply to the body. No
+ * I/O, no body mutation — the wrapper is responsible for applying results.
+ *
+ * Algorithm:
+ *  1. Walk user-role messages; for each block-with-cache_control, record
+ *     `{msg_hash, marker}` into `observed`. Duplicate hashes keep the
+ *     first (most recent in message order).
+ *  2. Merge `observed` into the prior `state.positions`: newly-observed
+ *     hashes are appended (or moved to the front if re-seen); absent-from-
+ *     this-body hashes are kept so they persist across turns.
+ *  3. For each hash in the new state, locate the corresponding message in
+ *     the body (by hash match). If found AND the message's last block
+ *     does NOT already carry a marker, emit a mutation to set it.
+ *  4. Cap the new state at CACHE_CONTROL_STICKY_MAX_POSITIONS (oldest
+ *     entries dropped first — LRU keyed on most-recent touch).
+ *
+ * Returns `{newState, mutations}` where mutations =
+ * `[{msgIdx, blockIdx, marker}]`. Pure; exported for unit tests.
+ */
+function updateCacheControlStickyState(body, priorState) {
+  const empty = { newState: { version: 1, positions: [] }, mutations: [] };
+  if (!body || typeof body !== "object" || !Array.isArray(body.messages)) return empty;
+  const prior =
+    priorState && Array.isArray(priorState.positions)
+      ? { version: 1, positions: priorState.positions.slice() }
+      : { version: 1, positions: [] };
+
+  // Build hash → msgIdx index for this body's user messages.
+  const hashToMsgIdx = new Map();
+  const observed = []; // [{msg_hash, marker}] in message order
+  for (let m = 0; m < body.messages.length; m++) {
+    const msg = body.messages[m];
+    if (!msg || msg.role !== "user" || !Array.isArray(msg.content) || msg.content.length === 0) continue;
+    const h = computeStickyMessageHash(msg);
+    if (!h) continue;
+    if (!hashToMsgIdx.has(h)) hashToMsgIdx.set(h, m);
+    // Observe any existing marker on this message (any block).
+    for (const b of msg.content) {
+      if (b && typeof b === "object" && b.cache_control && typeof b.cache_control === "object") {
+        observed.push({ msg_hash: h, marker: { ...b.cache_control } });
+        break;
+      }
+    }
+  }
+
+  // Merge observed into prior: move observed hashes to the end (most
+  // recent), refresh their marker. Unobserved prior entries stay in place.
+  const priorIndex = new Map(prior.positions.map((p, i) => [p.msg_hash, i]));
+  const nextPositions = prior.positions.slice();
+  for (const ob of observed) {
+    if (priorIndex.has(ob.msg_hash)) {
+      const i = priorIndex.get(ob.msg_hash);
+      nextPositions[i] = { msg_hash: ob.msg_hash, position_hint: "last_block", marker: ob.marker };
+    } else {
+      nextPositions.push({ msg_hash: ob.msg_hash, position_hint: "last_block", marker: ob.marker });
+      priorIndex.set(ob.msg_hash, nextPositions.length - 1);
+    }
+  }
+
+  // Cap at MAX_POSITIONS: keep the NEWEST (end of array) entries.
+  let capped = nextPositions;
+  if (capped.length > CACHE_CONTROL_STICKY_MAX_POSITIONS) {
+    capped = capped.slice(capped.length - CACHE_CONTROL_STICKY_MAX_POSITIONS);
+  }
+
+  // Compute mutations: for each tracked hash present in this body, if the
+  // message doesn't already have any marker, add one at its last block.
+  const mutations = [];
+  for (const pos of capped) {
+    const msgIdx = hashToMsgIdx.get(pos.msg_hash);
+    if (msgIdx === undefined) continue;
+    const msg = body.messages[msgIdx];
+    if (!msg || !Array.isArray(msg.content) || msg.content.length === 0) continue;
+    const hasMarker = msg.content.some(
+      (b) => b && typeof b === "object" && b.cache_control && typeof b.cache_control === "object"
+    );
+    if (hasMarker) continue;
+    mutations.push({
+      msgIdx,
+      blockIdx: msg.content.length - 1,
+      marker: { ...pos.marker },
+    });
+  }
+
+  return { newState: { version: 1, positions: capped }, mutations };
+}
+
+/**
+ * Wrapper: read state, compute mutations via
+ * updateCacheControlStickyState, apply mutations to `body` in place, write
+ * next state. Returns the count of marker mutations applied. Silent on
+ * any I/O error (best-effort).
+ */
+function applyCacheControlSticky(body, key) {
+  if (!body || typeof body !== "object" || !Array.isArray(body.messages)) return 0;
+  const prior = readCacheControlStickyState(key);
+  const { newState, mutations } = updateCacheControlStickyState(body, prior);
+  for (const mut of mutations) {
+    const msg = body.messages[mut.msgIdx];
+    if (!msg || !Array.isArray(msg.content)) continue;
+    const newContent = msg.content.slice();
+    const target = newContent[mut.blockIdx];
+    if (!target || typeof target !== "object") continue;
+    newContent[mut.blockIdx] = { ...target, cache_control: { ...mut.marker } };
+    body.messages[mut.msgIdx] = { ...msg, content: newContent };
+  }
+  writeCacheControlStickyState(key, newState);
+  return mutations.length;
+}
+
 /**
  * Core fix: on EVERY call, scan the entire message array for the LATEST
  * relocatable blocks (skills, MCP, deferred tools, hooks) and ensure they
@@ -905,6 +1161,7 @@ const _STATS_SCHEMA = {
   session_start_normalize: { applied: 0, skipped: 0, lastApplied: null },
   continue_trailer_strip: { applied: 0, skipped: 0, lastApplied: null },
   deferred_tools_restore: { applied: 0, skipped: 0, lastApplied: null },
+  cache_control_sticky: { applied: 0, skipped: 0, lastApplied: null },
 };
 
 function _createEmptyStats() {
@@ -1761,6 +2018,34 @@ globalThis.fetch = async function (url, options) {
         }
       }
 
+      // Extension: cache_control_sticky — reinstate historical cache_control
+      // markers on messages whose position CC has moved past. CC maintains
+      // at most one user-side marker at a time; as it moves the marker to
+      // the tail of each new user turn, the previous position loses the ~43
+      // bytes of cache_control framing — a tail-of-message byte drift that
+      // breaks every downstream cached block. This extension tracks marker
+      // positions by stable message-hash across turns (up to 3) and re-adds
+      // them on future bodies. Runs AFTER cache_control_normalize (when
+      // present) so normalize pins the canonical tail-marker first and
+      // sticky re-adds the historical ones. State file is per-project at
+      // ~/.claude/cache-fix-state/cache-control-sticky-<sha1(cwd)>.json.
+      // Opt-out via CACHE_FIX_SKIP_CACHE_CONTROL_STICKY=1 (defaults ON).
+      if (shouldApplyFix("cache_control_sticky") && payload.messages) {
+        try {
+          const stickyApplied = applyCacheControlSticky(payload, process.cwd());
+          if (stickyApplied > 0) {
+            modified = true;
+            debugLog(`APPLIED: cache_control_sticky reinstated ${stickyApplied} historical marker(s)`);
+            recordFixResult("cache_control_sticky", "applied");
+          } else {
+            recordFixResult("cache_control_sticky", "skipped");
+          }
+        } catch (e) {
+          debugLog(`cache_control_sticky: error (${e?.message}) — skipped`);
+          recordFixResult("cache_control_sticky", "skipped");
+        }
+      }
+
       // Bug 5: TTL enforcement (configurable per request type)
       // The client gates 1h cache TTL behind a GrowthBook allowlist that checks
       // querySource against patterns like "repl_main_thread*", "sdk", "auto_mode".
@@ -2193,5 +2478,13 @@ export {
   deferredToolsSnapshotPath,
   DEFERRED_TOOLS_AVAILABLE_MARKER,
   DEFERRED_TOOLS_UNAVAILABLE_MARKER,
+  computeStickyMessageHash,
+  cacheControlStickyStatePath,
+  updateCacheControlStickyState,
+  applyCacheControlSticky,
+  readCacheControlStickyState,
+  writeCacheControlStickyState,
+  CACHE_CONTROL_STICKY_MAX_POSITIONS,
+  CACHE_CONTROL_STICKY_DEFAULT_MARKER,
   _pinnedBlocks,  // exported so tests can reset between runs
 };

--- a/test/cacheControlSticky.test.mjs
+++ b/test/cacheControlSticky.test.mjs
@@ -1,0 +1,250 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  computeStickyMessageHash,
+  cacheControlStickyStatePath,
+  updateCacheControlStickyState,
+  applyCacheControlSticky,
+  readCacheControlStickyState,
+  writeCacheControlStickyState,
+  CACHE_CONTROL_STICKY_MAX_POSITIONS,
+  CACHE_CONTROL_STICKY_DEFAULT_MARKER,
+} from "../preload.mjs";
+
+// Helper: build a user message with a tool_use_id-keyed shape.
+function makeUserToolResult(toolUseId, text, cacheControl) {
+  const block = {
+    type: "tool_result",
+    tool_use_id: toolUseId,
+    content: text,
+  };
+  if (cacheControl) block.cache_control = { ...cacheControl };
+  return { role: "user", content: [block] };
+}
+
+function makeUserText(text, cacheControl) {
+  const block = { type: "text", text };
+  if (cacheControl) block.cache_control = { ...cacheControl };
+  return { role: "user", content: [block] };
+}
+
+const EPHEMERAL_1H = { type: "ephemeral", ttl: "1h" };
+
+test("cache_control_sticky: no marker-able messages → no-op, state empty", () => {
+  const body = { messages: [makeUserText("hello"), makeUserText("world")] };
+  const { newState, mutations } = updateCacheControlStickyState(body, { version: 1, positions: [] });
+  assert.equal(mutations.length, 0);
+  assert.deepEqual(newState.positions, []);
+});
+
+test("cache_control_sticky: first body with a marker → state records hash of that msg", () => {
+  const body = {
+    messages: [
+      makeUserToolResult("toolu_abc", "result text"),
+      makeUserText("follow-up", EPHEMERAL_1H),
+    ],
+  };
+  const { newState, mutations } = updateCacheControlStickyState(body, { version: 1, positions: [] });
+  // No mutations — the marker is already there; sticky only re-adds when
+  // missing. But the position must be recorded in state.
+  assert.equal(mutations.length, 0);
+  assert.equal(newState.positions.length, 1);
+  assert.ok(typeof newState.positions[0].msg_hash === "string");
+  assert.equal(newState.positions[0].msg_hash.length, 16);
+  assert.deepEqual(newState.positions[0].marker, EPHEMERAL_1H);
+});
+
+test("cache_control_sticky: subsequent body where CC removed the marker → marker re-added at last block", () => {
+  // Turn 1: user msg with hash H1 carries marker; record state.
+  const firstBody = { messages: [makeUserText("first turn", EPHEMERAL_1H)] };
+  const r1 = updateCacheControlStickyState(firstBody, { version: 1, positions: [] });
+  assert.equal(r1.newState.positions.length, 1);
+
+  // Turn 2: SAME first message, but marker dropped; CC has moved marker
+  // to the new last user turn.
+  const secondBody = {
+    messages: [
+      makeUserText("first turn"), // same content, no marker now
+      makeUserText("second turn", EPHEMERAL_1H),
+    ],
+  };
+  const r2 = updateCacheControlStickyState(secondBody, r1.newState);
+  // Sticky should emit a mutation re-adding marker on msg[0].
+  const firstMsgMuts = r2.mutations.filter((m) => m.msgIdx === 0);
+  assert.equal(firstMsgMuts.length, 1);
+  assert.deepEqual(firstMsgMuts[0].marker, EPHEMERAL_1H);
+  assert.equal(firstMsgMuts[0].blockIdx, 0);
+});
+
+test("cache_control_sticky: caps at MAX_POSITIONS, drops oldest (LRU)", () => {
+  assert.equal(CACHE_CONTROL_STICKY_MAX_POSITIONS, 3);
+  // Build a body carrying 4 historical markers — one more than cap.
+  const body = {
+    messages: [
+      makeUserText("m1", EPHEMERAL_1H),
+      makeUserText("m2", EPHEMERAL_1H),
+      makeUserText("m3", EPHEMERAL_1H),
+      makeUserText("m4", EPHEMERAL_1H),
+    ],
+  };
+  const r = updateCacheControlStickyState(body, { version: 1, positions: [] });
+  assert.equal(r.newState.positions.length, 3);
+  // LRU: keep the newest (end-of-list). Compute expected hashes:
+  const hashM2 = computeStickyMessageHash(makeUserText("m2"));
+  const hashM3 = computeStickyMessageHash(makeUserText("m3"));
+  const hashM4 = computeStickyMessageHash(makeUserText("m4"));
+  assert.deepEqual(
+    r.newState.positions.map((p) => p.msg_hash),
+    [hashM2, hashM3, hashM4]
+  );
+});
+
+test("cache_control_sticky: message hash is stable across content-block insertions", () => {
+  const original = {
+    role: "user",
+    content: [{ type: "text", text: "<reminder>stable prefix here</reminder> actual body content" }],
+  };
+  const afterSmooshSplit = {
+    role: "user",
+    content: [
+      { type: "text", text: "<reminder>stable prefix here</reminder> actual body content" },
+      { type: "text", text: "extra peeled reminder injected by smoosh_split" },
+    ],
+  };
+  const h1 = computeStickyMessageHash(original);
+  const h2 = computeStickyMessageHash(afterSmooshSplit);
+  assert.ok(h1 && h2);
+  assert.equal(h1, h2);
+});
+
+test("cache_control_sticky: tool_use_id-keyed messages hash by id (stable across text changes)", () => {
+  const m1 = {
+    role: "user",
+    content: [{ type: "tool_result", tool_use_id: "toolu_stable_123", content: "output v1" }],
+  };
+  const m2 = {
+    role: "user",
+    content: [{ type: "tool_result", tool_use_id: "toolu_stable_123", content: "output v2 different text" }],
+  };
+  assert.equal(computeStickyMessageHash(m1), computeStickyMessageHash(m2));
+});
+
+test("cache_control_sticky: state file corruption → falls back to empty state (no throw)", async () => {
+  const { mkdirSync } = await import("node:fs");
+  const key = `corrupt-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const path = cacheControlStickyStatePath(key);
+  try {
+    // Ensure parent dir exists then write garbage JSON.
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, "{not-json: true, broken", "utf-8");
+    const state = readCacheControlStickyState(key);
+    assert.equal(state.version, 1);
+    assert.deepEqual(state.positions, []);
+  } finally {
+    try { rmSync(path, { force: true }); } catch {}
+  }
+});
+
+test("cache_control_sticky: wraps cleanly with canonical last-msg marker (normalize + sticky compose)", () => {
+  // Simulate the post-normalize body: canonical marker on the last user
+  // message. Sticky has a prior state pointing at a historical msg with
+  // no current marker. Sticky re-adds historical, normalize's canonical
+  // stays untouched.
+  const historicalMsg = makeUserText("historical content");
+  const historicalHash = computeStickyMessageHash(historicalMsg);
+  const body = {
+    messages: [
+      makeUserText("historical content"), // no marker — dropped by CC
+      makeUserText("new last turn", EPHEMERAL_1H), // canonical from normalize
+    ],
+  };
+  const prior = {
+    version: 1,
+    positions: [{ msg_hash: historicalHash, position_hint: "last_block", marker: EPHEMERAL_1H }],
+  };
+  const r = updateCacheControlStickyState(body, prior);
+  // Only msg[0] gets a mutation; msg[1] already has canonical marker.
+  assert.equal(r.mutations.length, 1);
+  assert.equal(r.mutations[0].msgIdx, 0);
+});
+
+test("cache_control_sticky: idempotent — second pass emits no new mutations", () => {
+  const historicalMsg = makeUserText("hist");
+  const historicalHash = computeStickyMessageHash(historicalMsg);
+  const body = { messages: [makeUserText("hist"), makeUserText("new", EPHEMERAL_1H)] };
+  const prior = {
+    version: 1,
+    positions: [{ msg_hash: historicalHash, position_hint: "last_block", marker: EPHEMERAL_1H }],
+  };
+  const r1 = updateCacheControlStickyState(body, prior);
+  assert.equal(r1.mutations.length, 1);
+  // Apply the mutation.
+  const mut = r1.mutations[0];
+  const msg = body.messages[mut.msgIdx];
+  msg.content[mut.blockIdx] = { ...msg.content[mut.blockIdx], cache_control: { ...mut.marker } };
+  // Second pass: marker now present, no new mutations.
+  const r2 = updateCacheControlStickyState(body, r1.newState);
+  assert.equal(r2.mutations.length, 0);
+});
+
+test("cache_control_sticky: different project keys produce different state file paths", () => {
+  const p1 = cacheControlStickyStatePath("/project/alpha");
+  const p2 = cacheControlStickyStatePath("/project/beta");
+  assert.notEqual(p1, p2);
+  assert.ok(p1.includes("cache-control-sticky-"));
+  assert.ok(p2.includes("cache-control-sticky-"));
+  // Same key → same path (deterministic).
+  assert.equal(cacheControlStickyStatePath("/project/alpha"), p1);
+});
+
+test("cache_control_sticky: end-to-end apply writes state file and mutates body", () => {
+  const key = `e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const statePath = cacheControlStickyStatePath(key);
+  try {
+    // Seed a prior state: msg with hash H1 had a marker last turn.
+    const historicalHash = computeStickyMessageHash(makeUserText("historical"));
+    writeCacheControlStickyState(key, {
+      version: 1,
+      positions: [{ msg_hash: historicalHash, position_hint: "last_block", marker: EPHEMERAL_1H }],
+    });
+    const body = {
+      messages: [
+        makeUserText("historical"), // no marker this turn
+        makeUserText("new last turn"),
+      ],
+    };
+    const n = applyCacheControlSticky(body, key);
+    assert.equal(n, 1);
+    // Marker was added to msg[0].content[0].
+    assert.deepEqual(body.messages[0].content[0].cache_control, EPHEMERAL_1H);
+    // msg[1] untouched.
+    assert.equal(body.messages[1].content[0].cache_control, undefined);
+    // State persisted.
+    assert.ok(existsSync(statePath));
+    const persisted = JSON.parse(readFileSync(statePath, "utf-8"));
+    assert.equal(persisted.version, 1);
+    assert.ok(Array.isArray(persisted.positions));
+  } finally {
+    try { rmSync(statePath, { force: true }); } catch {}
+  }
+});
+
+test("cache_control_sticky: body with no messages → applyCacheControlSticky returns 0, no crash", () => {
+  assert.equal(applyCacheControlSticky({}, "k1"), 0);
+  assert.equal(applyCacheControlSticky({ messages: [] }, "k2"), 0);
+  assert.equal(applyCacheControlSticky(null, "k3"), 0);
+});
+
+test("cache_control_sticky: hash is null for messages with no identifiable content", () => {
+  assert.equal(computeStickyMessageHash(null), null);
+  assert.equal(computeStickyMessageHash({}), null);
+  assert.equal(computeStickyMessageHash({ role: "user" }), null);
+  assert.equal(computeStickyMessageHash({ role: "user", content: [] }), null);
+  assert.equal(computeStickyMessageHash({ role: "user", content: [{ type: "image" }] }), null);
+});
+
+test("cache_control_sticky: default marker constant is ephemeral/1h", () => {
+  assert.deepEqual(CACHE_CONTROL_STICKY_DEFAULT_MARKER, { type: "ephemeral", ttl: "1h" });
+});


### PR DESCRIPTION
## What

Adds a new `cache_control_sticky` extension that preserves historical `cache_control` marker positions across turns by reinstating them on future outbound bodies from a per-session state file.

## Why

### The miss this fixes

Observed empirically on 2026-04-17 at 16:27:13 UTC: a 1284-message session emitted `cache_creation_input_tokens=804,428` (hit rate 2.3%). Diff of main-session bodies 585 vs 587 showed ONE message diverged — `msg[1281]` — which lost its `cache_control: {type: "ephemeral", ttl: "1h"}` marker (~43 bytes of JSON framing). CC had moved the only message-level marker onto the new last user message `msg[1283]`, dropping it from `msg[1281]`. That tail-of-message byte drift invalidates every downstream cached block.

### Why `cache_control_normalize` can't fix this

`cache_control_normalize` (the sibling extension) strips all user-side markers and pins exactly ONE canonical marker at the last block of the last user message. That solves the current-marker-drift class — but CC has already DROPPED the historical marker by the time the body reaches this preload. Normalize sees a single marker on the last msg and nothing to restore.

### Approach

Maintain per-session state tracking where markers have appeared. Reinstate them on future turns as additive preservation — up to 3 historical positions (Anthropic's hard total-marker cap is 4: `system[2]` + 3 message-level breakpoints).

Messages are identified by a **stable hash** so compaction rewrites and block-insertion passes (like `smoosh_split`) don't confuse the tracker:
- Prefer `sha1(role | tool_use_id)` when a `tool_use` or `tool_result` id is available.
- Otherwise hash `role | firstTextBlock.slice(0, 256)`.

On each outbound body:
1. Walk user messages; observe current cache_control markers and their message hashes.
2. Merge into prior state (keep unseen prior entries, refresh re-seen ones, LRU cap at 3).
3. For each tracked hash still present in this body, if the message carries no marker, emit a mutation to add one at its last block.
4. Write updated state atomically to `~/.claude/cache-fix-state/cache-control-sticky-<sha1(cwd)[:16]>.json`.

### Pipeline order

Runs AFTER `cache_control_normalize` (when both are enabled). Normalize places the canonical tail marker first; sticky re-adds historical ones on their hashed messages. Sticky skips any message already carrying a marker, so it's safe either way.

## Default on, opt-out

Default ON. Opt-out via `CACHE_FIX_SKIP_CACHE_CONTROL_STICKY=1` (matches the extension-family convention).

## Exports

Pure helpers exported for unit tests:
- `computeStickyMessageHash(msg)`
- `updateCacheControlStickyState(body, priorState)` — **pure**, returns `{newState, mutations}`
- `applyCacheControlSticky(body, key)` — wrapper with I/O
- `readCacheControlStickyState(key)`, `writeCacheControlStickyState(key, state)`
- `cacheControlStickyStatePath(key)`
- `CACHE_CONTROL_STICKY_MAX_POSITIONS` (= 3)
- `CACHE_CONTROL_STICKY_DEFAULT_MARKER` (= `{type: "ephemeral", ttl: "1h"}`)

## Tests

14 new cases covering:
- No marker-able messages → no-op, state empty
- First body with a marker → state records hash
- Subsequent body where CC removed the marker → marker re-added at last block
- LRU cap at 3 when 4 markers observed
- Hash stable across content-block insertions (smoosh_split compat)
- Hash stable across text changes when `tool_use_id` is the anchor
- Corrupt state file → empty state fallback, no throw
- Composes cleanly with canonical-last-msg marker
- Idempotent (second pass emits no new mutations)
- Different project keys → different state file paths
- End-to-end `applyCacheControlSticky` writes state and mutates body
- Body with no messages → returns 0, no crash
- `computeStickyMessageHash` returns null for uncontented messages
- Default marker constant shape

Full suite: **121 pass** (107 prior + 14 new).

## Files touched

- `preload.mjs` — +~290 lines: new section between `findDeferredToolsBlockInBody` and the core relocate fix; pipeline block after `deferred_tools_restore`, before `ttl`; `_STATS_SCHEMA` entry; export block additions.
- `test/cacheControlSticky.test.mjs` — new, 14 tests.

## Trade-offs

- State file is best-effort: corrupt JSON → fall back to empty, warn-log. Never throws.
- We only re-add when the message carries NO existing marker — won't overwrite normalize's canonical placement or user/tool-placed markers.
- Hash collision space is 2^64 (16 hex chars). Worst-case false-match → one message gets a spurious marker added; no cache correctness issue because markers are cumulative-safe up to the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)