### PR TITLE
v3.0.0: Proxy architecture — Phase 1, 2, 3a directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,14 +7,16 @@ You are the independent code reviewer for the claude-code-cache-fix proxy (v3.0.
 ## PR Review Workflow
 
 1. Before any review, fetch the current PR head/ref. Do not assume a previously viewed diff is still current.
-2. Read the full existing PR comment thread before taking any action — do not act on stale or partial context.
-3. PR review comments must clearly identify the agent posting them: `Codex review:` prefix.
-4. If the work under review is a directive/spec only, post the plan review result. Add `plan-approved` only when the directive is approved with no blocking findings.
-5. If there are blocking issues, post findings in the PR comment, apply `changes-requested`, and do NOT add an approval label.
-6. If the implementation is approved, post an approval comment and add `approved-by-codex-agent`.
-7. Review and approval labels are markers of review state, not substitutes for review comments.
-8. Each agent owns only their own labels. Do not add or remove another agent's review or approval labels.
-9. For shared workflow/state labels (`directive-stage`, `implementation-stage`, `ready-for-merge`), communicate desired changes in the review comment rather than applying directly, unless the user explicitly instructs otherwise.
+2. Check out the PR branch locally before reviewing. Do reviews on the PR branch, not on `main`, so review artifacts can be committed directly to the branch under review.
+3. Read the full existing PR comment thread before taking any action — do not act on stale or partial context.
+4. PR review comments must clearly identify the agent posting them: `Codex review:` prefix.
+5. If the work under review is a directive/spec only, post the plan review result. Add `plan-approved` only when the directive is approved with no blocking findings.
+6. If there are blocking issues, post findings in the PR comment, apply `changes-requested`, and do NOT add an approval label.
+7. If the implementation is approved, post an approval comment and add `approved-by-codex-agent`.
+8. Review and approval labels are markers of review state, not substitutes for review comments.
+9. Each agent owns only their own labels. Do not add or remove another agent's review or approval labels.
+10. For shared workflow/state labels (`directive-stage`, `implementation-stage`, `ready-for-merge`), communicate desired changes in the review comment rather than applying directly, unless the user explicitly instructs otherwise.
+11. When you create a review document in `docs/code-reviews/`, commit it on the PR branch and push it upstream as part of the review workflow so the team can see the exact artifact tied to the review state.
 
 ## Labels You Own
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 - **Do not push directly to `main` unless the user explicitly instructs you to do so in the current turn.** Otherwise use feature branches and PRs, even for small fixes.
 - If writing directly to `main` is explicitly authorized, pull/rebase from `origin/main` before any other write action so you start from the current remote tip.
 - Branch naming: `feature/<name>` for features, `fix/<name>` for bugfixes.
+- **Multi-phase feature branches:** For large features with phases, use `feature/<name>-<phase>` sub-branches that merge back into the parent `feature/<name>` branch. Git does not allow nested refs when the parent exists, so use hyphens not slashes for the phase segment. Example: `feature/proxy-v3-extensions` merges into `feature/proxy-v3`, which merges into `main` when the full feature ships. Each sub-branch gets its own PR with Codex review before merging to the parent.
 - PRs require review before merge.
 - Commit messages: lead with what changed and why, not how.
 - Multi-phase issues: use `Ref #N` (not `Closes #N`) until the final phase PR.

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -53,38 +53,24 @@ proxyProc.stderr.on("data", (chunk) => {
   process.stderr.write(chunk);
 });
 
-function waitForHealth(port, maxAttempts = 30, interval = 200) {
-  let attempts = 0;
+function waitForReady() {
   return new Promise((resolve, reject) => {
-    function check() {
-      attempts++;
-      const req = http.get(`http://127.0.0.1:${port}/health`, (res) => {
-        if (res.statusCode === 200) {
-          res.resume();
-          resolve();
-        } else {
-          retry();
-        }
-      });
-      req.on("error", retry);
-      req.setTimeout(1000, () => {
-        req.destroy();
-        retry();
-      });
-    }
-    function retry() {
-      if (attempts >= maxAttempts) {
-        reject(new Error(`Proxy failed to become ready after ${maxAttempts} attempts`));
-        return;
-      }
-      setTimeout(check, interval);
-    }
-    check();
+    let output = "";
+    proxyProc.stdout.on("data", (chunk) => {
+      output += chunk.toString();
+      const match = output.match(/listening on ([\d.]+):(\d+)/);
+      if (match) resolve(parseInt(match[2], 10));
+    });
+    proxyProc.on("exit", (code) => {
+      reject(new Error(`Proxy exited (code ${code}) before ready`));
+    });
+    setTimeout(() => reject(new Error("Proxy failed to start within 10s")), 10000);
   });
 }
 
+let actualPort;
 try {
-  await waitForHealth(proxyPort);
+  actualPort = await waitForReady();
 } catch (err) {
   process.stderr.write(`${err.message}\n`);
   cleanup(1);
@@ -93,7 +79,7 @@ try {
 
 const claudeEnv = {
   ...process.env,
-  ANTHROPIC_BASE_URL: `http://127.0.0.1:${proxyPort}`,
+  ANTHROPIC_BASE_URL: `http://127.0.0.1:${actualPort}`,
 };
 
 claudeProc = spawn("claude", claudeArgs, {

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import { fork, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import http from "node:http";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SERVER_PATH = resolve(__dirname, "../proxy/server.mjs");
+
+const args = process.argv.slice(2);
+let proxyPort = 9801;
+let proxyUpstream = undefined;
+const claudeArgs = [];
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--proxy-port" && args[i + 1]) {
+    proxyPort = parseInt(args[++i], 10);
+  } else if (args[i] === "--proxy-upstream" && args[i + 1]) {
+    proxyUpstream = args[++i];
+  } else {
+    claudeArgs.push(args[i]);
+  }
+}
+
+const proxyEnv = { ...process.env, CACHE_FIX_PROXY_PORT: String(proxyPort) };
+if (proxyUpstream) proxyEnv.CACHE_FIX_PROXY_UPSTREAM = proxyUpstream;
+
+const proxyProc = fork(SERVER_PATH, [], {
+  stdio: ["ignore", "pipe", "pipe", "ipc"],
+  env: proxyEnv,
+});
+
+let claudeProc = null;
+let exiting = false;
+
+function cleanup(code) {
+  if (exiting) return;
+  exiting = true;
+  if (claudeProc && !claudeProc.killed) claudeProc.kill("SIGTERM");
+  if (proxyProc && !proxyProc.killed) proxyProc.kill("SIGTERM");
+  setTimeout(() => process.exit(code), 3000);
+}
+
+proxyProc.on("exit", (code) => {
+  if (!exiting) {
+    process.stderr.write(`proxy exited unexpectedly (code ${code})\n`);
+    cleanup(1);
+  }
+});
+
+proxyProc.stderr.on("data", (chunk) => {
+  process.stderr.write(chunk);
+});
+
+function waitForHealth(port, maxAttempts = 30, interval = 200) {
+  let attempts = 0;
+  return new Promise((resolve, reject) => {
+    function check() {
+      attempts++;
+      const req = http.get(`http://127.0.0.1:${port}/health`, (res) => {
+        if (res.statusCode === 200) {
+          res.resume();
+          resolve();
+        } else {
+          retry();
+        }
+      });
+      req.on("error", retry);
+      req.setTimeout(1000, () => {
+        req.destroy();
+        retry();
+      });
+    }
+    function retry() {
+      if (attempts >= maxAttempts) {
+        reject(new Error(`Proxy failed to become ready after ${maxAttempts} attempts`));
+        return;
+      }
+      setTimeout(check, interval);
+    }
+    check();
+  });
+}
+
+try {
+  await waitForHealth(proxyPort);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  cleanup(1);
+  process.exit(1);
+}
+
+const claudeEnv = {
+  ...process.env,
+  ANTHROPIC_BASE_URL: `http://127.0.0.1:${proxyPort}`,
+};
+
+claudeProc = spawn("claude", claudeArgs, {
+  stdio: "inherit",
+  env: claudeEnv,
+});
+
+claudeProc.on("error", (err) => {
+  if (err.code === "ENOENT") {
+    process.stderr.write("Error: 'claude' command not found. Is Claude Code installed?\n");
+  } else {
+    process.stderr.write(`Failed to start claude: ${err.message}\n`);
+  }
+  cleanup(1);
+});
+
+claudeProc.on("exit", (code) => {
+  cleanup(code ?? 0);
+  process.exit(code ?? 0);
+});
+
+process.on("SIGINT", () => cleanup(130));
+process.on("SIGTERM", () => cleanup(143));

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -82,12 +82,12 @@ const claudeEnv = {
   ANTHROPIC_BASE_URL: `http://127.0.0.1:${actualPort}`,
 };
 
-const claudeCmd = process.env.CACHE_FIX_CLAUDE_CMD || "claude";
 const spawnOpts = { stdio: ["inherit", "pipe", "pipe"], env: claudeEnv };
 if (process.env.CACHE_FIX_CLAUDE_CMD) {
-  claudeProc = spawn(claudeCmd, claudeArgs, { ...spawnOpts, shell: true });
+  const parts = process.env.CACHE_FIX_CLAUDE_CMD.split(" ");
+  claudeProc = spawn(parts[0], [...parts.slice(1), ...claudeArgs], spawnOpts);
 } else {
-  claudeProc = spawn(claudeCmd, claudeArgs, spawnOpts);
+  claudeProc = spawn("claude", claudeArgs, spawnOpts);
 }
 
 claudeProc.stdout.on("data", (chunk) => process.stdout.write(chunk));

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -82,10 +82,13 @@ const claudeEnv = {
   ANTHROPIC_BASE_URL: `http://127.0.0.1:${actualPort}`,
 };
 
-claudeProc = spawn("claude", claudeArgs, {
-  stdio: ["inherit", "pipe", "pipe"],
-  env: claudeEnv,
-});
+const claudeCmd = process.env.CACHE_FIX_CLAUDE_CMD || "claude";
+const spawnOpts = { stdio: ["inherit", "pipe", "pipe"], env: claudeEnv };
+if (process.env.CACHE_FIX_CLAUDE_CMD) {
+  claudeProc = spawn(claudeCmd, claudeArgs, { ...spawnOpts, shell: true });
+} else {
+  claudeProc = spawn(claudeCmd, claudeArgs, spawnOpts);
+}
 
 claudeProc.stdout.on("data", (chunk) => process.stdout.write(chunk));
 claudeProc.stderr.on("data", (chunk) => process.stderr.write(chunk));

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -34,18 +34,18 @@ const proxyProc = fork(SERVER_PATH, [], {
 let claudeProc = null;
 let exiting = false;
 
-function cleanup(code) {
+function cleanup() {
   if (exiting) return;
   exiting = true;
   if (claudeProc && !claudeProc.killed) claudeProc.kill("SIGTERM");
   if (proxyProc && !proxyProc.killed) proxyProc.kill("SIGTERM");
-  setTimeout(() => process.exit(code), 3000);
 }
 
 proxyProc.on("exit", (code) => {
   if (!exiting) {
     process.stderr.write(`proxy exited unexpectedly (code ${code})\n`);
-    cleanup(1);
+    cleanup();
+    process.exit(1);
   }
 });
 
@@ -73,7 +73,7 @@ try {
   actualPort = await waitForReady();
 } catch (err) {
   process.stderr.write(`${err.message}\n`);
-  cleanup(1);
+  cleanup();
   process.exit(1);
 }
 
@@ -83,9 +83,12 @@ const claudeEnv = {
 };
 
 claudeProc = spawn("claude", claudeArgs, {
-  stdio: "inherit",
+  stdio: ["inherit", "pipe", "pipe"],
   env: claudeEnv,
 });
+
+claudeProc.stdout.pipe(process.stdout);
+claudeProc.stderr.pipe(process.stderr);
 
 claudeProc.on("error", (err) => {
   if (err.code === "ENOENT") {
@@ -93,13 +96,15 @@ claudeProc.on("error", (err) => {
   } else {
     process.stderr.write(`Failed to start claude: ${err.message}\n`);
   }
-  cleanup(1);
+  cleanup();
+  process.exit(1);
 });
 
 claudeProc.on("exit", (code) => {
-  cleanup(code ?? 0);
-  process.exit(code ?? 0);
+  const exitCode = code ?? 0;
+  cleanup();
+  process.exit(exitCode);
 });
 
-process.on("SIGINT", () => cleanup(130));
-process.on("SIGTERM", () => cleanup(143));
+process.on("SIGINT", () => { cleanup(); process.exit(130); });
+process.on("SIGTERM", () => { cleanup(); process.exit(143); });

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -87,8 +87,8 @@ claudeProc = spawn("claude", claudeArgs, {
   env: claudeEnv,
 });
 
-claudeProc.stdout.pipe(process.stdout);
-claudeProc.stderr.pipe(process.stderr);
+claudeProc.stdout.on("data", (chunk) => process.stdout.write(chunk));
+claudeProc.stderr.on("data", (chunk) => process.stderr.write(chunk));
 
 claudeProc.on("error", (err) => {
   if (err.code === "ENOENT") {
@@ -100,7 +100,7 @@ claudeProc.on("error", (err) => {
   process.exit(1);
 });
 
-claudeProc.on("exit", (code) => {
+claudeProc.on("close", (code) => {
   const exitCode = code ?? 0;
   cleanup();
   process.exit(exitCode);

--- a/docs/code-reviews/proxy-v3-directive-rereview-2026-04-18.md
+++ b/docs/code-reviews/proxy-v3-directive-rereview-2026-04-18.md
@@ -1,0 +1,27 @@
+# Review: Proxy v3 Directive Re-Review
+
+Date: 2026-04-18
+Reviewed: docs/proxy-v3-directive.md
+Label applied: reviewed-by-codex-agent
+
+## What Is Correct
+- The remaining transport blocker is resolved. The directive now explicitly forces `accept-encoding: identity` on the upstream request and explains why that is necessary for line-oriented SSE parsing.
+- The prior major design concerns are now covered: header handling is explicit, telemetry capture includes both `message_start` and `message_delta`, and the readiness contract consistently uses `/health`.
+- The transport model remains sound: no full-response buffering, explicit backpressure, correct retry boundary at first byte, loopback-only inbound transport, outbound TLS, and clear abort propagation.
+- The security baseline is appropriate for plan approval: scoped `ANTHROPIC_BASE_URL`, no body logging, and no authorization logging.
+
+## Blockers
+None
+
+## What Needs Attention
+- `docs/proxy-v3-directive.md:118` still describes `stop_reason` as part of the `message_delta` usage object. That wording should be corrected before implementation so the parser reads the right event field.
+- `docs/proxy-v3-directive.md:111`, `docs/proxy-v3-directive.md:116` through `docs/proxy-v3-directive.md:120`, and `docs/proxy-v3-directive.md:128` through `docs/proxy-v3-directive.md:130` still blur the Phase 1 versus Phase 4 boundary. The current text says Phase 1 excludes response capture/logging while the proposed parser already assembles a telemetry record.
+- `docs/proxy-v3-directive.md:81` still names only `anthropic-ratelimit-*` response headers in the preserve list, while the surrounding text implies a broader transparent-proxy policy. That language could be widened for clarity before implementation starts.
+
+## Recommendations
+- Correct the `message_delta` schema wording so implementation does not key off the wrong JSON path.
+- Clarify whether Phase 1 only exposes telemetry extraction hooks or whether first-pass telemetry capture formally begins in Phase 1 and persistence lands in Phase 4.
+- Widen the response-header wording to reflect the actual end-to-end preservation rule, with hop-by-hop stripping as the exception.
+
+## Bottom Line
+Plan approved. The directive now covers the core transport and lifecycle decisions well enough to start implementation. The remaining issues are spec-clarity cleanups, not design blockers.

--- a/docs/code-reviews/proxy-v3-directive-review-2026-04-18.md
+++ b/docs/code-reviews/proxy-v3-directive-review-2026-04-18.md
@@ -1,0 +1,28 @@
+# Review: Proxy v3 Directive
+
+Date: 2026-04-18
+Reviewed: docs/proxy-v3-directive.md
+Label applied: changes-requested
+
+## What Is Correct
+- The prior three blockers are materially addressed. The directive now has an explicit hop-by-hop header policy, captures both `message_start` and `message_delta` usage for telemetry parity, and aligns the proxy and wrapper on a `/health` readiness check.
+- The streaming model is still the right one: no full-response buffering, explicit backpressure, and a clear pre-first-byte vs post-first-byte failure boundary are all correct for Claude Code's SSE behavior.
+- The security posture is improved. Loopback-only inbound transport, outbound TLS, scoped `ANTHROPIC_BASE_URL`, no body logging, and explicit abort propagation are the right defaults for a proxy that handles prompts and API credentials.
+- Per-phase test expectations are now placed on the critical path instead of being deferred to the end, which is the right change for transport work.
+
+## Blockers
+- `docs/proxy-v3-directive.md:80` through `docs/proxy-v3-directive.md:84` and `docs/proxy-v3-directive.md:107` through `docs/proxy-v3-directive.md:119` still do not define a `content-encoding` policy. The proxy plans to parse SSE `data:` lines in `stream.mjs`, but it does not say whether it forbids compressed upstream responses by stripping/overriding `accept-encoding`, or whether it will decompress and then rewrite `content-encoding` and related headers before forwarding. That gap is transport-critical: a compressed SSE body is not parseable as line-delimited text, and silently assuming plaintext would make the design incorrect if the upstream ever enables compression.
+
+## What Needs Attention
+- `docs/proxy-v3-directive.md:117` says `message_delta` carries `stop_reason` inside the final usage object. That is not the Anthropic event shape. `message_delta` carries output-token usage plus a separate delta payload for stop reason. The directive should name those fields correctly so the implementation does not key off the wrong JSON path.
+- `docs/proxy-v3-directive.md:110`, `docs/proxy-v3-directive.md:115` through `docs/proxy-v3-directive.md:119`, and `docs/proxy-v3-directive.md:127` through `docs/proxy-v3-directive.md:130` blur the Phase 1 vs Phase 4 boundary. The file says Phase 1 does not include response capture/logging, but the proposed Phase 1 stream/parser already assembles the telemetry record. That should be tightened: either Phase 1 only exposes parser hooks and Phase 4 persists telemetry, or the phase table should be updated to reflect that telemetry capture starts in Phase 1.
+- `docs/proxy-v3-directive.md:81` is still narrower than the existing `preload.mjs` behavior on response metadata. `preload.mjs` captures all `anthropic-*` headers plus identifiers such as `request-id` and `cf-ray`, not just rate-limit headers. The directive should make clear that end-to-end response headers are preserved broadly, with hop-by-hop stripping as the exception.
+
+## Recommendations
+- Add one explicit rule for transfer codings and content codings. Either force identity encoding upstream for streamed SSE inspection, or specify a decompression/recompression path and the exact header normalization that goes with it.
+- Correct the SSE event schema language so `message_delta` parsing refers to `event.usage.output_tokens` and the separate stop-reason field in the delta payload.
+- Tighten the phase contract around telemetry so the implementation team knows whether Phase 1 is only transport plus parser hooks or transport plus first-pass capture.
+- Widen the response-header language from `anthropic-ratelimit-*` to the actual transparent-proxy rule: preserve end-to-end response headers needed by clients and monitoring, strip only hop-by-hop headers.
+
+## Bottom Line
+Revise once more before adding `plan-approved`. The directive is much stronger than the earlier draft and most of the important review feedback landed cleanly, but the missing content-encoding decision is still a real transport-design gap for an SSE-parsing proxy. After that is specified, this is close to a sound implementation directive.

--- a/docs/code-reviews/proxy-v3-implementation-rereview-2-2026-04-20.md
+++ b/docs/code-reviews/proxy-v3-implementation-rereview-2-2026-04-20.md
@@ -1,0 +1,29 @@
+# Review: Proxy v3 Implementation Re-Review 2
+
+Date: 2026-04-20
+Reviewed: test/proxy-upstream.test.mjs, test/proxy-stream.test.mjs, test/proxy-wrapper.test.mjs
+Label applied: changes-requested
+
+## What Is Correct
+- The prior upstream-test blocker is resolved. `test/proxy-upstream.test.mjs` now uses a local HTTP fake upstream instead of the real Anthropic endpoint, and it verifies real `http://` forwarding, request-header stripping, response-header stripping, `accept-encoding: identity`, and abort behavior.
+- The requested-vs-served telemetry follow-up is partially addressed. `test/proxy-stream.test.mjs` now asserts that `requestedModel` survives streaming once set upstream.
+- The package artifact remains correct. `npm pack --dry-run` still includes `bin/claude-via-proxy.mjs` and `proxy/*`.
+
+## Blockers
+- The test suite is still not reliable enough for approval. Both `node --test test/proxy-wrapper.test.mjs test/proxy-server.test.mjs test/proxy-upstream.test.mjs test/proxy-stream.test.mjs` and the full `npm test` failed locally, but with different wrapper-test failures on different runs:
+  - `test/proxy-wrapper.test.mjs:129-147` failed once because the wrapper exited `0` instead of propagating the fake claude exit code `42`.
+  - `test/proxy-wrapper.test.mjs:100-126` failed on subsequent runs because expected child stdout (`BASE_URL=...`) was empty during the full suite, even though the same file passed in isolation.
+  This is now a flaky verification path rather than the old upstream hang, but it is still blocking because the PR does not have a stable passing test run under the normal suite command.
+
+## What Needs Attention
+- `test/proxy-wrapper.test.mjs:100-147` relies on a shared repo-local `.test-bin/claude` shim and watchdog timers that are never cleared. That setup is a plausible source of the non-deterministic behavior seen under suite execution.
+- `test/proxy-wrapper.test.mjs:102-104` shells out to `curl` inside the fake `claude` script, which adds another external dependency to a test that is already sensitive to process/stdout timing.
+- The implementation itself may be correct here; the failure evidence points more strongly to test harness instability than to a confirmed runtime defect. But until the harness is stable, approval should stay blocked.
+
+## Recommendations
+- Make the wrapper tests hermetic: avoid shared mutable shim paths where possible, clear watchdog timers after successful exits, and remove unnecessary external process dependencies such as `curl`.
+- Re-run `node --test test/proxy-wrapper.test.mjs test/proxy-server.test.mjs test/proxy-upstream.test.mjs test/proxy-stream.test.mjs` and `npm test` until they pass cleanly and repeatably without variance between runs.
+- If the wrapper logic is correct and only stdout capture is flaky, tighten the assertion method so it validates `ANTHROPIC_BASE_URL` without depending on inherited stdio timing.
+
+## Bottom Line
+The original upstream hang is fixed, and the new upstream tests are substantially better. I still cannot approve because the wrapper verification became flaky under real suite execution, which means the branch still does not have a dependable clean test run.

--- a/docs/code-reviews/proxy-v3-implementation-rereview-2026-04-20.md
+++ b/docs/code-reviews/proxy-v3-implementation-rereview-2026-04-20.md
@@ -1,0 +1,26 @@
+# Review: Proxy v3 Implementation Re-Review
+
+Date: 2026-04-20
+Reviewed: package.json, proxy/upstream.mjs, proxy/server.mjs, bin/claude-via-proxy.mjs, test/proxy-*.test.mjs
+Label applied: changes-requested
+
+## What Is Correct
+- The previously reported implementation blockers are addressed in `9e498aa`: the package artifact now includes `bin/` and `proxy/`, the wrapper has a published `bin` entry, `forwardRequest()` selects `http` versus `https` transport by upstream protocol, and `server.mjs` now captures `requestedModel` from the request body before streaming begins.
+- The wrapper tests now exercise `bin/claude-via-proxy.mjs` itself rather than only forking the proxy server. Local verification confirmed the missing-`claude` path, `ANTHROPIC_BASE_URL` scoping, and child exit-code propagation.
+- `npm pack --dry-run` now includes the proxy runtime files and wrapper entrypoint, so the package-shipping blocker from the previous review is resolved.
+
+## Blockers
+- `test/proxy-upstream.test.mjs:1` still does not terminate cleanly under Node's test runner. `timeout 20s node --test test/proxy-upstream.test.mjs` prints both assertions as passed, but the process never exits on its own and ends with the file cancelled: `'Promise resolution is still pending but the event loop has already resolved'`. The same issue prevents `npm test` from completing cleanly in local verification. Until the suite exits successfully without an external timeout, the implementation is not ready for approval.
+
+## What Needs Attention
+- `test/proxy-upstream.test.mjs:7-43` still does not actually verify the new `http://` upstream path or header forwarding against a live local upstream. The code fix itself looks correct, but the test coverage remains weaker than the change it is meant to protect.
+- `proxy/server.mjs:24-30` and `:54-55` now populate `requestedModel`, but there is still no explicit test proving requested-versus-served model capture works through a proxied request.
+- `test/proxy-wrapper.test.mjs:92-145` uses 15-second watchdog timers that are not cleared after successful exits. They eventually drain, but they also stretch wrapper-test runtime to roughly 18 seconds in local runs.
+
+## Recommendations
+- Fix `test/proxy-upstream.test.mjs` so `node --test` exits without external timeouts, then re-run the full suite and report the clean result.
+- Replace the current upstream smoke test with a real local `http://127.0.0.1:<port>` forwarding assertion so the protocol-selection fix is covered by execution, not just inspection.
+- Add a focused test for `requestedModel` telemetry capture and clear the wrapper watchdog timers once each child process exits.
+
+## Bottom Line
+The main code blockers from the prior review are resolved, but I still would not approve this implementation yet because the local verification bar is not met: `npm test` does not finish cleanly, and the isolated failure points back to `test/proxy-upstream.test.mjs`. Fix the hanging test path, then this should be close to approval.

--- a/docs/code-reviews/proxy-v3-implementation-rereview-3-2026-04-20.md
+++ b/docs/code-reviews/proxy-v3-implementation-rereview-3-2026-04-20.md
@@ -1,0 +1,27 @@
+# Review: Proxy v3 Implementation Re-Review 3
+
+Date: 2026-04-20
+Reviewed: implementation state through fe0be5b
+Label applied: changes-requested
+
+## What Is Correct
+- The clarification on PR #41 is accurate: the upstream-test hang fix from `fe0be5b` is already part of the implementation history under review.
+- The upstream verification remains improved versus the original implementation: local fake upstream, real `http://` forwarding assertions, header-policy checks, and explicit abort coverage.
+- The requested-model preservation check remains present in `test/proxy-stream.test.mjs`.
+
+## Blockers
+- Re-reviewing the implementation state through `fe0be5b` does not change the remaining blocker. The wrapper tests are still flaky under the real suite commands:
+  - `node --test test/proxy-wrapper.test.mjs test/proxy-server.test.mjs test/proxy-upstream.test.mjs test/proxy-stream.test.mjs` failed locally at `test/proxy-wrapper.test.mjs:129-147`, where the wrapper exited `0` instead of propagating the fake claude exit code `42`.
+  - `npm test` failed locally at `test/proxy-wrapper.test.mjs:100-126`, where expected child stdout (`BASE_URL=...`) was empty during the full suite.
+- Because the same code passes in isolation but fails under the actual suite commands used for verification, the branch still lacks a stable clean test run and is not ready for approval.
+
+## What Needs Attention
+- The clarification resolved branch-history confusion, not the test-stability problem.
+- The evidence still points to wrapper-test harness instability under suite execution rather than a resolved verification story.
+
+## Recommendations
+- Fix the wrapper test harness so the combined proxy test command and `npm test` both pass cleanly and repeatably.
+- Once that is done, rerun the same suite commands and re-request review.
+
+## Bottom Line
+The latest clarification is noted and the implementation was re-checked on the correct commit range. The review outcome is unchanged: `changes-requested` remains until the wrapper tests stop failing under the normal suite commands.

--- a/docs/code-reviews/proxy-v3-implementation-rereview-4-2026-04-20.md
+++ b/docs/code-reviews/proxy-v3-implementation-rereview-4-2026-04-20.md
@@ -1,0 +1,27 @@
+# Review: Proxy v3 Implementation Re-Review 4
+
+Date: 2026-04-20
+Reviewed: ca83d3a
+Label applied: changes-requested
+
+## What Is Correct
+- `ca83d3a` directly targets the two previously reported wrapper-test failure modes by removing deferred cleanup exit logic and changing the spawned `claude` child to use piped stdout/stderr relayed through the wrapper.
+- The updated wrapper implementation in `bin/claude-via-proxy.mjs` matches the intent described in the PR comment.
+
+## Blockers
+- The fix does not pass local verification. The exact commands the PR comment cites as passing still fail here:
+  - `node --test test/proxy-wrapper.test.mjs` failed at `test/proxy-wrapper.test.mjs:129-147` because the wrapper exited `0` instead of propagating fake-claude exit code `42`.
+  - `node --test test/proxy-wrapper.test.mjs test/proxy-server.test.mjs test/proxy-upstream.test.mjs test/proxy-stream.test.mjs` failed at both `test/proxy-wrapper.test.mjs:100-126` (empty `BASE_URL=...` output) and `:129-147` (exit code `1` instead of `42`).
+  - `npm test` failed with the same two wrapper assertions.
+- Because the reported fix is not reproducible under local verification, the branch still does not have a dependable clean test run and cannot be approved.
+
+## What Needs Attention
+- The continued variance strongly suggests the wrapper test harness is still interacting badly with shared state or process timing. The repo-local `.test-bin/claude` shim remains shared across multiple tests in the same file, and the assertions still depend on shell-script behavior plus inherited process lifecycle.
+- This is no longer an “unverified concern”; the failing commands were rerun after the fix and still fail.
+
+## Recommendations
+- Reproduce locally with the exact commands above and inspect the wrapper-test harness first, especially shared fake-binary state and child-process exit timing.
+- Do not treat the wrapper reliability issue as resolved until those commands pass cleanly and repeatably on the branch under review.
+
+## Bottom Line
+I re-reviewed the latest claimed wrapper reliability fix in `ca83d3a`. The implementation change is present, but the verification result is unchanged: wrapper tests still fail locally under the exact commands cited in the PR, so `changes-requested` remains.

--- a/docs/code-reviews/proxy-v3-implementation-rereview-5-2026-04-20.md
+++ b/docs/code-reviews/proxy-v3-implementation-rereview-5-2026-04-20.md
@@ -1,0 +1,27 @@
+# Review: Proxy v3 Implementation Re-Review 5
+
+Date: 2026-04-20
+Reviewed: 0dcadab
+Label applied: changes-requested
+
+## What Is Correct
+- `0dcadab` again targets the right wrapper failure modes: it replaces `pipe()` with explicit `data` handlers and switches the child lifecycle handler from `"exit"` to `"close"`.
+- The committed wrapper code matches the PR explanation for this latest attempted fix.
+
+## Blockers
+- The branch still does not pass local verification under the exact commands named in the PR:
+  - `node --test test/proxy-wrapper.test.mjs` still fails at `test/proxy-wrapper.test.mjs:129-147`, with the wrapper exiting `0` instead of propagating fake-claude exit code `42`.
+  - `node --test test/proxy-wrapper.test.mjs test/proxy-server.test.mjs test/proxy-upstream.test.mjs test/proxy-stream.test.mjs` still fails at `test/proxy-wrapper.test.mjs:100-126` because expected child stdout (`BASE_URL=...`) is empty, and also fails the exit-code assertion (`1` instead of `42`).
+  - `npm test` still fails on the same wrapper stdout assertion.
+- Because these failures still reproduce after the latest fix, the wrapper reliability issue remains unresolved and approval is still blocked.
+
+## What Needs Attention
+- The latest code change did not eliminate the underlying wrapper-test instability in this environment.
+- The stdout-path and exit-code-path assertions are still sensitive to the wrapper test harness and/or process model in a way that is not yet under control.
+
+## Recommendations
+- Reproduce locally with the exact three commands above and debug the wrapper tests with that exact invocation order.
+- Do not clear review state until those commands pass cleanly and repeatably on the PR branch itself.
+
+## Bottom Line
+I re-reviewed the latest wrapper-race fix in `0dcadab`. The intended changes are present, but the verification outcome is still not clean, so `changes-requested` remains.

--- a/docs/code-reviews/proxy-v3-implementation-rereview-6-2026-04-20.md
+++ b/docs/code-reviews/proxy-v3-implementation-rereview-6-2026-04-20.md
@@ -1,0 +1,26 @@
+# Review: Proxy v3 Implementation Re-Review 6
+
+Date: 2026-04-20
+Reviewed: 6b510b0
+Label applied: changes-requested
+
+## What Is Correct
+- `6b510b0` materially improves the wrapper test harness by removing the bash/PATH fake-`claude` setup and replacing it with explicit Node-based helper scripts driven through `CACHE_FIX_CLAUDE_CMD`.
+- That change does improve local verification: `node --test test/proxy-wrapper.test.mjs` now passes cleanly, and the `BASE_URL=...` stdout assertion also passes inside the full `npm test` run.
+
+## Blockers
+- One blocking verification failure remains. The exit-code propagation test still fails under combined execution:
+  - `node --test test/proxy-wrapper.test.mjs test/proxy-server.test.mjs test/proxy-upstream.test.mjs test/proxy-stream.test.mjs` failed at `test/proxy-wrapper.test.mjs:114-133`, with actual exit code `1` instead of `42`.
+  - `npm test` failed on the same assertion.
+- Because the branch still does not produce a clean passing run under the actual suite commands, approval is still blocked.
+
+## What Needs Attention
+- The latest change narrowed the problem substantially: the stdout-path issue appears resolved, but the wrapper exit-code path is still unstable under multi-file suite execution.
+- This now looks like a more focused child-process lifecycle issue rather than a general cross-environment test harness problem.
+
+## Recommendations
+- Debug the `CACHE_FIX_CLAUDE_CMD` exit-code path specifically under combined suite execution, since isolation now passes.
+- Re-run the exact combined proxy command and `npm test` after the next fix and only clear review once both are green.
+
+## Bottom Line
+The fresh fix is an improvement and removes the stdout-capture failure, but it does not fully resolve the wrapper reliability blocker. `changes-requested` remains until the exit-code propagation test also passes under the combined suite commands.

--- a/docs/code-reviews/proxy-v3-implementation-rereview-7-2026-04-20.md
+++ b/docs/code-reviews/proxy-v3-implementation-rereview-7-2026-04-20.md
@@ -1,0 +1,30 @@
+# Review: proxy v3 implementation
+
+Date: 2026-04-20
+Reviewed: commit 40b1dfc
+Label applied: changes-requested
+
+## What Is Correct
+- The latest wrapper change addresses the previously suspected cross-test environment leakage by scrubbing `CACHE_FIX_PROXY_PORT` and `CACHE_FIX_PROXY_UPSTREAM` before forking the wrapper test process.
+- `bin/claude-via-proxy.mjs` no longer depends on `shell: true` for `CACHE_FIX_CLAUDE_CMD`, which is a cleaner and less environment-sensitive execution path.
+- The proxy/server/stream/upstream tests still pass in this environment; the remaining issue is isolated to the wrapper harness.
+
+## Blockers
+- `test/proxy-wrapper.test.mjs:89-112` and `:114-136` still fail under local verification because the fake child scripts are deleted before the forked wrapper process reliably consumes them. Reproducible failures:
+  - `node --test test/proxy-wrapper.test.mjs` failed at `:107` with `Expected BASE_URL in output, got:`.
+  - `node --test test/proxy-wrapper.test.mjs test/proxy-server.test.mjs test/proxy-upstream.test.mjs test/proxy-stream.test.mjs` failed at `:134` with `Expected exit 42, got 1`, and stderr showed `ENOENT` opening `test/.fake-claude-exit.mjs`.
+  - `npm test` failed on both wrapper assertions, including `Cannot find module '/home/manager/git_repos/claude-code-cache-fix_codex/test/.fake-claude-exit.mjs'`.
+
+## What Needs Attention
+- The current test cleanup strategy uses `finally { unlinkSync(script) }` immediately after awaiting wrapper process exit. That is not sufficient when the wrapper's spawned child may still be in module-load startup or stdio-drain timing; the test should not remove the file until the fake child has definitely finished consuming it.
+- The new `cleanEnv()` helper appears directionally correct, but the reproduced failures show that environment leakage was not the only source of flakiness. The review comment should reflect the actual remaining failure mode.
+
+## Recommendations
+- Make the wrapper tests use uniquely named temporary files and defer deletion until after the fake child process is guaranteed complete, or avoid filesystem race entirely by invoking a stable checked-in helper script.
+- Re-run the exact verification commands after that harness fix:
+  - `node --test test/proxy-wrapper.test.mjs`
+  - `node --test test/proxy-wrapper.test.mjs test/proxy-server.test.mjs test/proxy-upstream.test.mjs test/proxy-stream.test.mjs`
+  - `npm test`
+
+## Bottom Line
+`40b1dfc` improves the wrapper test setup, but it does not clear the blocker here. The branch still fails local verification because the wrapper tests race their own temporary fake-claude script cleanup, so I cannot remove `changes-requested` yet.

--- a/docs/code-reviews/proxy-v3-implementation-rereview-8-2026-04-20.md
+++ b/docs/code-reviews/proxy-v3-implementation-rereview-8-2026-04-20.md
@@ -1,0 +1,22 @@
+# Review: proxy v3 implementation
+
+Date: 2026-04-20
+Reviewed: commit 7a59a1b
+Label applied: approved-by-codex-agent
+
+## What Is Correct
+- The remaining wrapper-test flake is resolved by removing temporary fake-script files from the harness entirely and using inline `node -e` commands instead.
+- Adding `{ concurrency: 1 }` to the wrapper test suite is appropriate here because these tests fork subprocesses and share process-level environment assumptions.
+- Local verification now passes cleanly for the previously failing commands, and the package artifact still includes the proxy runtime.
+
+## Blockers
+None
+
+## What Needs Attention
+- `needs-sim-validation` should remain until the proxy is exercised against real Claude Code traffic, since that integration risk was not covered by unit tests alone.
+
+## Recommendations
+- Proceed with merge review once the team is satisfied with external/sim validation coverage.
+
+## Bottom Line
+The implementation is now in an approvable state. The prior wrapper-test race no longer reproduces here, the combined proxy suite passes, `npm test` is clean, and the package dry-run still includes the shipped proxy entrypoints.

--- a/docs/code-reviews/proxy-v3-implementation-review-2026-04-20.md
+++ b/docs/code-reviews/proxy-v3-implementation-review-2026-04-20.md
@@ -1,0 +1,30 @@
+# Review: Proxy v3 Implementation
+
+Date: 2026-04-20
+Reviewed: proxy/, bin/claude-via-proxy.mjs, package.json, test/proxy-*.test.mjs
+Label applied: changes-requested
+
+## What Is Correct
+- The basic transport shape matches the directive: loopback HTTP server, outbound request forwarding, SSE byte-for-byte relay, and explicit backpressure handling in `proxy/stream.mjs`.
+- The wrapper correctly scopes `ANTHROPIC_BASE_URL` to the spawned `claude` child instead of mutating the parent shell environment.
+- The implementation keeps the core security baseline intact: no request-body logging, no API-key logging, and no attempt to persist response bodies.
+- Focused server and wrapper tests pass locally (`node --test test/proxy-server.test.mjs`, `node --test test/proxy-wrapper.test.mjs`).
+
+## Blockers
+- `package.json:6-13` still publishes only the preload-era entrypoints. `npm pack --dry-run` confirms the tarball omits both `bin/claude-via-proxy.mjs` and `proxy/*`, so the new proxy path cannot ship to users from the package artifact at all.
+- `proxy/upstream.mjs:1-2` and `proxy/upstream.mjs:48-69` hard-code `https.request()` even though `CACHE_FIX_PROXY_UPSTREAM` / `--proxy-upstream` are configurable. Any `http://...` upstream for local simulation or integration testing will fail before the first request is forwarded, which undercuts the review workflow's required sim validation path.
+- `proxy/stream.mjs:1-10` defines `requestedModel`, but no code ever populates it from the request body. That misses the directive's requested-vs-served model capture needed for spoofing detection and regresses the telemetry value that Phase 1 was supposed to preserve.
+
+## What Needs Attention
+- `test/proxy-wrapper.test.mjs:8-64` never executes `bin/claude-via-proxy.mjs`; it only forks `proxy/server.mjs`. That leaves the actual wrapper lifecycle, arg parsing, readiness polling, `claude` spawn path, and failure handling untested.
+- `test/proxy-upstream.test.mjs:17-43` explicitly avoids asserting real header forwarding and would still pass even if the configurable upstream transport is broken. The current tests therefore do not protect the most failure-prone part of `forwardRequest()`.
+- `package.json:3` is still versioned as `2.0.3` while the PR is framed as `v3.0.0`. If release semantics matter for downstream install and communication, that metadata should be updated in the implementation PR rather than later.
+
+## Recommendations
+- Update package metadata so the publish artifact includes the new runtime files and exposes the wrapper entrypoint that users are meant to run.
+- Select the outbound transport from `new URL(config.upstream).protocol` and add an integration test that successfully forwards through a local `http://127.0.0.1:<port>` fake upstream.
+- Parse the collected request body once in `server.mjs`, set `telemetry.requestedModel`, and add a test that verifies requested-versus-served model capture across a proxied SSE response.
+- Replace the current wrapper smoke test with one that runs `bin/claude-via-proxy.mjs` against stubbed `claude` and proxy children so the wrapper contract is actually exercised.
+
+## Bottom Line
+Revise before approval. The basic proxy skeleton is in place, but this PR is not yet shippable as `v3.0.0`: the published package would not contain the new runtime, configurable non-TLS upstreams are broken despite being part of the interface, and requested-versus-served model telemetry is still missing.

--- a/docs/code-reviews/proxy-v3a-extensions-directive-rereview-2026-04-20.md
+++ b/docs/code-reviews/proxy-v3a-extensions-directive-rereview-2026-04-20.md
@@ -1,0 +1,23 @@
+# Review: proxy v3a extension pipeline directive
+
+Date: 2026-04-20
+Reviewed: docs/proxy-v3a-extensions-directive.md
+Label applied: reviewed-by-codex-agent
+
+## What Is Correct
+- The directive now defines a concrete SSE stream rewrite contract, including parse scope, reserialization, passthrough behavior for unmodified events, treatment of non-`data:` lines, and fallback behavior on parse/serialization failure.
+- The new `onResponseStart(ctx)` hook closes the earlier architectural gap for streaming-path extensions that need response status/headers before body forwarding.
+- The previous follow-ups are also addressed: the branch name is corrected, `extensions.json` is explicitly part of hot reload, and `skip: true` now defines the direct client response path.
+
+## Blockers
+None
+
+## What Needs Attention
+- Section numbering is slightly out of order (`1.5` appears before `1.3` / `1.4`). That is cosmetic only.
+
+## Recommendations
+- Proceed to implementation on `feature/proxy-v3-extensions`.
+- Keep `directive-stage` until implementation begins; then transition review state through the implementation workflow.
+
+## Bottom Line
+The directive is now specific enough to implement safely. The prior transport and hook-surface blockers are resolved, so I would add `plan-approved`.

--- a/docs/code-reviews/proxy-v3a-extensions-directive-review-2026-04-20.md
+++ b/docs/code-reviews/proxy-v3a-extensions-directive-review-2026-04-20.md
@@ -1,0 +1,31 @@
+# Review: proxy v3a extension pipeline directive
+
+Date: 2026-04-20
+Reviewed: docs/proxy-v3a-extensions-directive.md
+Label applied: changes-requested
+
+## What Is Correct
+- The phase split is sensible. Treating the extension pipeline as a separate directive on top of the already-approved proxy foundation keeps the work bounded.
+- Porting preload fixes as individually toggleable modules is the right abstraction for long-term maintainability and observability.
+- Error isolation and the requirement that zero enabled extensions still yield transparent forwarding are both good baseline constraints.
+
+## Blockers
+- `docs/proxy-v3a-extensions-directive.md:40-44`, `:55-57`, and `:131-139` do not define a wire-safe stream rewrite contract. The directive says each SSE `data:` line is parsed, passed through `onStreamEvent`, then the "modified response/stream" is forwarded, but it never specifies how mutated events are serialized back to bytes. That is transport-critical. The current proxy forwards raw chunks in [proxy/stream.mjs](/home/manager/git_repos/claude-code-cache-fix_codex/proxy/stream.mjs:1), not reconstructed events. Before implementation, the spec needs to say whether the stream layer will fully own SSE reserialization, what happens to non-`data:` lines (`event:`, `id:`, `retry:`, comments), and whether multi-line `data:` payloads are preserved or normalized.
+- The proposed hook surface cannot support the listed streaming observability extensions because it never exposes response headers/status on the streaming path. `cache-telemetry` is explicitly defined in `docs/proxy-v3a-extensions-directive.md:108-109` as extracting `cache_read/cache_creation` from response headers, but `onStreamEvent(ctx)` only gets `{ event, meta, telemetry }` and `onResponse(ctx)` is non-streaming only. The spec needs a response-start/header hook, or equivalent streaming context, before this design can be implemented coherently.
+
+## What Needs Attention
+- `docs/proxy-v3a-extensions-directive.md:7` still names the branch as `feature/proxy-v3/extensions`, which conflicts with the branch naming rule added in the same PR (`feature/proxy-v3-extensions`). That is a doc consistency issue, not a blocker by itself.
+- `docs/proxy-v3a-extensions-directive.md:63-76` describes hot reload for modules, but not whether changes to `proxy/extensions.json` are also watched and applied without restart. Since enabled/order overrides live there, the hot-reload behavior should cover it explicitly.
+- `docs/proxy-v3a-extensions-directive.md:33-34` mentions `skip: true` to abort forwarding, but the directive does not define what response shape/status the client receives when an extension does that.
+
+## Recommendations
+- Add a concrete stream-processing contract that defines:
+  - the canonical parsed SSE unit,
+  - which line types are surfaced to extensions,
+  - how mutated events are serialized back to bytes,
+  - and which framing/header invariants must be preserved.
+- Add a streaming response-start hook, or broaden stream hook context, so extensions can read and possibly annotate response status/headers before body streaming begins.
+- Update the branch reference and clarify whether `extensions.json` participates in hot reload.
+
+## Bottom Line
+The overall direction is good, but I would revise once more before adding `plan-approved`. As written, the directive does not yet specify how safe streamed response mutation works on the wire, and it does not expose the data that the proposed streaming telemetry extension needs.

--- a/docs/code-reviews/proxy-v3a-extensions-implementation-rereview-2-2026-04-21.md
+++ b/docs/code-reviews/proxy-v3a-extensions-implementation-rereview-2-2026-04-21.md
@@ -1,0 +1,23 @@
+# Review: proxy v3a extension pipeline implementation
+
+Date: 2026-04-21
+Reviewed: PR #45 implementation on commit 05f8bb8
+Label applied: approved-by-codex-agent
+
+## What Is Correct
+- The non-streaming response path now honors the approved Phase 3a contract: successful non-streaming responses are buffered, parsed, passed through `runOnResponse()`, and only then written back to the client.
+- The earlier implementation blockers are resolved: stream hooks receive `responseHeaders`, `fresh-session-sort` is present, and non-streaming `onResponse` is no longer limited to error responses.
+- Local verification passed for `node --test test/proxy-pipeline.test.mjs test/proxy-integration.test.mjs`, `npm test`, and `npm pack --dry-run`.
+
+## Blockers
+None
+
+## What Needs Attention
+- `proxy/extensions/cache-telemetry.mjs` still appears narrower than the directive text: it records transient stream-derived stats in `ctx.meta.cacheStats`, but it does not yet implement the full response-header / `~/.claude/quota-status.json` persistence behavior described in the spec. That is not blocking for this PR’s approval, but it is still a follow-up gap between implementation and directive wording.
+
+## Recommendations
+- Proceed with merge review from the implementation side.
+- Keep `needs-sim-validation` in mind if the team wants real Claude Code traffic verification before merge.
+
+## Bottom Line
+The implementation is now in an approvable state. The remaining contract mismatch on the non-streaming path is resolved, the full local test suite passes, and the package artifact still ships the proxy runtime and extensions.

--- a/docs/code-reviews/proxy-v3a-extensions-implementation-rereview-2026-04-21.md
+++ b/docs/code-reviews/proxy-v3a-extensions-implementation-rereview-2026-04-21.md
@@ -1,0 +1,24 @@
+# Review: proxy v3a extension pipeline implementation
+
+Date: 2026-04-21
+Reviewed: PR #45 implementation on commit 5a0311b
+Label applied: changes-requested
+
+## What Is Correct
+- `proxy/stream.mjs` now threads `responseHeaders` into the stream hook context, so the earlier streaming metadata contract gap is resolved.
+- The missing `fresh-session-sort` extension is now present and registered in `proxy/extensions.json`.
+- Local verification passed for `node --test test/proxy-pipeline.test.mjs test/proxy-integration.test.mjs`, `npm test`, and `npm pack --dry-run`.
+
+## Blockers
+- `proxy/server.mjs:78-99` still does not implement the approved non-streaming response contract. `runOnResponse()` is only invoked inside the `statusCode >= 400` branch, which means successful non-streaming JSON responses still bypass the `onResponse` hook entirely. The approved directive said non-streaming responses are buffered, parsed, and passed through `onResponse` hooks; the current branch still only does that for error responses.
+
+## What Needs Attention
+- Because `clientRes.writeHead(statusCode, responseHeaders)` happens before the `runOnResponse()` branch (`proxy/server.mjs:76`), any future `onResponse` extension that mutates response headers would not affect what the client actually receives. That is not a blocker for the current extension set, but it is inconsistent with the advertised mutable-header hook surface.
+- `proxy/extensions/cache-telemetry.mjs` still does not implement the directive’s stated behavior of extracting from response headers and writing `~/.claude/quota-status.json`; it only records transient values in `ctx.meta.cacheStats`.
+
+## Recommendations
+- Generalize the non-streaming path so successful JSON responses also buffer, parse, invoke `runOnResponse()`, and only then write headers/body to the client.
+- If `onResponse` is meant to allow header mutation, delay `writeHead()` until after `runOnResponse()` completes for non-streaming responses.
+
+## Bottom Line
+The branch is much closer now, but I still cannot approve it yet. The implementation still falls short of the approved contract on the non-streaming success path, even though the previous streaming-metadata and missing-extension blockers are fixed.

--- a/docs/code-reviews/proxy-v3a-extensions-implementation-review-2026-04-21.md
+++ b/docs/code-reviews/proxy-v3a-extensions-implementation-review-2026-04-21.md
@@ -1,0 +1,27 @@
+# Review: proxy v3a extension pipeline implementation
+
+Date: 2026-04-21
+Reviewed: PR #45 implementation on commit d73eacc
+Label applied: changes-requested
+
+## What Is Correct
+- The branch introduces the expected extension-pipeline scaffolding (`proxy/pipeline.mjs`, `proxy/watcher.mjs`, extension modules, integration tests) and keeps the package artifact shipping the new proxy files.
+- The request-path hook execution and snapshotting model are reasonable, and the new test coverage is materially better than the previous proxy phases.
+- Local verification passed for `node --test test/proxy-pipeline.test.mjs test/proxy-integration.test.mjs`, `npm test`, and `npm pack --dry-run`.
+
+## Blockers
+- `proxy/server.mjs:71-76` and `proxy/stream.mjs:63-65` break the approved hook contract for streaming responses. `onResponseStart()` runs, but the streaming hook context is still created with `responseHeaders: null`, so streaming extensions never receive the response metadata the directive explicitly added this hook for. Any extension that needs headers during `onStreamEvent` still cannot work as specified.
+- `proxy/pipeline.mjs:78-88` defines `runOnResponse()`, but `proxy/server.mjs:76-98` never buffers a non-streaming response or calls it. The implementation therefore exposes an `onResponse` API that is not actually wired into the server. That is a functional gap, not just missing polish: non-streaming response extensions cannot run at all.
+- The approved directive’s success criteria require all five core cache fixes to be ported, including `fresh-session-sort` (`docs/proxy-v3a-extensions-directive.md:149`), but there is no corresponding extension module in `proxy/extensions/`. The current branch ships four core fixes plus extra helper/observability extensions, so the promised phase scope is still incomplete.
+
+## What Needs Attention
+- `proxy/extensions/cache-telemetry.mjs:1-24` does not implement the behavior described in the directive. It records transient values into `ctx.meta.cacheStats`, but it does not extract from response headers or write `~/.claude/quota-status.json` as specified.
+- Current tests do not cover the missing `onResponse` path or the missing `responseHeaders` propagation into `onStreamEvent`, which is why these contract gaps are passing unnoticed.
+
+## Recommendations
+- Thread the `onResponseStart()` header snapshot into `streamResponse()` so `ctx.responseHeaders` is populated for stream hooks.
+- Implement the documented non-streaming path by buffering/parsing non-SSE responses and invoking `runOnResponse()`, or narrow the public hook contract if non-streaming support is intentionally out of scope.
+- Add the missing `fresh-session-sort` extension and tests, or explicitly revise the phase scope before approval.
+
+## Bottom Line
+The branch is close, but I cannot approve it yet. The server still does not honor the full hook contract it now advertises, and one of the five promised core fixes is not implemented on the branch.

--- a/docs/proxy-v3-directive.md
+++ b/docs/proxy-v3-directive.md
@@ -79,9 +79,10 @@ A Node.js HTTP server on loopback that:
 - **TLS.** The proxy listens on plain HTTP (loopback only). The outbound connection to `api.anthropic.com` uses HTTPS. Node's `https` module or `fetch` handles this.
 - **Header policy.** The proxy is transparent for end-to-end headers but must handle hop-by-hop headers correctly:
   - **Preserve (forward as-is):** `authorization`, `anthropic-version`, `anthropic-beta`, `anthropic-dangerous-direct-browser-access`, `content-type`, `accept`, `x-stainless-*`, `x-api-key`, all `anthropic-ratelimit-*` response headers
-  - **Recompute:** `host` (set to upstream hostname), `content-length` (recalculate after extension pipeline modifies body in Phase 3)
+  - **Recompute:** `host` (set to upstream hostname), `content-length` (recalculate after extension pipeline modifies body in Phase 3), `accept-encoding` (force `identity` — see Content-Encoding constraint)
   - **Strip on request:** `connection`, `keep-alive`, `transfer-encoding`, `proxy-*`, `te`, `upgrade`
   - **Strip on response:** `connection`, `keep-alive`, `transfer-encoding` (proxy manages its own chunked encoding to client)
+- **Content-Encoding.** The proxy must request identity encoding from upstream by setting `accept-encoding: identity` on the outbound request. SSE parsing in `stream.mjs` operates on line-delimited text — compressed responses (gzip, br) are not parseable without decompression. Forcing identity encoding avoids the need for a decompression layer while preserving the ability to parse `message_start` and `message_delta` events. If a future use case requires compressed upstream responses, add explicit decompression before the SSE parser, and strip/recompute `content-encoding` on the response to the client.
 - **Timeout.** CC sets `x-stainless-timeout: 600` (10 minutes). The proxy must not impose a shorter timeout.
 - **No auth handling.** The proxy forwards the `Authorization` header as-is. It never reads, stores, or logs API keys.
 - **No body logging.** Request and response bodies must never be logged by default. No prompt content, tool payloads, or response text in any log output. Debug mode (future) must use explicit redaction for any metadata logging. Authorization headers must never appear in logs under any mode.

--- a/docs/proxy-v3-directive.md
+++ b/docs/proxy-v3-directive.md
@@ -1,0 +1,207 @@
+# Proxy v3.0.0 — Team Architecture & Design
+
+Date: 2026-04-18
+Status: Draft — pending Codex review
+Related: https://github.com/cnighswonger/claude-code-cache-fix/issues/40
+
+## Team Structure
+
+### Manager Session (Project Lead)
+- **Location:** `~/git_repos/claude` 
+- **Model:** Opus 4.6
+- **Role:** Strategic decisions, PR review, community coordination, requirements
+- Feeds design constraints and requirements to the Proxy Builder
+- Relays deafsquad/fgrosswig/wadabum feedback
+- Sends implementation plans to Codex Review Agent
+- Deep context on the CC community, issues, collaborators, blog series
+- Does NOT write proxy code
+
+### Proxy Builder (CC Teammate)
+- **Location:** `~/git_repos/claude-code-cache-fix` on `feature/proxy-v3` branch
+- **Model:** Opus 4.6
+- **Role:** Implementation — proxy server, extension pipeline, launch wrapper, tests
+- Works from #40 spec + design refinements from Codex review
+- Submits plans for review before implementing
+- Follows the `directive-stage → plan-approved → implementation-stage → ready-for-merge` workflow
+
+### Codex Review Agent (External — OpenAI Codex CLI)
+- **Location:** `~/git_repos/claude-code-cache-fix_codex`
+- **Role:** Independent code review per AGENTS.md
+- Reviews plans and implementations via markdown files in `docs/code-reviews/`
+- Feedback relayed through Manager or directly consumed by Proxy Builder
+- Applies review labels on GitHub
+
+### Proxy Test Agent (New — Dedicated Integration Testing)
+- **Location:** TBD (lightweight test repo or `~/git_repos/claude-code-cache-fix` itself)
+- **Model:** Opus 4.6 (match production use case)
+- **Role:** Dedicated integration test agent for the proxy
+- Routes all traffic through our proxy on `127.0.0.1:9801`
+- Exercises real CC workloads — tool calls, file reads, edits, subagents
+- Validates extension pipeline, cache behavior, detection layer
+- Reports issues back to Manager session
+- NOT the Kanfei Sim Agent — that agent has its own project and context
+
+---
+
+## Implementation Order
+
+| Phase | Component | Depends On |
+|-------|-----------|-----------|
+| 1 | Proxy HTTP server (listen, forward, stream SSE) | Nothing |
+| 2 | Launch wrapper (`claude-via-proxy`) | Phase 1 |
+| 3 | Extension pipeline (load 16 extensions, run in-process) | Phase 1 |
+| 4 | Response capture (meter integration, headers, usage) | Phase 1 |
+| 5 | Detection module (#39 — structural fingerprinting, drift) | Phase 3 |
+| 6 | Remote telemetry (opt-in sanitized reporting) | Phase 5 |
+| 7 | Tests (per-phase, not deferred to end) | Each phase |
+| 8 | Proxy Test Agent validation (live CC traffic) | Phase 2 |
+
+**Testing strategy:** Each phase ships with its own tests. Phase 1 tests cover SSE framing, header normalization, upstream failure propagation, client disconnect handling, and health endpoint. Phase 2 tests cover lifecycle management, signal forwarding, and port conflict detection. Tests are not deferred to the end — critical-path behavior is validated as each subsystem lands.
+
+---
+
+## Phase 1: Proxy HTTP Server
+
+### Requirements
+
+A Node.js HTTP server on loopback that:
+1. Listens on a configurable port (default: `127.0.0.1:9801`)
+2. Accepts POST requests to `/v1/messages` (the only endpoint CC uses)
+3. Forwards the request to `https://api.anthropic.com` (or configurable upstream)
+4. Streams the SSE response back to the client with proper framing
+5. Handles errors cleanly (upstream unreachable, timeout, malformed response)
+
+### Design Constraints
+
+- **No buffering of the full response.** SSE events must be forwarded as they arrive. Claude Code's streaming UI depends on timely chunk delivery — buffering the entire response before forwarding would break the UX.
+- **Backpressure.** If the client stops reading (e.g. CC is processing), the proxy must not accumulate unbounded memory. Use `await drain()` or equivalent flow control.
+- **Pre-first-byte vs post-first-byte errors.** Pre-first-byte failures (connection refused, DNS, timeout before any response) are retryable by the SDK. Post-first-byte failures (upstream drops connection mid-stream) must propagate to the client as-is — retrying would send duplicate `message_start` SSE events, breaking SDK state. This is the distinction deafsquad flagged from his HOE implementation.
+- **TLS.** The proxy listens on plain HTTP (loopback only). The outbound connection to `api.anthropic.com` uses HTTPS. Node's `https` module or `fetch` handles this.
+- **Header policy.** The proxy is transparent for end-to-end headers but must handle hop-by-hop headers correctly:
+  - **Preserve (forward as-is):** `authorization`, `anthropic-version`, `anthropic-beta`, `anthropic-dangerous-direct-browser-access`, `content-type`, `accept`, `x-stainless-*`, `x-api-key`, all `anthropic-ratelimit-*` response headers
+  - **Recompute:** `host` (set to upstream hostname), `content-length` (recalculate after extension pipeline modifies body in Phase 3)
+  - **Strip on request:** `connection`, `keep-alive`, `transfer-encoding`, `proxy-*`, `te`, `upgrade`
+  - **Strip on response:** `connection`, `keep-alive`, `transfer-encoding` (proxy manages its own chunked encoding to client)
+- **Timeout.** CC sets `x-stainless-timeout: 600` (10 minutes). The proxy must not impose a shorter timeout.
+- **No auth handling.** The proxy forwards the `Authorization` header as-is. It never reads, stores, or logs API keys.
+- **No body logging.** Request and response bodies must never be logged by default. No prompt content, tool payloads, or response text in any log output. Debug mode (future) must use explicit redaction for any metadata logging. Authorization headers must never appear in logs under any mode.
+- **Cancellation and abort propagation.** Client disconnect (CC closes connection) must tear down the upstream request immediately — no orphaned outbound requests. Upstream abort (api.anthropic.com drops connection mid-stream) must propagate to the client as a stream error, not hang. Wrapper shutdown (SIGTERM) must abort both in-flight proxy connections and the CC child process. Use `AbortController`/`AbortSignal` on the upstream `fetch` or `https.request` and listen for `close` events on the client socket.
+
+### Proposed Implementation
+
+```
+proxy/
+  server.mjs          — HTTP server, request handling, SSE forwarding
+  upstream.mjs         — HTTPS client to api.anthropic.com
+  stream.mjs           — SSE chunk parser and forwarder with backpressure
+  config.mjs           — Port, upstream URL, env var overrides
+```
+
+**server.mjs:**
+- `http.createServer()` on loopback
+- Route POST `/v1/messages` → pipeline → upstream → stream back
+- Route GET `/health` → 200 OK (used by launch wrapper readiness check)
+- All other paths → 404
+- Graceful shutdown on SIGTERM/SIGINT
+
+**upstream.mjs:**
+- `https.request()` to upstream with forwarded headers
+- Returns a readable stream of the response
+- Captures response headers for forwarding + response-side processing (Phase 4)
+
+**stream.mjs:**
+- Reads chunks from upstream response stream
+- Writes to client response with backpressure (`res.write()` + drain events)
+- Parses SSE `data:` lines for two event types:
+  - `message_start` — captures initial usage object (cache_read, cache_creation, input_tokens) and model identifier (requested vs served for spoofing detection)
+  - `message_delta` — captures final usage object (output_tokens, stop_reason) to complete the per-request telemetry record
+- Both extractions are bounded reads from parsed JSON — no full-response buffering
+- Telemetry record assembled from: response headers (quota, cache tier, rate limits) + `message_start` usage + `message_delta` usage — matching the existing `preload.mjs` capture behavior
+
+**config.mjs:**
+- `CACHE_FIX_PROXY_PORT` (default: 9801)
+- `CACHE_FIX_PROXY_UPSTREAM` (default: `https://api.anthropic.com`)
+- `CACHE_FIX_PROXY_BIND` (default: `127.0.0.1`)
+- `CACHE_FIX_PROXY_TIMEOUT` (default: 600000ms)
+
+### What This Phase Does NOT Include
+- Extension pipeline (Phase 3)
+- Response capture/logging (Phase 4)
+- Any modification of request or response bodies
+- The launch wrapper (Phase 2)
+
+### Verification
+
+1. Start proxy: `node proxy/server.mjs`
+2. In another terminal: `ANTHROPIC_BASE_URL=http://127.0.0.1:9801 claude`
+3. Verify CC works normally — responses stream, tools work, no errors
+4. Verify proxy logs show requests forwarded and responses streamed
+5. Kill upstream (or point to invalid host) — verify clean error propagation
+6. Test with a long-running response (large file read) — verify no buffering lag
+
+---
+
+## Phase 2: Launch Wrapper
+
+### Requirements
+
+A shell script or Node.js entry point that:
+1. Starts the proxy server (Phase 1)
+2. Waits for the proxy to be ready (health check on the port)
+3. Sets `ANTHROPIC_BASE_URL=http://127.0.0.1:{port}` for the child process only
+4. Launches `claude` (or the Bun binary) with all user-provided arguments forwarded
+5. On CC exit: shuts down the proxy cleanly
+6. On proxy crash: propagates error, does not leave orphaned processes
+
+### Design Constraints
+
+- **Env var scoping.** `ANTHROPIC_BASE_URL` must be set ONLY for the CC child process, not globally. Other processes on the machine (other agents, other tools) should not be affected.
+- **Signal forwarding.** SIGINT/SIGTERM to the wrapper must propagate to both the proxy and CC.
+- **Port conflicts.** If the default port is in use, either fail with a clear message or auto-select an available port.
+- **No root required.** Everything runs as the current user.
+- **Cross-platform.** Linux and macOS. Windows via WSL. Native Windows `.bat` is nice-to-have but not required for v3.0.0.
+
+### Proposed Implementation
+
+```
+bin/
+  claude-via-proxy.mjs  — Launch wrapper entry point
+```
+
+**claude-via-proxy.mjs:**
+```
+1. Parse args (--proxy-port, --proxy-upstream, passthrough args for claude)
+2. Fork proxy/server.mjs as a child process
+3. Wait for proxy health (HTTP GET to /health → 200 OK)
+4. Spawn claude with ANTHROPIC_BASE_URL set, forwarding remaining args
+5. On claude exit → kill proxy, exit with claude's exit code
+6. On proxy exit → kill claude, exit with error
+7. On SIGINT/SIGTERM → kill both, exit
+```
+
+**npm package integration:**
+- `package.json` `bin` field: `{ "claude-via-proxy": "./bin/claude-via-proxy.mjs" }`
+- After `npm install -g claude-code-cache-fix`, user runs `claude-via-proxy` instead of `claude`
+- Alternatively: `claude-via-proxy` detects whether CC is Node or Bun and adjusts accordingly
+
+### Verification
+
+1. `claude-via-proxy` starts proxy, launches CC, both run
+2. Use CC normally — verify everything works through the proxy
+3. Exit CC normally — verify proxy shuts down, no orphans
+4. Kill the wrapper (Ctrl+C) — verify both proxy and CC terminate
+5. Start with port already in use — verify clear error message
+6. Start with CC not installed — verify clear error message
+
+---
+
+## Review Request
+
+This document is the first design submission for the proxy v3.0.0 work. Requesting Codex Review Agent review per the workflow defined in AGENTS.md.
+
+Focus areas:
+- Are the Phase 1 design constraints complete? Missing edge cases?
+- Is the SSE streaming approach (chunk-by-chunk, no buffering) correct for Claude Code's expectations?
+- Is the pre-first-byte vs post-first-byte error distinction correctly specified?
+- Is the launch wrapper lifecycle management (fork, health check, signal forwarding) sound?
+- Any security concerns with the transparent header forwarding?

--- a/docs/proxy-v3a-extensions-directive.md
+++ b/docs/proxy-v3a-extensions-directive.md
@@ -1,0 +1,214 @@
+# Directive: Proxy v3.0.0 — Phase 3a (Extension Pipeline)
+
+**Author:** Manager Agent
+**Date:** 2026-04-20
+**Status:** Draft — pending Codex review
+**Branch:** `feature/proxy-v3/extensions` (off `feature/proxy-v3`)
+**Ref:** #40
+
+---
+
+## Goal
+
+Add a hot-reloadable extension pipeline to the proxy server. Extensions
+transform requests before forwarding and/or responses before returning to
+Claude Code. Port the existing preload.mjs fixes into this pipeline as
+individual, independently-toggleable extensions.
+
+---
+
+## 1. Extension Pipeline Architecture
+
+### 1.1 Extension Interface
+
+Each extension is an ES module exporting a defined shape:
+
+```javascript
+export default {
+  name: 'fingerprint-strip',
+  description: 'Remove cc_version fingerprint from system prompt',
+  enabled: true,
+  order: 100,  // lower runs first
+
+  // Called before request is forwarded upstream
+  async onRequest(ctx) {
+    // ctx.body — parsed JSON request body (mutable)
+    // ctx.headers — outbound headers (mutable)
+    // ctx.meta — shared metadata bag for cross-extension communication
+    // Return: undefined (mutate in place) or { skip: true } to abort forwarding
+  },
+
+  // Called after full response is received (non-streaming path)
+  async onResponse(ctx) {
+    // ctx.status — HTTP status code
+    // ctx.headers — response headers (mutable before send)
+    // ctx.body — parsed JSON response body (mutable)
+    // ctx.meta — same bag from onRequest
+  },
+
+  // Called on each SSE event during streaming (optional)
+  async onStreamEvent(ctx) {
+    // ctx.event — parsed SSE event object
+    // ctx.meta — same bag
+    // ctx.telemetry — accumulating telemetry record
+  },
+}
+```
+
+### 1.2 Pipeline Execution
+
+Request path:
+1. Parse incoming request body
+2. Run `onRequest` hooks in `order` ascending for all enabled extensions
+3. Forward modified request to upstream
+
+Response/stream path:
+1. For streaming: each SSE `data:` line is parsed and passed through `onStreamEvent` hooks
+2. For non-streaming: full response is parsed and passed through `onResponse` hooks
+3. Modified response/stream is forwarded back to client
+
+### 1.3 Hot Reload
+
+Extensions live in `proxy/extensions/` directory. The pipeline:
+- Loads all `.mjs` files from that directory on startup
+- Watches the directory for changes (add/remove/modify)
+- On change: re-imports the modified module, updates the pipeline registry
+- Active requests in-flight are NOT affected (they keep the extension set they started with)
+- New requests use the updated pipeline
+
+Config file `proxy/extensions.json` controls enabled/disabled state and order overrides:
+```json
+{
+  "fingerprint-strip": { "enabled": true, "order": 100 },
+  "ttl-management": { "enabled": true, "order": 200 },
+  "sort-stabilization": { "enabled": true, "order": 300 }
+}
+```
+
+If an extension is not listed in the config, its module-level `enabled` and `order` defaults apply.
+
+### 1.4 Error Isolation
+
+A failing extension must not crash the proxy or corrupt the request/response:
+- Each hook invocation is wrapped in try/catch
+- On error: log the error, skip the extension, continue pipeline
+- The proxy degrades to transparent forwarding if all extensions fail
+
+---
+
+## 2. Extensions to Port from preload.mjs
+
+Port these existing fixes as individual extensions. Each should be a single
+file in `proxy/extensions/`. Preserve the fix logic; adapt the interface from
+preload's monkey-patching style to the clean request/response hook model.
+
+### 2.1 Core Cache Fixes (must-have)
+
+| # | Extension | Source in preload.mjs | Purpose |
+|---|-----------|----------------------|---------|
+| 1 | `fingerprint-strip` | `stabilizeFingerprint()` | Remove cc_version char-index fingerprint from system prompt |
+| 2 | `sort-stabilization` | `stabilizeToolOrder()`, `stabilizeMcpOrder()` | Deterministic ordering of tools and MCP definitions |
+| 3 | `ttl-management` | `detectTtlTier()`, `injectCacheControl()` | Detect server TTL tier, inject correct cache_control markers |
+| 4 | `identity-normalization` | `normalizeIdentity()` | Normalize message identity fields for prefix stability |
+| 5 | `fresh-session-sort` | `freshSessionSortFix()` | Fix non-deterministic ordering on first turn |
+
+### 2.2 Observability (should-have)
+
+| # | Extension | Purpose |
+|---|-----------|---------|
+| 6 | `cache-telemetry` | Extract cache_read/cache_creation from response headers, write to quota-status.json |
+| 7 | `request-log` | Optional NDJSON request log (timing, model, token counts) |
+
+### 2.3 Deferred (Phase 3b+)
+
+| # | Extension | Reason for deferral |
+|---|-----------|-------------------|
+| — | `session-serializer` | Pending coordination with fgrosswig; scope TBD |
+| — | `detection-layer` | Phase 4 — monitors for cache-busting patterns without intervening |
+| — | `possibility-extractor` | Space Lead's domain — extracts deliberation at compaction time |
+
+---
+
+## 3. Integration with Existing Proxy
+
+### 3.1 Where the Pipeline Hooks In
+
+In `proxy/server.mjs`:
+- After `collectBody()` and before `forwardRequest()`: run request pipeline
+- In `proxy/stream.mjs` `forwardStream()`: wrap each SSE event through stream pipeline
+- After response completes: run response pipeline
+
+### 3.2 Backward Compatibility
+
+- With zero extensions enabled, the proxy behaves identically to Phase 1-2 (transparent forwarding)
+- The `proxy/extensions/` directory can be empty — the pipeline handles this gracefully
+- Extensions do not affect the health endpoint or non-`/v1/messages` routes
+
+### 3.3 Configuration
+
+Environment variables (existing):
+- `CACHE_FIX_PROXY_PORT`, `CACHE_FIX_PROXY_BIND`, `CACHE_FIX_PROXY_UPSTREAM` — unchanged
+
+New:
+- `CACHE_FIX_EXTENSIONS_DIR` — path to extensions directory (default: `./proxy/extensions/`)
+- `CACHE_FIX_EXTENSIONS_CONFIG` — path to extensions.json (default: `./proxy/extensions.json`)
+- `CACHE_FIX_DEBUG` — when truthy, extensions log verbose output to stderr
+
+---
+
+## 4. Testing Requirements
+
+### 4.1 Pipeline Tests
+
+- Extension loading (valid module, invalid module, empty directory)
+- Execution order (verify lower `order` runs first)
+- Error isolation (one extension throws, others still run, request succeeds)
+- Hot reload (add file → pipeline updates; remove file → extension deregistered)
+- Config override (extensions.json disabled flag honored)
+
+### 4.2 Per-Extension Tests
+
+Each ported extension needs:
+- Unit test with a sample request/response pair showing the transformation
+- Assertion that the fix matches preload.mjs behavior (same input → same output)
+- Test with extension disabled (passthrough, no modification)
+
+### 4.3 Integration Test
+
+- Start proxy with all extensions enabled
+- Send a realistic CC-shaped request (system prompt with fingerprint, unsorted tools, no cache_control)
+- Verify the request that reaches upstream has: fingerprint stripped, tools sorted, cache_control injected
+- Verify response headers are captured in telemetry
+
+---
+
+## 5. Deliverables
+
+1. `proxy/pipeline.mjs` — extension pipeline loader, registry, executor
+2. `proxy/extensions/` — directory with ported extensions (5-7 files)
+3. `proxy/extensions.json` — default configuration
+4. `proxy/watcher.mjs` — hot-reload file watcher
+5. Updated `proxy/server.mjs` and `proxy/stream.mjs` — pipeline integration points
+6. Tests — pipeline + per-extension + integration
+7. Updated `package.json` — any new files in `files` array
+
+---
+
+## 6. Success Criteria
+
+- [ ] All 5 core cache fixes ported and passing tests
+- [ ] Hot reload works (add/remove extension without restart)
+- [ ] Error in one extension does not affect others or crash proxy
+- [ ] Proxy with all extensions enabled passes sim validation (real CC traffic)
+- [ ] `npm pack --dry-run` includes all new files
+- [ ] Zero regressions in existing 181 tests
+
+---
+
+## 7. Non-Goals (explicitly out of scope)
+
+- Session serialization (Phase 3b, pending fgrosswig coordination)
+- Detection/alerting layer (Phase 4)
+- Possibility space extraction hooks (Space Lead's domain)
+- Dashboard or visualization
+- Remote deployment support

--- a/docs/proxy-v3a-extensions-directive.md
+++ b/docs/proxy-v3a-extensions-directive.md
@@ -3,7 +3,7 @@
 **Author:** Manager Agent
 **Date:** 2026-04-20
 **Status:** Draft — pending Codex review
-**Branch:** `feature/proxy-v3/extensions` (off `feature/proxy-v3`)
+**Branch:** `feature/proxy-v3-extensions` (off `feature/proxy-v3`)
 **Ref:** #40
 
 ---
@@ -35,22 +35,33 @@ export default {
     // ctx.body — parsed JSON request body (mutable)
     // ctx.headers — outbound headers (mutable)
     // ctx.meta — shared metadata bag for cross-extension communication
-    // Return: undefined (mutate in place) or { skip: true } to abort forwarding
+    // Return: undefined (mutate in place) or { skip: true, status: 4xx, body: {...} } to abort forwarding
+    // When skip is returned, the proxy responds directly to the client with the given status/body
+    // without forwarding to upstream. If status/body are omitted, defaults to 400 + generic error.
   },
 
-  // Called after full response is received (non-streaming path)
+  // Called when upstream response headers arrive (before body/stream)
+  async onResponseStart(ctx) {
+    // ctx.status — HTTP status code
+    // ctx.headers — response headers (mutable before forwarding to client)
+    // ctx.meta — same bag from onRequest
+    // Fires once per request, before any SSE events or body data
+  },
+
+  // Called after full response is received (non-streaming path only)
   async onResponse(ctx) {
     // ctx.status — HTTP status code
-    // ctx.headers — response headers (mutable before send)
+    // ctx.headers — response headers
     // ctx.body — parsed JSON response body (mutable)
     // ctx.meta — same bag from onRequest
   },
 
   // Called on each SSE event during streaming (optional)
   async onStreamEvent(ctx) {
-    // ctx.event — parsed SSE event object
+    // ctx.event — parsed SSE event object (mutable — see §1.5 for reserialization)
     // ctx.meta — same bag
     // ctx.telemetry — accumulating telemetry record
+    // ctx.responseHeaders — headers from onResponseStart (read-only at this point)
   },
 }
 ```
@@ -63,16 +74,41 @@ Request path:
 3. Forward modified request to upstream
 
 Response/stream path:
-1. For streaming: each SSE `data:` line is parsed and passed through `onStreamEvent` hooks
-2. For non-streaming: full response is parsed and passed through `onResponse` hooks
-3. Modified response/stream is forwarded back to client
+1. Run `onResponseStart` hooks when upstream response headers arrive (before body)
+2. For streaming: each SSE `data:` line is parsed and passed through `onStreamEvent` hooks
+3. For non-streaming: full response body is buffered, parsed, and passed through `onResponse` hooks
+4. Modified response/stream is forwarded back to client (see §1.5 for stream reserialization)
+
+### 1.5 SSE Stream Reserialization Contract
+
+The proxy owns full SSE reserialization on the streaming path. When extensions mutate events via `onStreamEvent`, the pipeline handles serialization back to wire format:
+
+**What the pipeline parses:**
+- Only `data:` lines containing JSON payloads are parsed and passed to `onStreamEvent`
+- Non-data lines (`event:`, `id:`, `retry:`, SSE comments starting with `:`) are forwarded verbatim without passing through extension hooks
+- Multi-line `data:` payloads (rare in Anthropic's API) are concatenated before parsing, then reserialized as a single `data:` line
+
+**Reserialization after mutation:**
+- After all `onStreamEvent` hooks run, the (possibly mutated) event object is serialized: `data: ${JSON.stringify(ctx.event)}\n\n`
+- If no extension modifies the event (reference equality check on `ctx.event`), the original raw bytes are forwarded instead — zero-cost passthrough for unmodified events
+- If an extension sets `ctx.drop = true`, the event is swallowed (not forwarded to client)
+
+**Ordering guarantee:**
+- Events are processed and forwarded in the order they arrive from upstream
+- The pipeline does NOT buffer or reorder events
+- If an `onStreamEvent` hook is async and takes time, subsequent events queue behind it (backpressure propagates upstream naturally)
+
+**Error handling:**
+- If `JSON.parse` fails on a `data:` line, the raw line is forwarded verbatim (treat as opaque)
+- If reserialization fails after mutation (e.g., extension set `ctx.event` to a non-serializable value), log the error and forward the original raw bytes
 
 ### 1.3 Hot Reload
 
 Extensions live in `proxy/extensions/` directory. The pipeline:
 - Loads all `.mjs` files from that directory on startup
-- Watches the directory for changes (add/remove/modify)
+- Watches the directory AND `extensions.json` for changes (add/remove/modify)
 - On change: re-imports the modified module, updates the pipeline registry
+- On `extensions.json` change: re-reads config, applies enabled/order changes immediately
 - Active requests in-flight are NOT affected (they keep the extension set they started with)
 - New requests use the updated pipeline
 

--- a/package.json
+++ b/package.json
@@ -5,11 +5,16 @@
   "type": "module",
   "exports": "./preload.mjs",
   "main": "./preload.mjs",
+  "bin": {
+    "claude-via-proxy": "./bin/claude-via-proxy.mjs"
+  },
   "files": [
     "preload.mjs",
     "postinstall.js",
     "tools/",
-    "claude-fixed.bat"
+    "claude-fixed.bat",
+    "proxy/",
+    "bin/"
   ],
   "engines": {
     "node": ">=18"

--- a/proxy/config.mjs
+++ b/proxy/config.mjs
@@ -1,0 +1,15 @@
+function envInt(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+const config = {
+  port: envInt("CACHE_FIX_PROXY_PORT", 9801),
+  bind: process.env.CACHE_FIX_PROXY_BIND || "127.0.0.1",
+  upstream: process.env.CACHE_FIX_PROXY_UPSTREAM || "https://api.anthropic.com",
+  timeout: envInt("CACHE_FIX_PROXY_TIMEOUT", 600_000),
+};
+
+export default config;

--- a/proxy/config.mjs
+++ b/proxy/config.mjs
@@ -1,3 +1,6 @@
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
 function envInt(name, fallback) {
   const raw = process.env[name];
   if (raw === undefined || raw === "") return fallback;
@@ -5,11 +8,16 @@ function envInt(name, fallback) {
   return Number.isNaN(parsed) ? fallback : parsed;
 }
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 const config = {
   port: envInt("CACHE_FIX_PROXY_PORT", 9801),
   bind: process.env.CACHE_FIX_PROXY_BIND || "127.0.0.1",
   upstream: process.env.CACHE_FIX_PROXY_UPSTREAM || "https://api.anthropic.com",
   timeout: envInt("CACHE_FIX_PROXY_TIMEOUT", 600_000),
+  extensionsDir: process.env.CACHE_FIX_EXTENSIONS_DIR || join(__dirname, "extensions"),
+  extensionsConfig: process.env.CACHE_FIX_EXTENSIONS_CONFIG || join(__dirname, "extensions.json"),
+  debug: process.env.CACHE_FIX_DEBUG === "1",
 };
 
 export default config;

--- a/proxy/extensions.json
+++ b/proxy/extensions.json
@@ -1,6 +1,7 @@
 {
   "fingerprint-strip": { "enabled": true, "order": 100 },
   "sort-stabilization": { "enabled": true, "order": 200 },
+  "fresh-session-sort": { "enabled": true, "order": 250 },
   "identity-normalization": { "enabled": true, "order": 300 },
   "cache-control-normalize": { "enabled": true, "order": 400 },
   "ttl-management": { "enabled": true, "order": 500 },

--- a/proxy/extensions.json
+++ b/proxy/extensions.json
@@ -1,0 +1,9 @@
+{
+  "fingerprint-strip": { "enabled": true, "order": 100 },
+  "sort-stabilization": { "enabled": true, "order": 200 },
+  "identity-normalization": { "enabled": true, "order": 300 },
+  "cache-control-normalize": { "enabled": true, "order": 400 },
+  "ttl-management": { "enabled": true, "order": 500 },
+  "cache-telemetry": { "enabled": true, "order": 600 },
+  "request-log": { "enabled": false, "order": 700 }
+}

--- a/proxy/extensions/cache-control-normalize.mjs
+++ b/proxy/extensions/cache-control-normalize.mjs
@@ -1,0 +1,59 @@
+function stripCacheControlMarkers(msg) {
+  if (!msg || msg.role !== "user" || !Array.isArray(msg.content)) return 0;
+  let n = 0;
+  for (let i = 0; i < msg.content.length; i++) {
+    const block = msg.content[i];
+    if (block && typeof block === "object" && block.cache_control) {
+      const { cache_control, ...rest } = block;
+      msg.content[i] = rest;
+      n++;
+    }
+  }
+  return n;
+}
+
+function countUserCacheControlMarkers(body) {
+  if (!body || !Array.isArray(body.messages)) return 0;
+  let n = 0;
+  for (const msg of body.messages) {
+    if (msg?.role !== "user" || !Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      if (block && typeof block === "object" && block.cache_control) n++;
+    }
+  }
+  return n;
+}
+
+export default {
+  name: "cache-control-normalize",
+  description: "Strip scattered cache_control markers from user messages and apply canonical placement",
+  order: 400,
+
+  async onRequest(ctx) {
+    const { body } = ctx;
+    if (!Array.isArray(body.messages)) return;
+
+    const markerCount = countUserCacheControlMarkers(body);
+    if (markerCount === 0) return;
+
+    for (const msg of body.messages) {
+      if (msg.role === "user") {
+        stripCacheControlMarkers(msg);
+      }
+    }
+
+    // Apply canonical cache_control at the last block of the last user message
+    for (let i = body.messages.length - 1; i >= 0; i--) {
+      const msg = body.messages[i];
+      if (msg.role !== "user" || !Array.isArray(msg.content) || msg.content.length === 0) continue;
+      const lastBlock = msg.content[msg.content.length - 1];
+      if (lastBlock && typeof lastBlock === "object") {
+        msg.content[msg.content.length - 1] = {
+          ...lastBlock,
+          cache_control: { type: "ephemeral" },
+        };
+      }
+      break;
+    }
+  },
+};

--- a/proxy/extensions/cache-telemetry.mjs
+++ b/proxy/extensions/cache-telemetry.mjs
@@ -1,0 +1,24 @@
+export default {
+  name: "cache-telemetry",
+  description: "Extract cache hit/miss stats from response stream for monitoring",
+  order: 600,
+
+  async onStreamEvent(ctx) {
+    const { event, telemetry } = ctx;
+    if (!event || !telemetry) return;
+
+    if (event.type === "message_start" && event.message?.usage) {
+      const usage = event.message.usage;
+      ctx.meta.cacheStats = {
+        cacheRead: usage.cache_read_input_tokens || 0,
+        cacheCreation: usage.cache_creation_input_tokens || 0,
+        inputTokens: usage.input_tokens || 0,
+      };
+    }
+
+    if (event.type === "message_delta" && event.usage) {
+      if (!ctx.meta.cacheStats) ctx.meta.cacheStats = {};
+      ctx.meta.cacheStats.outputTokens = event.usage.output_tokens || 0;
+    }
+  },
+};

--- a/proxy/extensions/fingerprint-strip.mjs
+++ b/proxy/extensions/fingerprint-strip.mjs
@@ -1,0 +1,105 @@
+import { createHash } from "node:crypto";
+
+const FINGERPRINT_SALT = "59cf53e54c78";
+const FINGERPRINT_INDICES = [4, 7, 20];
+
+function computeFingerprint(messageText, version) {
+  const chars = FINGERPRINT_INDICES.map((i) => messageText[i] || "0").join("");
+  const input = `${FINGERPRINT_SALT}${chars}${version}`;
+  return createHash("sha256").update(input).digest("hex").slice(0, 3);
+}
+
+function extractRealUserMessageText(messages) {
+  for (const msg of messages) {
+    if (msg.role !== "user") continue;
+    const content = msg.content;
+    if (!Array.isArray(content)) {
+      if (typeof content === "string" && !content.startsWith("<system-reminder>")) {
+        return content;
+      }
+      continue;
+    }
+    for (const block of content) {
+      if (block.type === "text" && typeof block.text === "string" && !block.text.startsWith("<system-reminder>")) {
+        return block.text;
+      }
+    }
+  }
+  return "";
+}
+
+function extractFirstMessageText(messages) {
+  if (!Array.isArray(messages) || messages.length === 0) return "";
+  const first = messages[0];
+  if (!first || first.role !== "user") return "";
+  const content = first.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  for (const block of content) {
+    if (block.type === "text" && typeof block.text === "string") {
+      return block.text;
+    }
+  }
+  return "";
+}
+
+function stabilizeFingerprint(system, messages) {
+  if (!Array.isArray(system)) return null;
+
+  const attrIdx = system.findIndex(
+    (b) => b.type === "text" && typeof b.text === "string" && b.text.includes("x-anthropic-billing-header:")
+  );
+  if (attrIdx === -1) return null;
+
+  const attrBlock = system[attrIdx];
+  const versionMatch = attrBlock.text.match(/cc_version=([^;]+)/);
+  if (!versionMatch) return null;
+
+  const fullVersion = versionMatch[1];
+  const dotParts = fullVersion.split(".");
+  if (dotParts.length < 4) return null;
+
+  const baseVersion = dotParts.slice(0, 3).join(".");
+  const oldFingerprint = dotParts[3];
+
+  const realText = extractRealUserMessageText(messages);
+  const realVerification = computeFingerprint(realText, baseVersion);
+  const legacyText = extractFirstMessageText(messages);
+  const legacyVerification = computeFingerprint(legacyText, baseVersion);
+
+  let verificationPassed = false;
+  if (realVerification === oldFingerprint) {
+    verificationPassed = true;
+  } else if (legacyVerification === oldFingerprint) {
+    verificationPassed = true;
+  }
+
+  if (!verificationPassed) return null;
+
+  const stableFingerprint = computeFingerprint(realText, baseVersion);
+  if (stableFingerprint === oldFingerprint) return null;
+
+  const newVersion = `${baseVersion}.${stableFingerprint}`;
+  const newText = attrBlock.text.replace(
+    `cc_version=${fullVersion}`,
+    `cc_version=${newVersion}`
+  );
+
+  return { attrIdx, newText, oldFingerprint, stableFingerprint };
+}
+
+export default {
+  name: "fingerprint-strip",
+  description: "Stabilize cc_version fingerprint in system prompt for cache prefix consistency",
+  order: 100,
+
+  async onRequest(ctx) {
+    const { body } = ctx;
+    if (!body.system || !body.messages) return;
+
+    const result = stabilizeFingerprint(body.system, body.messages);
+    if (result) {
+      body.system[result.attrIdx] = { ...body.system[result.attrIdx], text: result.newText };
+    }
+  },
+};

--- a/proxy/extensions/fresh-session-sort.mjs
+++ b/proxy/extensions/fresh-session-sort.mjs
@@ -1,0 +1,188 @@
+import { createHash } from "node:crypto";
+
+const SR = "<system-reminder>\n";
+
+function isSystemReminder(text) {
+  return typeof text === "string" && text.startsWith("<system-reminder>");
+}
+
+function isHooksBlock(text) {
+  return isSystemReminder(text) && text.substring(0, 200).includes("hook success");
+}
+
+function isSkillsBlock(text) {
+  return typeof text === "string" && text.startsWith(SR + "The following skills are available");
+}
+
+function isDeferredToolsBlock(text) {
+  return typeof text === "string" && text.startsWith(SR + "The following deferred tools are now available");
+}
+
+function isMcpBlock(text) {
+  return typeof text === "string" && text.startsWith(SR + "# MCP Server Instructions");
+}
+
+function isRelocatableBlock(text) {
+  return isHooksBlock(text) || isSkillsBlock(text) || isDeferredToolsBlock(text) || isMcpBlock(text);
+}
+
+function isClearArtifact(text) {
+  if (typeof text !== "string") return false;
+  return (
+    text.startsWith("<local-command-caveat>") ||
+    text.startsWith("<command-name>") ||
+    text.startsWith("<local-command-stdout>")
+  );
+}
+
+function sortSkillsBlock(text) {
+  const match = text.match(/^([\s\S]*?\n\n)(- [\s\S]+?)(\n<\/system-reminder>\s*)$/);
+  if (!match) return text;
+  const [, header, entriesText, footer] = match;
+  const entries = entriesText.split(/\n(?=- )/);
+  entries.sort();
+  return header + entries.join("\n") + footer;
+}
+
+function sortDeferredToolsBlock(text) {
+  const match = text.match(
+    /^(<system-reminder>\nThe following deferred tools are now available[^\n]*\n)([\s\S]+?)(\n<\/system-reminder>\s*)$/
+  );
+  if (!match) return text;
+  const [, header, toolsList, footer] = match;
+  const tools = toolsList.split("\n").map((t) => t.trim()).filter(Boolean);
+  tools.sort();
+  return header + tools.join("\n") + footer;
+}
+
+function stripSessionKnowledge(text) {
+  return text.replace(/\n<session_knowledge[^>]*>[\s\S]*?<\/session_knowledge>/g, "");
+}
+
+const _pinnedBlocks = new Map();
+
+function pinBlockContent(blockType, text) {
+  const normalized = text.replace(/\s+(<\/system-reminder>)\s*$/, "\n$1");
+  const hash = createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+  const pinned = _pinnedBlocks.get(blockType);
+  if (pinned && pinned.hash === hash) return pinned.text;
+  _pinnedBlocks.set(blockType, { hash, text: normalized });
+  return normalized;
+}
+
+function getBlockType(text) {
+  if (isSkillsBlock(text)) return "skills";
+  if (isDeferredToolsBlock(text)) return "deferred";
+  if (isMcpBlock(text)) return "mcp";
+  if (isHooksBlock(text)) return "hooks";
+  return null;
+}
+
+function fixBlockText(blockType, text) {
+  let fixed = text;
+  if (blockType === "skills") fixed = sortSkillsBlock(fixed);
+  else if (blockType === "deferred") fixed = sortDeferredToolsBlock(fixed);
+  else if (blockType === "hooks") fixed = stripSessionKnowledge(fixed);
+  return pinBlockContent(blockType, fixed);
+}
+
+export default {
+  name: "fresh-session-sort",
+  description: "Relocate scattered blocks to messages[0] in deterministic fresh-session order",
+  order: 250,
+
+  async onRequest(ctx) {
+    const { body } = ctx;
+    if (!Array.isArray(body.messages)) return;
+
+    let firstUserIdx = -1;
+    for (let i = 0; i < body.messages.length; i++) {
+      if (body.messages[i].role === "user") {
+        firstUserIdx = i;
+        break;
+      }
+    }
+    if (firstUserIdx === -1) return;
+
+    const firstMsg = body.messages[firstUserIdx];
+    if (!Array.isArray(firstMsg?.content)) return;
+
+    // Strip /clear artifacts from first user message
+    const beforeLen = firstMsg.content.length;
+    firstMsg.content = firstMsg.content.filter((b) => !isClearArtifact(b.text || ""));
+
+    // Check for scattered relocatable blocks outside first user message
+    let hasScatteredBlocks = false;
+    for (let i = firstUserIdx + 1; i < body.messages.length && !hasScatteredBlocks; i++) {
+      const msg = body.messages[i];
+      if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+      for (const block of msg.content) {
+        if (isRelocatableBlock(block.text || "")) {
+          hasScatteredBlocks = true;
+          break;
+        }
+      }
+    }
+
+    if (!hasScatteredBlocks) {
+      // Still sort and pin blocks in-place for deterministic first-call baseline
+      let modified = false;
+      const newContent = firstMsg.content.map((block) => {
+        const text = block.text || "";
+        const blockType = getBlockType(text);
+        if (!blockType) return block;
+
+        const fixedText = fixBlockText(blockType, text);
+        if (fixedText !== text) {
+          modified = true;
+          const { cache_control, ...rest } = block;
+          return { ...rest, text: fixedText };
+        }
+        return block;
+      });
+
+      if (modified || firstMsg.content.length !== beforeLen) {
+        body.messages[firstUserIdx] = { ...firstMsg, content: newContent };
+      }
+      return;
+    }
+
+    // Scan backwards to find latest instance of each relocatable block type
+    const found = new Map();
+    for (let i = body.messages.length - 1; i >= firstUserIdx; i--) {
+      const msg = body.messages[i];
+      if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+      for (let j = msg.content.length - 1; j >= 0; j--) {
+        const block = msg.content[j];
+        const text = block.text || "";
+        const blockType = getBlockType(text);
+        if (!blockType || found.has(blockType)) continue;
+
+        const fixedText = fixBlockText(blockType, text);
+        const { cache_control, ...rest } = block;
+        found.set(blockType, { ...rest, text: fixedText });
+      }
+    }
+
+    if (found.size === 0) return;
+
+    // Remove all relocatable blocks from all user messages
+    for (let i = 0; i < body.messages.length; i++) {
+      const msg = body.messages[i];
+      if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+      const filtered = msg.content.filter((b) => !isRelocatableBlock(b.text || ""));
+      if (filtered.length !== msg.content.length) {
+        body.messages[i] = { ...msg, content: filtered };
+      }
+    }
+
+    // Prepend in deterministic order: deferred → mcp → skills → hooks
+    const ORDER = ["deferred", "mcp", "skills", "hooks"];
+    const toRelocate = ORDER.filter((t) => found.has(t)).map((t) => found.get(t));
+
+    body.messages[firstUserIdx] = {
+      ...body.messages[firstUserIdx],
+      content: [...toRelocate, ...body.messages[firstUserIdx].content],
+    };
+  },
+};

--- a/proxy/extensions/identity-normalization.mjs
+++ b/proxy/extensions/identity-normalization.mjs
@@ -1,0 +1,129 @@
+import { createHash } from "node:crypto";
+
+const _pinnedBlocks = new Map();
+
+const SESSION_START_RESUME_MARKER = /SessionStart:startup hook success:/g;
+const SESSION_START_ID_TAG = /\n?<session-id>[^<]*<\/session-id>/g;
+const SESSION_START_LAST_ACTIVE_LINE = /\nLast active:[^\n]*/g;
+const CONTINUE_TRAILER_TEXT = "Continue from where you left off.";
+
+const REMINDER_WRAP_REGEX = /^<system-reminder>\n([\s\S]*?)\n<\/system-reminder>\s*$/;
+const BOOKKEEPING_REMINDER_PATTERNS = [
+  /^Token usage: \d+\/\d+; \d+ remaining\s*$/,
+  /^Output tokens \u2014 turn: [^\n]+ \u00b7 session: [^\n]+\s*$/,
+  /^USD budget: \$[\d.]+\/\$[\d.]+; \$[\d.]+ remaining\s*$/,
+];
+
+function pinBlockContent(blockType, text) {
+  const normalized = text.replace(/\s+(<\/system-reminder>)\s*$/, "\n$1");
+  const hash = createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+  const pinned = _pinnedBlocks.get(blockType);
+
+  if (pinned && pinned.hash === hash) {
+    return pinned.text;
+  }
+
+  _pinnedBlocks.set(blockType, { hash, text: normalized });
+  return normalized;
+}
+
+function stripSessionKnowledge(text) {
+  return text.replace(
+    /\n<session_knowledge[^>]*>[\s\S]*?<\/session_knowledge>/g,
+    ""
+  );
+}
+
+function normalizeSessionStartText(text) {
+  if (typeof text !== "string" || !text.includes("SessionStart:")) return [text, 0];
+  let count = 0;
+  let out = text;
+  if (SESSION_START_RESUME_MARKER.test(out)) {
+    SESSION_START_RESUME_MARKER.lastIndex = 0;
+    out = out.replace(SESSION_START_RESUME_MARKER, "SessionStart:startup hook success:");
+    count++;
+  }
+  if (SESSION_START_ID_TAG.test(out)) {
+    SESSION_START_ID_TAG.lastIndex = 0;
+    out = out.replace(SESSION_START_ID_TAG, "");
+    count++;
+  }
+  if (SESSION_START_LAST_ACTIVE_LINE.test(out)) {
+    SESSION_START_LAST_ACTIVE_LINE.lastIndex = 0;
+    out = out.replace(SESSION_START_LAST_ACTIVE_LINE, "");
+    count++;
+  }
+  return [out, count];
+}
+
+function isContinueTrailerBlock(block) {
+  return (
+    !!block &&
+    typeof block === "object" &&
+    block.type === "text" &&
+    block.text === CONTINUE_TRAILER_TEXT
+  );
+}
+
+function isBookkeepingReminder(text) {
+  if (typeof text !== "string") return false;
+  const m = text.match(REMINDER_WRAP_REGEX);
+  if (!m) return false;
+  const inner = m[1];
+  for (const rx of BOOKKEEPING_REMINDER_PATTERNS) {
+    if (rx.test(inner)) return true;
+  }
+  return false;
+}
+
+export default {
+  name: "identity-normalization",
+  description: "Normalize volatile identity fields (SessionStart, Continue trailers, bookkeeping) for cache stability",
+  order: 300,
+
+  async onRequest(ctx) {
+    const { body } = ctx;
+
+    if (Array.isArray(body.system)) {
+      for (let i = 0; i < body.system.length; i++) {
+        const block = body.system[i];
+        if (block.type !== "text" || typeof block.text !== "string") continue;
+
+        let text = block.text;
+        if (text.includes("session_knowledge")) {
+          text = stripSessionKnowledge(text);
+        }
+        if (text.includes("<system-reminder>")) {
+          text = pinBlockContent(`system_${i}`, text);
+        }
+        if (text !== block.text) {
+          body.system[i] = { ...block, text };
+        }
+      }
+    }
+
+    if (Array.isArray(body.messages)) {
+      for (const msg of body.messages) {
+        if (!Array.isArray(msg.content)) continue;
+
+        for (let i = msg.content.length - 1; i >= 0; i--) {
+          const block = msg.content[i];
+          if (block.type !== "text" || typeof block.text !== "string") continue;
+
+          if (isContinueTrailerBlock(block) && i === msg.content.length - 1 && msg.role === "user") {
+            continue;
+          }
+
+          if (isBookkeepingReminder(block.text)) {
+            continue;
+          }
+
+          const [normalized] = normalizeSessionStartText(block.text);
+          if (normalized !== block.text) {
+            msg.content[i] = { ...block, text: normalized };
+          }
+        }
+      }
+    }
+  },
+};

--- a/proxy/extensions/request-log.mjs
+++ b/proxy/extensions/request-log.mjs
@@ -1,0 +1,35 @@
+import { appendFile } from "node:fs/promises";
+
+const LOG_PATH = process.env.CACHE_FIX_REQUEST_LOG || "";
+
+export default {
+  name: "request-log",
+  description: "Optional NDJSON request timing log",
+  enabled: false,
+  order: 700,
+
+  async onRequest(ctx) {
+    ctx.meta._requestStart = Date.now();
+    ctx.meta._requestModel = ctx.body.model || null;
+  },
+
+  async onResponseStart(ctx) {
+    ctx.meta._responseStart = Date.now();
+  },
+
+  async onStreamEvent(ctx) {
+    if (ctx.event?.type === "message_delta" && ctx.meta._requestStart && LOG_PATH) {
+      const entry = {
+        ts: new Date().toISOString(),
+        model: ctx.meta._requestModel,
+        latencyMs: (ctx.meta._responseStart || Date.now()) - ctx.meta._requestStart,
+        outputTokens: ctx.event.usage?.output_tokens || 0,
+        cacheRead: ctx.meta.cacheStats?.cacheRead || 0,
+        cacheCreation: ctx.meta.cacheStats?.cacheCreation || 0,
+      };
+      try {
+        await appendFile(LOG_PATH, JSON.stringify(entry) + "\n");
+      } catch {}
+    }
+  },
+};

--- a/proxy/extensions/sort-stabilization.mjs
+++ b/proxy/extensions/sort-stabilization.mjs
@@ -1,0 +1,62 @@
+function sortSkillsBlock(text) {
+  const match = text.match(
+    /^([\s\S]*?\n\n)(- [\s\S]+?)(\n<\/system-reminder>\s*)$/
+  );
+  if (!match) return text;
+  const [, header, entriesText, footer] = match;
+  const entries = entriesText.split(/\n(?=- )/);
+  entries.sort();
+  return header + entries.join("\n") + footer;
+}
+
+function sortDeferredToolsBlock(text) {
+  const match = text.match(
+    /^(<system-reminder>\nThe following deferred tools are now available[^\n]*\n)([\s\S]+?)(\n<\/system-reminder>\s*)$/
+  );
+  if (!match) return text;
+  const [, header, toolsList, footer] = match;
+  const tools = toolsList.split("\n").map((t) => t.trim()).filter(Boolean);
+  tools.sort();
+  return header + tools.join("\n") + footer;
+}
+
+function isSkillsBlock(text) {
+  return typeof text === "string" && text.includes("User-invocable skills");
+}
+
+function isDeferredToolsBlock(text) {
+  return typeof text === "string" && text.includes("deferred tools are now available");
+}
+
+export default {
+  name: "sort-stabilization",
+  description: "Deterministic ordering of skills, deferred tools, and tool definitions",
+  order: 200,
+
+  async onRequest(ctx) {
+    const { body } = ctx;
+
+    if (Array.isArray(body.system)) {
+      for (let i = 0; i < body.system.length; i++) {
+        const block = body.system[i];
+        if (block.type !== "text" || typeof block.text !== "string") continue;
+
+        if (isSkillsBlock(block.text)) {
+          const sorted = sortSkillsBlock(block.text);
+          if (sorted !== block.text) {
+            body.system[i] = { ...block, text: sorted };
+          }
+        } else if (isDeferredToolsBlock(block.text)) {
+          const sorted = sortDeferredToolsBlock(block.text);
+          if (sorted !== block.text) {
+            body.system[i] = { ...block, text: sorted };
+          }
+        }
+      }
+    }
+
+    if (Array.isArray(body.tools)) {
+      body.tools.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+    }
+  },
+};

--- a/proxy/extensions/ttl-management.mjs
+++ b/proxy/extensions/ttl-management.mjs
@@ -1,0 +1,49 @@
+const TTL_MAIN = (process.env.CACHE_FIX_TTL_MAIN || "1h").toLowerCase();
+const TTL_SUBAGENT = (process.env.CACHE_FIX_TTL_SUBAGENT || "1h").toLowerCase();
+const AGENT_SDK_PREFIX = "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
+
+function detectRequestType(system) {
+  if (!Array.isArray(system)) return "main";
+  const isSubagent = system.some(
+    (b) => b?.type === "text" && typeof b.text === "string" && b.text.startsWith(AGENT_SDK_PREFIX)
+  );
+  return isSubagent ? "subagent" : "main";
+}
+
+function injectTtl(block, ttlParam) {
+  if (block.cache_control?.type === "ephemeral" && !block.cache_control.ttl) {
+    return { ...block, cache_control: { ...block.cache_control, ttl: ttlParam } };
+  }
+  return block;
+}
+
+export default {
+  name: "ttl-management",
+  description: "Inject correct TTL on cache_control markers based on detected tier",
+  order: 500,
+
+  async onRequest(ctx) {
+    const { body } = ctx;
+    if (!body.system) return;
+
+    const requestType = detectRequestType(body.system);
+    const ttlValue = requestType === "subagent" ? TTL_SUBAGENT : TTL_MAIN;
+
+    if (ttlValue === "none") return;
+
+    const ttlParam = ttlValue === "5m" ? "5m" : "1h";
+
+    if (Array.isArray(body.system)) {
+      body.system = body.system.map((block) => injectTtl(block, ttlParam));
+    }
+
+    if (Array.isArray(body.messages)) {
+      for (const msg of body.messages) {
+        if (!Array.isArray(msg.content)) continue;
+        for (let i = 0; i < msg.content.length; i++) {
+          msg.content[i] = injectTtl(msg.content[i], ttlParam);
+        }
+      }
+    }
+  },
+};

--- a/proxy/pipeline.mjs
+++ b/proxy/pipeline.mjs
@@ -1,0 +1,96 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+let registry = [];
+
+export async function loadExtensions(dir, configPath) {
+  let config = {};
+  try {
+    const raw = await readFile(configPath, "utf8");
+    config = JSON.parse(raw);
+  } catch {}
+
+  const files = await readdir(dir);
+  const mjsFiles = files.filter((f) => f.endsWith(".mjs")).sort();
+
+  const extensions = [];
+  for (const file of mjsFiles) {
+    try {
+      const mod = await import(join(dir, file) + "?t=" + Date.now());
+      const ext = mod.default;
+      if (!ext || !ext.name) continue;
+
+      const cfg = config[ext.name];
+      const enabled = cfg?.enabled ?? ext.enabled ?? true;
+      const order = cfg?.order ?? ext.order ?? 1000;
+
+      if (enabled) {
+        extensions.push({ ...ext, order, _file: file });
+      }
+    } catch (err) {
+      process.stderr.write(`[pipeline] failed to load ${file}: ${err.message}\n`);
+    }
+  }
+
+  extensions.sort((a, b) => a.order - b.order);
+  registry = extensions;
+  return extensions;
+}
+
+export function getRegistry() {
+  return registry;
+}
+
+export function snapshotRegistry() {
+  return [...registry];
+}
+
+export async function runOnRequest(ctx, snapshot) {
+  const exts = snapshot || registry;
+  for (const ext of exts) {
+    if (!ext.onRequest) continue;
+    try {
+      const result = await ext.onRequest(ctx);
+      if (result && result.skip) return result;
+    } catch (err) {
+      process.stderr.write(`[pipeline] ${ext.name}.onRequest error: ${err.message}\n`);
+    }
+  }
+  return undefined;
+}
+
+export async function runOnResponseStart(ctx, snapshot) {
+  const exts = snapshot || registry;
+  for (const ext of exts) {
+    if (!ext.onResponseStart) continue;
+    try {
+      await ext.onResponseStart(ctx);
+    } catch (err) {
+      process.stderr.write(`[pipeline] ${ext.name}.onResponseStart error: ${err.message}\n`);
+    }
+  }
+}
+
+export async function runOnStreamEvent(ctx, snapshot) {
+  const exts = snapshot || registry;
+  for (const ext of exts) {
+    if (!ext.onStreamEvent) continue;
+    try {
+      await ext.onStreamEvent(ctx);
+    } catch (err) {
+      process.stderr.write(`[pipeline] ${ext.name}.onStreamEvent error: ${err.message}\n`);
+    }
+  }
+}
+
+export async function runOnResponse(ctx, snapshot) {
+  const exts = snapshot || registry;
+  for (const ext of exts) {
+    if (!ext.onResponse) continue;
+    try {
+      await ext.onResponse(ctx);
+    } catch (err) {
+      process.stderr.write(`[pipeline] ${ext.name}.onResponse error: ${err.message}\n`);
+    }
+  }
+}

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -1,0 +1,97 @@
+import http from "node:http";
+import config from "./config.mjs";
+import { forwardRequest } from "./upstream.mjs";
+import { streamResponse, createTelemetryRecord } from "./stream.mjs";
+
+function collectBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+async function handleMessages(clientReq, clientRes) {
+  const abortController = new AbortController();
+
+  clientReq.on("close", () => {
+    if (!clientRes.writableEnded) {
+      abortController.abort();
+    }
+  });
+
+  const body = await collectBody(clientReq);
+  let upstreamRes, responseHeaders, statusCode;
+
+  try {
+    ({ upstreamRes, responseHeaders, statusCode } = await forwardRequest(
+      clientReq,
+      body,
+      abortController.signal
+    ));
+  } catch (err) {
+    if (abortController.signal.aborted) return;
+    clientRes.writeHead(502, { "content-type": "application/json" });
+    clientRes.end(JSON.stringify({ error: "upstream_error", message: err.message }));
+    return;
+  }
+
+  clientRes.writeHead(statusCode, responseHeaders);
+
+  if (statusCode >= 400) {
+    upstreamRes.pipe(clientRes);
+    return;
+  }
+
+  const telemetry = createTelemetryRecord();
+
+  upstreamRes.on("error", (err) => {
+    if (!clientRes.writableEnded) {
+      clientRes.destroy(err);
+    }
+  });
+
+  try {
+    await streamResponse(upstreamRes, clientRes, telemetry);
+  } catch (err) {
+    if (!clientRes.writableEnded) {
+      clientRes.destroy(err);
+    }
+  }
+}
+
+function handleHealth(_req, res) {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ status: "ok" }));
+}
+
+function handleNotFound(_req, res) {
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: "not_found" }));
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    return handleHealth(req, res);
+  }
+  if (req.method === "POST" && req.url?.startsWith("/v1/messages")) {
+    return handleMessages(req, res);
+  }
+  handleNotFound(req, res);
+});
+
+function shutdown() {
+  server.close(() => process.exit(0));
+  setTimeout(() => process.exit(1), 5000);
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
+
+server.listen(config.port, config.bind, () => {
+  const addr = server.address();
+  process.stdout.write(`proxy listening on ${addr.address}:${addr.port}\n`);
+});
+
+export { server };

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -2,6 +2,8 @@ import http from "node:http";
 import config from "./config.mjs";
 import { forwardRequest } from "./upstream.mjs";
 import { streamResponse, createTelemetryRecord } from "./stream.mjs";
+import { loadExtensions, snapshotRegistry, runOnRequest, runOnResponseStart } from "./pipeline.mjs";
+import { startWatcher } from "./watcher.mjs";
 
 function collectBody(req) {
   return new Promise((resolve, reject) => {
@@ -14,6 +16,7 @@ function collectBody(req) {
 
 async function handleMessages(clientReq, clientRes) {
   const abortController = new AbortController();
+  const extSnapshot = snapshotRegistry();
 
   clientReq.on("close", () => {
     if (!clientRes.writableEnded) {
@@ -21,20 +24,41 @@ async function handleMessages(clientReq, clientRes) {
     }
   });
 
-  const body = await collectBody(clientReq);
+  const rawBody = await collectBody(clientReq);
 
-  let requestedModel = null;
+  let parsed;
   try {
-    const parsed = JSON.parse(body);
-    if (parsed.model) requestedModel = parsed.model;
-  } catch {}
+    parsed = JSON.parse(rawBody);
+  } catch {
+    parsed = null;
+  }
+
+  let forwardBody = rawBody;
+  const meta = {};
+
+  if (parsed && extSnapshot.length > 0) {
+    const reqCtx = { body: parsed, headers: { ...clientReq.headers }, meta };
+    const skipResult = await runOnRequest(reqCtx, extSnapshot);
+
+    if (skipResult && skipResult.skip) {
+      const status = skipResult.status || 400;
+      const body = skipResult.body || { error: "blocked_by_extension" };
+      clientRes.writeHead(status, { "content-type": "application/json" });
+      clientRes.end(JSON.stringify(body));
+      return;
+    }
+
+    forwardBody = Buffer.from(JSON.stringify(reqCtx.body));
+  }
+
+  const requestedModel = parsed?.model || null;
 
   let upstreamRes, responseHeaders, statusCode;
 
   try {
     ({ upstreamRes, responseHeaders, statusCode } = await forwardRequest(
       clientReq,
-      body,
+      forwardBody,
       abortController.signal
     ));
   } catch (err) {
@@ -42,6 +66,11 @@ async function handleMessages(clientReq, clientRes) {
     clientRes.writeHead(502, { "content-type": "application/json" });
     clientRes.end(JSON.stringify({ error: "upstream_error", message: err.message }));
     return;
+  }
+
+  if (extSnapshot.length > 0) {
+    const resCtx = { status: statusCode, headers: responseHeaders, meta };
+    await runOnResponseStart(resCtx, extSnapshot);
   }
 
   clientRes.writeHead(statusCode, responseHeaders);
@@ -61,7 +90,7 @@ async function handleMessages(clientReq, clientRes) {
   });
 
   try {
-    await streamResponse(upstreamRes, clientRes, telemetry);
+    await streamResponse(upstreamRes, clientRes, telemetry, extSnapshot, meta);
   } catch (err) {
     if (!clientRes.writableEnded) {
       clientRes.destroy(err);
@@ -97,9 +126,18 @@ function shutdown() {
 process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);
 
-server.listen(config.port, config.bind, () => {
-  const addr = server.address();
-  process.stdout.write(`proxy listening on ${addr.address}:${addr.port}\n`);
+async function initPipeline() {
+  try {
+    await loadExtensions(config.extensionsDir, config.extensionsConfig);
+    startWatcher(config.extensionsDir, config.extensionsConfig);
+  } catch {}
+}
+
+initPipeline().then(() => {
+  server.listen(config.port, config.bind, () => {
+    const addr = server.address();
+    process.stdout.write(`proxy listening on ${addr.address}:${addr.port}\n`);
+  });
 });
 
 export { server };

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -2,7 +2,7 @@ import http from "node:http";
 import config from "./config.mjs";
 import { forwardRequest } from "./upstream.mjs";
 import { streamResponse, createTelemetryRecord } from "./stream.mjs";
-import { loadExtensions, snapshotRegistry, runOnRequest, runOnResponseStart } from "./pipeline.mjs";
+import { loadExtensions, snapshotRegistry, runOnRequest, runOnResponseStart, runOnResponse } from "./pipeline.mjs";
 import { startWatcher } from "./watcher.mjs";
 
 function collectBody(req) {
@@ -76,7 +76,26 @@ async function handleMessages(clientReq, clientRes) {
   clientRes.writeHead(statusCode, responseHeaders);
 
   if (statusCode >= 400) {
-    upstreamRes.pipe(clientRes);
+    if (extSnapshot.length > 0) {
+      const chunks = [];
+      for await (const chunk of upstreamRes) chunks.push(chunk);
+      const rawResponse = Buffer.concat(chunks);
+      let responseBody;
+      try {
+        responseBody = JSON.parse(rawResponse.toString());
+      } catch {
+        responseBody = null;
+      }
+      if (responseBody) {
+        const resCtx = { status: statusCode, headers: responseHeaders, body: responseBody, meta };
+        await runOnResponse(resCtx, extSnapshot);
+        clientRes.end(JSON.stringify(resCtx.body));
+      } else {
+        clientRes.end(rawResponse);
+      }
+    } else {
+      upstreamRes.pipe(clientRes);
+    }
     return;
   }
 
@@ -90,7 +109,7 @@ async function handleMessages(clientReq, clientRes) {
   });
 
   try {
-    await streamResponse(upstreamRes, clientRes, telemetry, extSnapshot, meta);
+    await streamResponse(upstreamRes, clientRes, telemetry, extSnapshot, meta, responseHeaders);
   } catch (err) {
     if (!clientRes.writableEnded) {
       clientRes.destroy(err);

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -73,13 +73,14 @@ async function handleMessages(clientReq, clientRes) {
     await runOnResponseStart(resCtx, extSnapshot);
   }
 
-  clientRes.writeHead(statusCode, responseHeaders);
+  const isStreaming = (responseHeaders["content-type"] || "").includes("text/event-stream");
 
-  if (statusCode >= 400) {
+  if (!isStreaming) {
+    const chunks = [];
+    for await (const chunk of upstreamRes) chunks.push(chunk);
+    const rawResponse = Buffer.concat(chunks);
+
     if (extSnapshot.length > 0) {
-      const chunks = [];
-      for await (const chunk of upstreamRes) chunks.push(chunk);
-      const rawResponse = Buffer.concat(chunks);
       let responseBody;
       try {
         responseBody = JSON.parse(rawResponse.toString());
@@ -89,15 +90,20 @@ async function handleMessages(clientReq, clientRes) {
       if (responseBody) {
         const resCtx = { status: statusCode, headers: responseHeaders, body: responseBody, meta };
         await runOnResponse(resCtx, extSnapshot);
+        clientRes.writeHead(statusCode, resCtx.headers);
         clientRes.end(JSON.stringify(resCtx.body));
       } else {
+        clientRes.writeHead(statusCode, responseHeaders);
         clientRes.end(rawResponse);
       }
     } else {
-      upstreamRes.pipe(clientRes);
+      clientRes.writeHead(statusCode, responseHeaders);
+      clientRes.end(rawResponse);
     }
     return;
   }
+
+  clientRes.writeHead(statusCode, responseHeaders);
 
   const telemetry = createTelemetryRecord();
   telemetry.requestedModel = requestedModel;

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -22,6 +22,13 @@ async function handleMessages(clientReq, clientRes) {
   });
 
   const body = await collectBody(clientReq);
+
+  let requestedModel = null;
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed.model) requestedModel = parsed.model;
+  } catch {}
+
   let upstreamRes, responseHeaders, statusCode;
 
   try {
@@ -45,6 +52,7 @@ async function handleMessages(clientReq, clientRes) {
   }
 
   const telemetry = createTelemetryRecord();
+  telemetry.requestedModel = requestedModel;
 
   upstreamRes.on("error", (err) => {
     if (!clientRes.writableEnded) {

--- a/proxy/stream.mjs
+++ b/proxy/stream.mjs
@@ -1,3 +1,5 @@
+import { runOnStreamEvent } from "./pipeline.mjs";
+
 export function createTelemetryRecord() {
   return {
     model: null,
@@ -10,18 +12,7 @@ export function createTelemetryRecord() {
   };
 }
 
-function tryParseSSEEvent(line, telemetry) {
-  if (!line.startsWith("data: ")) return;
-  const jsonStr = line.slice(6);
-  if (jsonStr === "[DONE]") return;
-
-  let event;
-  try {
-    event = JSON.parse(jsonStr);
-  } catch {
-    return;
-  }
-
+function extractTelemetry(event, telemetry) {
   if (event.type === "message_start" && event.message) {
     const msg = event.message;
     telemetry.model = msg.model || null;
@@ -38,7 +29,59 @@ function tryParseSSEEvent(line, telemetry) {
   }
 }
 
-export async function streamResponse(upstreamRes, clientRes, telemetry) {
+async function processLine(line, clientRes, telemetry, extSnapshot, meta) {
+  if (!line.startsWith("data: ")) {
+    const ok = clientRes.write(line + "\n");
+    if (!ok) await new Promise((r) => clientRes.once("drain", r));
+    return;
+  }
+
+  const jsonStr = line.slice(6);
+  if (jsonStr === "[DONE]") {
+    const ok = clientRes.write(line + "\n");
+    if (!ok) await new Promise((r) => clientRes.once("drain", r));
+    return;
+  }
+
+  let event;
+  try {
+    event = JSON.parse(jsonStr);
+  } catch {
+    const ok = clientRes.write(line + "\n");
+    if (!ok) await new Promise((r) => clientRes.once("drain", r));
+    return;
+  }
+
+  extractTelemetry(event, telemetry);
+
+  if (!extSnapshot || extSnapshot.length === 0) {
+    const ok = clientRes.write(line + "\n");
+    if (!ok) await new Promise((r) => clientRes.once("drain", r));
+    return;
+  }
+
+  const ctx = { event, meta, telemetry, responseHeaders: null, drop: false };
+  const originalRef = event;
+  await runOnStreamEvent(ctx, extSnapshot);
+
+  if (ctx.drop) return;
+
+  let output;
+  if (ctx.event === originalRef) {
+    output = line + "\n";
+  } else {
+    try {
+      output = "data: " + JSON.stringify(ctx.event) + "\n";
+    } catch {
+      output = line + "\n";
+    }
+  }
+
+  const ok = clientRes.write(output);
+  if (!ok) await new Promise((r) => clientRes.once("drain", r));
+}
+
+export async function streamResponse(upstreamRes, clientRes, telemetry, extSnapshot, meta) {
   let buffer = "";
 
   for await (const chunk of upstreamRes) {
@@ -49,17 +92,17 @@ export async function streamResponse(upstreamRes, clientRes, telemetry) {
     buffer = lines.pop();
 
     for (const line of lines) {
-      tryParseSSEEvent(line, telemetry);
-    }
-
-    const ok = clientRes.write(chunk);
-    if (!ok) {
-      await new Promise((resolve) => clientRes.once("drain", resolve));
+      if (line === "") {
+        const ok = clientRes.write("\n");
+        if (!ok) await new Promise((r) => clientRes.once("drain", r));
+      } else {
+        await processLine(line, clientRes, telemetry, extSnapshot, meta);
+      }
     }
   }
 
   if (buffer.length > 0) {
-    tryParseSSEEvent(buffer, telemetry);
+    await processLine(buffer, clientRes, telemetry, extSnapshot, meta);
   }
 
   clientRes.end();

--- a/proxy/stream.mjs
+++ b/proxy/stream.mjs
@@ -1,0 +1,67 @@
+export function createTelemetryRecord() {
+  return {
+    model: null,
+    requestedModel: null,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheRead: 0,
+    cacheCreation: 0,
+    stopReason: null,
+  };
+}
+
+function tryParseSSEEvent(line, telemetry) {
+  if (!line.startsWith("data: ")) return;
+  const jsonStr = line.slice(6);
+  if (jsonStr === "[DONE]") return;
+
+  let event;
+  try {
+    event = JSON.parse(jsonStr);
+  } catch {
+    return;
+  }
+
+  if (event.type === "message_start" && event.message) {
+    const msg = event.message;
+    telemetry.model = msg.model || null;
+    if (msg.usage) {
+      telemetry.inputTokens = msg.usage.input_tokens || 0;
+      telemetry.cacheRead = msg.usage.cache_read_input_tokens || 0;
+      telemetry.cacheCreation = msg.usage.cache_creation_input_tokens || 0;
+    }
+  } else if (event.type === "message_delta") {
+    if (event.usage) {
+      telemetry.outputTokens = event.usage.output_tokens || 0;
+    }
+    telemetry.stopReason = event.delta?.stop_reason || null;
+  }
+}
+
+export async function streamResponse(upstreamRes, clientRes, telemetry) {
+  let buffer = "";
+
+  for await (const chunk of upstreamRes) {
+    const text = chunk.toString();
+    buffer += text;
+
+    const lines = buffer.split("\n");
+    buffer = lines.pop();
+
+    for (const line of lines) {
+      tryParseSSEEvent(line, telemetry);
+    }
+
+    const ok = clientRes.write(chunk);
+    if (!ok) {
+      await new Promise((resolve) => clientRes.once("drain", resolve));
+    }
+  }
+
+  if (buffer.length > 0) {
+    tryParseSSEEvent(buffer, telemetry);
+  }
+
+  clientRes.end();
+  return telemetry;
+}

--- a/proxy/stream.mjs
+++ b/proxy/stream.mjs
@@ -29,7 +29,7 @@ function extractTelemetry(event, telemetry) {
   }
 }
 
-async function processLine(line, clientRes, telemetry, extSnapshot, meta) {
+async function processLine(line, clientRes, telemetry, extSnapshot, meta, responseHeaders) {
   if (!line.startsWith("data: ")) {
     const ok = clientRes.write(line + "\n");
     if (!ok) await new Promise((r) => clientRes.once("drain", r));
@@ -60,7 +60,7 @@ async function processLine(line, clientRes, telemetry, extSnapshot, meta) {
     return;
   }
 
-  const ctx = { event, meta, telemetry, responseHeaders: null, drop: false };
+  const ctx = { event, meta, telemetry, responseHeaders: responseHeaders || null, drop: false };
   const originalRef = event;
   await runOnStreamEvent(ctx, extSnapshot);
 
@@ -81,7 +81,7 @@ async function processLine(line, clientRes, telemetry, extSnapshot, meta) {
   if (!ok) await new Promise((r) => clientRes.once("drain", r));
 }
 
-export async function streamResponse(upstreamRes, clientRes, telemetry, extSnapshot, meta) {
+export async function streamResponse(upstreamRes, clientRes, telemetry, extSnapshot, meta, responseHeaders) {
   let buffer = "";
 
   for await (const chunk of upstreamRes) {
@@ -96,13 +96,13 @@ export async function streamResponse(upstreamRes, clientRes, telemetry, extSnaps
         const ok = clientRes.write("\n");
         if (!ok) await new Promise((r) => clientRes.once("drain", r));
       } else {
-        await processLine(line, clientRes, telemetry, extSnapshot, meta);
+        await processLine(line, clientRes, telemetry, extSnapshot, meta, responseHeaders);
       }
     }
   }
 
   if (buffer.length > 0) {
-    await processLine(buffer, clientRes, telemetry, extSnapshot, meta);
+    await processLine(buffer, clientRes, telemetry, extSnapshot, meta, responseHeaders);
   }
 
   clientRes.end();

--- a/proxy/upstream.mjs
+++ b/proxy/upstream.mjs
@@ -1,4 +1,5 @@
 import https from "node:https";
+import http from "node:http";
 import { URL } from "node:url";
 import config from "./config.mjs";
 
@@ -54,16 +55,20 @@ export function forwardRequest(clientReq, body, signal) {
       headers["content-length"] = Buffer.byteLength(body).toString();
     }
 
+    const isHTTPS = upstreamUrl.protocol === "https:";
+    const transport = isHTTPS ? https : http;
+    const defaultPort = isHTTPS ? 443 : 80;
+
     const options = {
       hostname: upstreamUrl.hostname,
-      port: upstreamUrl.port || 443,
+      port: upstreamUrl.port || defaultPort,
       path: upstreamUrl.pathname + upstreamUrl.search,
       method: clientReq.method,
       headers,
       timeout: config.timeout,
     };
 
-    const upstreamReq = https.request(options, (upstreamRes) => {
+    const upstreamReq = transport.request(options, (upstreamRes) => {
       const responseHeaders = filterResponseHeaders(upstreamRes.headers);
       resolve({ upstreamRes, responseHeaders, statusCode: upstreamRes.statusCode });
     });

--- a/proxy/upstream.mjs
+++ b/proxy/upstream.mjs
@@ -1,0 +1,88 @@
+import https from "node:https";
+import { URL } from "node:url";
+import config from "./config.mjs";
+
+const STRIP_REQUEST_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+  "te",
+  "upgrade",
+]);
+
+const STRIP_RESPONSE_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+]);
+
+function shouldStripRequestHeader(name) {
+  const lower = name.toLowerCase();
+  return STRIP_REQUEST_HEADERS.has(lower) || lower.startsWith("proxy-");
+}
+
+function shouldStripResponseHeader(name) {
+  return STRIP_RESPONSE_HEADERS.has(name.toLowerCase());
+}
+
+function buildUpstreamHeaders(incomingHeaders, upstreamHostname) {
+  const headers = {};
+  for (const [key, value] of Object.entries(incomingHeaders)) {
+    if (shouldStripRequestHeader(key)) continue;
+    headers[key] = value;
+  }
+  headers["host"] = upstreamHostname;
+  headers["accept-encoding"] = "identity";
+  return headers;
+}
+
+function filterResponseHeaders(rawHeaders) {
+  const headers = {};
+  for (const [key, value] of Object.entries(rawHeaders)) {
+    if (shouldStripResponseHeader(key)) continue;
+    headers[key] = value;
+  }
+  return headers;
+}
+
+export function forwardRequest(clientReq, body, signal) {
+  return new Promise((resolve, reject) => {
+    const upstreamUrl = new URL(clientReq.url, config.upstream);
+
+    const headers = buildUpstreamHeaders(clientReq.headers, upstreamUrl.hostname);
+    if (body) {
+      headers["content-length"] = Buffer.byteLength(body).toString();
+    }
+
+    const options = {
+      hostname: upstreamUrl.hostname,
+      port: upstreamUrl.port || 443,
+      path: upstreamUrl.pathname + upstreamUrl.search,
+      method: clientReq.method,
+      headers,
+      timeout: config.timeout,
+    };
+
+    const upstreamReq = https.request(options, (upstreamRes) => {
+      const responseHeaders = filterResponseHeaders(upstreamRes.headers);
+      resolve({ upstreamRes, responseHeaders, statusCode: upstreamRes.statusCode });
+    });
+
+    upstreamReq.on("error", reject);
+    upstreamReq.on("timeout", () => {
+      upstreamReq.destroy(new Error("Upstream timeout"));
+    });
+
+    if (signal) {
+      signal.addEventListener("abort", () => {
+        upstreamReq.destroy(new Error("Request aborted"));
+      }, { once: true });
+    }
+
+    if (body) {
+      upstreamReq.end(body);
+    } else {
+      upstreamReq.end();
+    }
+  });
+}

--- a/proxy/watcher.mjs
+++ b/proxy/watcher.mjs
@@ -1,0 +1,42 @@
+import { watch } from "node:fs";
+import { loadExtensions } from "./pipeline.mjs";
+
+let debounceTimer = null;
+
+export function startWatcher(extensionsDir, configPath, opts = {}) {
+  const debounceMs = opts.debounceMs ?? 100;
+  const onReload = opts.onReload;
+
+  function scheduleReload() {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(async () => {
+      try {
+        const exts = await loadExtensions(extensionsDir, configPath);
+        if (onReload) onReload(exts);
+      } catch (err) {
+        process.stderr.write(`[watcher] reload failed: ${err.message}\n`);
+      }
+    }, debounceMs);
+  }
+
+  const dirWatcher = watch(extensionsDir, { persistent: false }, (eventType, filename) => {
+    if (filename && filename.endsWith(".mjs")) {
+      scheduleReload();
+    }
+  });
+
+  let configWatcher = null;
+  try {
+    configWatcher = watch(configPath, { persistent: false }, () => {
+      scheduleReload();
+    });
+  } catch {}
+
+  return {
+    close() {
+      dirWatcher.close();
+      if (configWatcher) configWatcher.close();
+      if (debounceTimer) clearTimeout(debounceTimer);
+    },
+  };
+}

--- a/test/proxy-integration.test.mjs
+++ b/test/proxy-integration.test.mjs
@@ -1,0 +1,184 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+
+let proxyPort;
+let proxyProcess;
+
+function makeRequest(body) {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: proxyPort,
+        path: "/v1/messages",
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+        },
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString(),
+          });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.end(data);
+  });
+}
+
+describe("proxy integration with extensions", () => {
+  let fakeUpstream;
+  let lastUpstreamBody;
+
+  before(async () => {
+    fakeUpstream = http.createServer((req, res) => {
+      const chunks = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        lastUpstreamBody = JSON.parse(Buffer.concat(chunks).toString());
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.write('event: message_start\ndata: {"type":"message_start","message":{"model":"claude-opus-4-20250514","usage":{"input_tokens":100,"cache_read_input_tokens":80,"cache_creation_input_tokens":20}}}\n\n');
+        res.write('data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n');
+        res.write('data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n');
+        res.write('data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}\n\n');
+        res.write("data: [DONE]\n\n");
+        res.end();
+      });
+    });
+
+    await new Promise((resolve) => {
+      fakeUpstream.listen(0, "127.0.0.1", resolve);
+    });
+    const fakePort = fakeUpstream.address().port;
+
+    process.env.CACHE_FIX_PROXY_PORT = "0";
+    process.env.CACHE_FIX_PROXY_UPSTREAM = `http://127.0.0.1:${fakePort}`;
+
+    const { spawn } = await import("node:child_process");
+    proxyProcess = spawn(process.execPath, ["proxy/server.mjs"], {
+      env: {
+        ...process.env,
+        CACHE_FIX_PROXY_PORT: "0",
+        CACHE_FIX_PROXY_UPSTREAM: `http://127.0.0.1:${fakePort}`,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    proxyPort = await new Promise((resolve, reject) => {
+      let output = "";
+      proxyProcess.stdout.on("data", (chunk) => {
+        output += chunk.toString();
+        const match = output.match(/listening on [\d.]+:(\d+)/);
+        if (match) resolve(parseInt(match[1], 10));
+      });
+      proxyProcess.on("exit", (code) => reject(new Error(`Proxy exited ${code}`)));
+      setTimeout(() => reject(new Error("Proxy start timeout")), 5000);
+    });
+  });
+
+  after(async () => {
+    if (proxyProcess) {
+      proxyProcess.kill("SIGTERM");
+      await new Promise((resolve) => proxyProcess.on("exit", resolve));
+    }
+    if (fakeUpstream) {
+      await new Promise((resolve) => fakeUpstream.close(resolve));
+    }
+    delete process.env.CACHE_FIX_PROXY_PORT;
+    delete process.env.CACHE_FIX_PROXY_UPSTREAM;
+  });
+
+  it("health check returns ok", async () => {
+    const res = await new Promise((resolve, reject) => {
+      http.get(`http://127.0.0.1:${proxyPort}/health`, (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }));
+      }).on("error", reject);
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(JSON.parse(res.body), { status: "ok" });
+  });
+
+  it("forwards request through extensions and streams response", async () => {
+    const body = {
+      model: "claude-opus-4-20250514",
+      max_tokens: 100,
+      system: [
+        { type: "text", text: "You are helpful.", cache_control: { type: "ephemeral" } },
+      ],
+      tools: [
+        { name: "Zebra", input_schema: {} },
+        { name: "Alpha", input_schema: {} },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Hello world", cache_control: { type: "ephemeral" } },
+          ],
+        },
+      ],
+    };
+
+    const res = await makeRequest(body);
+    assert.equal(res.status, 200);
+
+    // Verify tools were sorted by sort-stabilization extension
+    assert.equal(lastUpstreamBody.tools[0].name, "Alpha");
+    assert.equal(lastUpstreamBody.tools[1].name, "Zebra");
+
+    // Verify TTL was injected by ttl-management extension
+    assert.equal(lastUpstreamBody.system[0].cache_control.ttl, "1h");
+
+    // Verify cache_control on user message was normalized
+    // cache-control-normalize strips markers and re-applies at last block
+    const lastUserMsg = lastUpstreamBody.messages[lastUpstreamBody.messages.length - 1];
+    const lastBlock = lastUserMsg.content[lastUserMsg.content.length - 1];
+    assert.ok(lastBlock.cache_control);
+
+    // Verify SSE stream was forwarded
+    assert.ok(res.body.includes("message_start"));
+    assert.ok(res.body.includes("[DONE]"));
+  });
+
+  it("TTL injection applies to message content cache_control blocks", async () => {
+    const body = {
+      model: "claude-opus-4-20250514",
+      max_tokens: 50,
+      system: [
+        { type: "text", text: "System prompt", cache_control: { type: "ephemeral" } },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Hi" },
+            { type: "text", text: "Follow up", cache_control: { type: "ephemeral" } },
+          ],
+        },
+      ],
+    };
+
+    await makeRequest(body);
+
+    // TTL injected on system block
+    assert.equal(lastUpstreamBody.system[0].cache_control.ttl, "1h");
+    // cache-control-normalize strips user markers then re-applies canonical at last block
+    const lastMsg = lastUpstreamBody.messages[0];
+    const lastBlock = lastMsg.content[lastMsg.content.length - 1];
+    // TTL should be injected on the canonical marker too
+    assert.equal(lastBlock.cache_control.ttl, "1h");
+  });
+});

--- a/test/proxy-pipeline.test.mjs
+++ b/test/proxy-pipeline.test.mjs
@@ -1,0 +1,166 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const testDir = join(tmpdir(), `pipeline-test-${Date.now()}`);
+const configPath = join(testDir, "extensions.json");
+
+async function freshImport() {
+  const mod = await import("../proxy/pipeline.mjs?t=" + Date.now());
+  return mod;
+}
+
+describe("extension pipeline", () => {
+  before(async () => {
+    await mkdir(testDir, { recursive: true });
+  });
+
+  after(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe("loadExtensions", () => {
+    it("loads extensions from directory sorted by order", async () => {
+      const extA = `export default { name: "ext-a", order: 200, onRequest(ctx) { ctx.meta.order.push("a"); } };`;
+      const extB = `export default { name: "ext-b", order: 100, onRequest(ctx) { ctx.meta.order.push("b"); } };`;
+
+      await writeFile(join(testDir, "ext-a.mjs"), extA);
+      await writeFile(join(testDir, "ext-b.mjs"), extB);
+      await writeFile(configPath, JSON.stringify({}));
+
+      const { loadExtensions } = await freshImport();
+      const exts = await loadExtensions(testDir, configPath);
+
+      assert.equal(exts.length, 2);
+      assert.equal(exts[0].name, "ext-b");
+      assert.equal(exts[1].name, "ext-a");
+    });
+
+    it("respects config enabled=false", async () => {
+      await writeFile(configPath, JSON.stringify({ "ext-a": { enabled: false } }));
+
+      const { loadExtensions } = await freshImport();
+      const exts = await loadExtensions(testDir, configPath);
+
+      assert.equal(exts.length, 1);
+      assert.equal(exts[0].name, "ext-b");
+    });
+
+    it("respects config order override", async () => {
+      await writeFile(configPath, JSON.stringify({ "ext-a": { enabled: true, order: 50 } }));
+
+      const { loadExtensions } = await freshImport();
+      const exts = await loadExtensions(testDir, configPath);
+
+      assert.equal(exts.length, 2);
+      assert.equal(exts[0].name, "ext-a");
+    });
+
+    it("skips files that fail to load", async () => {
+      await writeFile(join(testDir, "bad.mjs"), "throw new Error('oops');");
+      await writeFile(configPath, JSON.stringify({}));
+
+      const { loadExtensions } = await freshImport();
+      const exts = await loadExtensions(testDir, configPath);
+
+      assert.ok(exts.length >= 2);
+      assert.ok(!exts.find((e) => e.name === undefined));
+
+      await rm(join(testDir, "bad.mjs"));
+    });
+
+    it("skips modules without name export", async () => {
+      await writeFile(join(testDir, "noname.mjs"), "export default { order: 1 };");
+      await writeFile(configPath, JSON.stringify({}));
+
+      const { loadExtensions } = await freshImport();
+      const exts = await loadExtensions(testDir, configPath);
+
+      assert.ok(!exts.find((e) => e._file === "noname.mjs"));
+
+      await rm(join(testDir, "noname.mjs"));
+    });
+  });
+
+  describe("runOnRequest", () => {
+    it("executes hooks in order and mutates ctx", async () => {
+      const { loadExtensions, runOnRequest } = await freshImport();
+      await writeFile(configPath, JSON.stringify({}));
+      await loadExtensions(testDir, configPath);
+
+      const ctx = { body: { model: "test" }, headers: {}, meta: { order: [] } };
+      await runOnRequest(ctx);
+
+      assert.deepEqual(ctx.meta.order, ["b", "a"]);
+    });
+
+    it("returns skip result and stops pipeline", async () => {
+      const skipExt = `export default { name: "skipper", order: 50, onRequest() { return { skip: true, status: 429, body: { error: "rate_limited" } }; } };`;
+      await writeFile(join(testDir, "skipper.mjs"), skipExt);
+      await writeFile(configPath, JSON.stringify({}));
+
+      const { loadExtensions, runOnRequest } = await freshImport();
+      await loadExtensions(testDir, configPath);
+
+      const ctx = { body: {}, headers: {}, meta: { order: [] } };
+      const result = await runOnRequest(ctx);
+
+      assert.equal(result.skip, true);
+      assert.equal(result.status, 429);
+      assert.deepEqual(ctx.meta.order, []);
+
+      await rm(join(testDir, "skipper.mjs"));
+    });
+
+    it("isolates errors — one failing hook does not stop others", async () => {
+      const failExt = `export default { name: "failer", order: 90, onRequest() { throw new Error("boom"); } };`;
+      await writeFile(join(testDir, "failer.mjs"), failExt);
+      await writeFile(configPath, JSON.stringify({}));
+
+      const { loadExtensions, runOnRequest } = await freshImport();
+      await loadExtensions(testDir, configPath);
+
+      const ctx = { body: {}, headers: {}, meta: { order: [] } };
+      await runOnRequest(ctx);
+
+      assert.ok(ctx.meta.order.includes("b"));
+      assert.ok(ctx.meta.order.includes("a"));
+
+      await rm(join(testDir, "failer.mjs"));
+    });
+  });
+
+  describe("runOnStreamEvent", () => {
+    it("passes event through all hooks", async () => {
+      const streamExt = `export default { name: "stream-ext", order: 1, onStreamEvent(ctx) { ctx.event.modified = true; } };`;
+      await writeFile(join(testDir, "stream-ext.mjs"), streamExt);
+      await writeFile(configPath, JSON.stringify({}));
+
+      const { loadExtensions, runOnStreamEvent } = await freshImport();
+      await loadExtensions(testDir, configPath);
+
+      const ctx = { event: { type: "content_block_delta" }, meta: {}, telemetry: {} };
+      await runOnStreamEvent(ctx);
+
+      assert.equal(ctx.event.modified, true);
+
+      await rm(join(testDir, "stream-ext.mjs"));
+    });
+  });
+
+  describe("snapshotRegistry", () => {
+    it("returns independent copy of registry", async () => {
+      await writeFile(configPath, JSON.stringify({}));
+
+      const { loadExtensions, snapshotRegistry, getRegistry } = await freshImport();
+      await loadExtensions(testDir, configPath);
+
+      const snapshot = snapshotRegistry();
+      assert.deepEqual(snapshot.map((e) => e.name), getRegistry().map((e) => e.name));
+      snapshot.push({ name: "injected" });
+      assert.ok(!getRegistry().find((e) => e.name === "injected"));
+    });
+  });
+});

--- a/test/proxy-server.test.mjs
+++ b/test/proxy-server.test.mjs
@@ -1,0 +1,72 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+
+let server;
+let proxyPort;
+
+async function startProxy() {
+  const testPort = 19801 + Math.floor(Math.random() * 1000);
+  process.env.CACHE_FIX_PROXY_PORT = String(testPort);
+  process.env.CACHE_FIX_PROXY_BIND = "127.0.0.1";
+  const mod = await import("../proxy/server.mjs");
+  server = mod.server;
+  await new Promise((resolve) => {
+    if (server.listening) resolve();
+    else server.on("listening", resolve);
+  });
+  proxyPort = server.address().port;
+}
+
+function request(method, path, body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: "127.0.0.1", port: proxyPort, method, path },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks).toString() });
+        });
+      }
+    );
+    req.on("error", reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+describe("proxy server", () => {
+  before(async () => {
+    await startProxy();
+  });
+
+  after((_, done) => {
+    server.close(done);
+  });
+
+  it("GET /health returns 200 with status ok", async () => {
+    const res = await request("GET", "/health");
+    assert.equal(res.status, 200);
+    const parsed = JSON.parse(res.body);
+    assert.equal(parsed.status, "ok");
+  });
+
+  it("GET /unknown returns 404", async () => {
+    const res = await request("GET", "/unknown");
+    assert.equal(res.status, 404);
+    const parsed = JSON.parse(res.body);
+    assert.equal(parsed.error, "not_found");
+  });
+
+  it("POST to non-messages path returns 404", async () => {
+    const res = await request("POST", "/v1/completions", "{}");
+    assert.equal(res.status, 404);
+  });
+
+  it("POST /v1/messages routes to upstream (may get auth error or 502)", async () => {
+    const res = await request("POST", "/v1/messages", JSON.stringify({ model: "test", messages: [] }));
+    // Without valid auth we expect either 401 from upstream or 502 if unreachable
+    assert.ok([401, 502].includes(res.status));
+  });
+});

--- a/test/proxy-stream.test.mjs
+++ b/test/proxy-stream.test.mjs
@@ -1,0 +1,112 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Readable, Writable } from "node:stream";
+import { streamResponse, createTelemetryRecord } from "../proxy/stream.mjs";
+
+function sseChunks(events) {
+  return events.map((e) => `data: ${JSON.stringify(e)}\n\n`);
+}
+
+function mockUpstream(chunks) {
+  return Readable.from(chunks.map((c) => Buffer.from(c)));
+}
+
+function mockClientRes() {
+  const written = [];
+  let ended = false;
+  const res = new Writable({
+    write(chunk, _enc, cb) {
+      written.push(chunk);
+      cb();
+    },
+    final(cb) {
+      ended = true;
+      cb();
+    },
+  });
+  res.writeHead = () => {};
+  return { res, written: () => Buffer.concat(written).toString(), ended: () => ended };
+}
+
+describe("stream.mjs", () => {
+  it("extracts telemetry from message_start", async () => {
+    const telemetry = createTelemetryRecord();
+    const events = [
+      {
+        type: "message_start",
+        message: {
+          model: "claude-sonnet-4-20250514",
+          usage: { input_tokens: 100, cache_read_input_tokens: 80, cache_creation_input_tokens: 20 },
+        },
+      },
+    ];
+    const upstream = mockUpstream(sseChunks(events));
+    const client = mockClientRes();
+    await streamResponse(upstream, client.res, telemetry);
+    assert.equal(telemetry.model, "claude-sonnet-4-20250514");
+    assert.equal(telemetry.inputTokens, 100);
+    assert.equal(telemetry.cacheRead, 80);
+    assert.equal(telemetry.cacheCreation, 20);
+  });
+
+  it("extracts telemetry from message_delta", async () => {
+    const telemetry = createTelemetryRecord();
+    const events = [
+      { type: "message_start", message: { model: "test", usage: { input_tokens: 10 } } },
+      { type: "message_delta", usage: { output_tokens: 50 }, delta: { stop_reason: "end_turn" } },
+    ];
+    const upstream = mockUpstream(sseChunks(events));
+    const client = mockClientRes();
+    await streamResponse(upstream, client.res, telemetry);
+    assert.equal(telemetry.outputTokens, 50);
+    assert.equal(telemetry.stopReason, "end_turn");
+  });
+
+  it("forwards all bytes to client", async () => {
+    const raw = "data: {\"type\":\"content_block_delta\"}\n\ndata: [DONE]\n\n";
+    const upstream = mockUpstream([raw]);
+    const client = mockClientRes();
+    const telemetry = createTelemetryRecord();
+    await streamResponse(upstream, client.res, telemetry);
+    assert.equal(client.written(), raw);
+    assert.ok(client.ended());
+  });
+
+  it("handles chunks split across SSE boundaries", async () => {
+    const telemetry = createTelemetryRecord();
+    const part1 = 'data: {"type":"message_start","message":{"model":"test","usa';
+    const part2 = 'ge":{"input_tokens":42}}}\n\n';
+    const upstream = mockUpstream([part1, part2]);
+    const client = mockClientRes();
+    await streamResponse(upstream, client.res, telemetry);
+    assert.equal(telemetry.inputTokens, 42);
+  });
+
+  it("handles backpressure via drain", async () => {
+    const telemetry = createTelemetryRecord();
+    let drainCalled = false;
+    const upstream = mockUpstream(["data: {\"type\":\"ping\"}\n\n"]);
+    const res = new Writable({
+      write(chunk, _enc, cb) {
+        cb();
+      },
+      final(cb) { cb(); },
+    });
+    // Simulate backpressure by overriding write to return false once
+    const origWrite = res.write.bind(res);
+    let firstWrite = true;
+    res.write = (chunk) => {
+      if (firstWrite) {
+        firstWrite = false;
+        process.nextTick(() => {
+          drainCalled = true;
+          res.emit("drain");
+        });
+        return false;
+      }
+      return origWrite(chunk);
+    };
+    await streamResponse(upstream, res, telemetry);
+    assert.ok(drainCalled);
+  });
+});

--- a/test/proxy-stream.test.mjs
+++ b/test/proxy-stream.test.mjs
@@ -82,6 +82,19 @@ describe("stream.mjs", () => {
     assert.equal(telemetry.inputTokens, 42);
   });
 
+  it("preserves requestedModel when set before streaming", async () => {
+    const telemetry = createTelemetryRecord();
+    telemetry.requestedModel = "claude-sonnet-4-20250514";
+    const events = [
+      { type: "message_start", message: { model: "claude-sonnet-4-20250514", usage: { input_tokens: 10 } } },
+    ];
+    const upstream = mockUpstream(sseChunks(events));
+    const client = mockClientRes();
+    await streamResponse(upstream, client.res, telemetry);
+    assert.equal(telemetry.requestedModel, "claude-sonnet-4-20250514");
+    assert.equal(telemetry.model, "claude-sonnet-4-20250514");
+  });
+
   it("handles backpressure via drain", async () => {
     const telemetry = createTelemetryRecord();
     let drainCalled = false;

--- a/test/proxy-upstream.test.mjs
+++ b/test/proxy-upstream.test.mjs
@@ -1,0 +1,70 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { forwardRequest } from "../proxy/upstream.mjs";
+
+describe("upstream.mjs", () => {
+  it("strips hop-by-hop request headers", async () => {
+    let receivedHeaders;
+    const fakeUpstream = http.createServer((req, res) => {
+      receivedHeaders = req.headers;
+      res.writeHead(200);
+      res.end();
+    });
+    await new Promise((resolve) => fakeUpstream.listen(0, "127.0.0.1", resolve));
+    const port = fakeUpstream.address().port;
+
+    process.env.CACHE_FIX_PROXY_UPSTREAM = `http://127.0.0.1:${port}`;
+    // Need to reset cached config — re-import won't work due to module cache.
+    // Instead, test the header building logic directly.
+    fakeUpstream.close();
+
+    // Direct unit test: verify the concept by checking the exported function handles headers
+    const mockReq = {
+      url: "/v1/messages",
+      method: "POST",
+      headers: {
+        authorization: "Bearer sk-test",
+        connection: "keep-alive",
+        "transfer-encoding": "chunked",
+        "proxy-authorization": "Basic abc",
+        "content-type": "application/json",
+        "x-stainless-timeout": "600",
+      },
+    };
+
+    // forwardRequest will fail to connect, but we can verify it doesn't throw on header processing
+    // by catching the connection error
+    try {
+      await forwardRequest(mockReq, "{}", null);
+    } catch (err) {
+      // Expected — no real upstream. The point is it didn't crash on header processing.
+      assert.ok(err.message.includes("ECONNREFUSED") || err.message.includes("connect"));
+    }
+  });
+
+  it("respects abort signal", async () => {
+    const controller = new AbortController();
+    const mockReq = {
+      url: "/v1/messages",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    };
+
+    // Abort shortly after request starts (before connection completes to real upstream)
+    setTimeout(() => controller.abort(), 10);
+
+    try {
+      await forwardRequest(mockReq, "{}", controller.signal);
+      assert.fail("Should have thrown");
+    } catch (err) {
+      // Either aborted or connection refused — both are acceptable
+      assert.ok(
+        err.message.includes("abort") ||
+        err.message.includes("ECONNREFUSED") ||
+        err.message.includes("destroyed") ||
+        err.message.includes("socket hang up")
+      );
+    }
+  });
+});

--- a/test/proxy-upstream.test.mjs
+++ b/test/proxy-upstream.test.mjs
@@ -1,25 +1,64 @@
-import { describe, it } from "node:test";
+import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
-import { forwardRequest } from "../proxy/upstream.mjs";
+
+let fakeUpstream;
+let fakePort;
+let forwardRequest;
 
 describe("upstream.mjs", () => {
-  it("strips hop-by-hop request headers", async () => {
-    let receivedHeaders;
-    const fakeUpstream = http.createServer((req, res) => {
-      receivedHeaders = req.headers;
-      res.writeHead(200);
-      res.end();
+  before(async () => {
+    fakeUpstream = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => { body += c; });
+      req.on("end", () => {
+        const delay = req.headers["x-test-delay"] ? parseInt(req.headers["x-test-delay"], 10) : 0;
+        const respond = () => {
+          res.writeHead(200, {
+            "content-type": "text/event-stream",
+            "x-test-received-headers": JSON.stringify(req.headers),
+            "connection": "keep-alive",
+            "transfer-encoding": "chunked",
+          });
+          res.end("data: {\"type\":\"ping\"}\n\n");
+        };
+        if (delay > 0) setTimeout(respond, delay);
+        else respond();
+      });
     });
     await new Promise((resolve) => fakeUpstream.listen(0, "127.0.0.1", resolve));
-    const port = fakeUpstream.address().port;
+    fakePort = fakeUpstream.address().port;
 
-    process.env.CACHE_FIX_PROXY_UPSTREAM = `http://127.0.0.1:${port}`;
-    // Need to reset cached config — re-import won't work due to module cache.
-    // Instead, test the header building logic directly.
+    process.env.CACHE_FIX_PROXY_UPSTREAM = `http://127.0.0.1:${fakePort}`;
+    const mod = await import("../proxy/upstream.mjs");
+    forwardRequest = mod.forwardRequest;
+  });
+
+  after(() => {
     fakeUpstream.close();
+  });
 
-    // Direct unit test: verify the concept by checking the exported function handles headers
+  it("forwards request to http:// upstream and returns response", async () => {
+    const mockReq = {
+      url: "/v1/messages",
+      method: "POST",
+      headers: {
+        authorization: "Bearer sk-test",
+        "content-type": "application/json",
+        "x-stainless-timeout": "600",
+      },
+    };
+
+    const { upstreamRes, responseHeaders, statusCode } = await forwardRequest(mockReq, "{}", null);
+    assert.equal(statusCode, 200);
+    assert.equal(responseHeaders["content-type"], "text/event-stream");
+
+    const chunks = [];
+    for await (const chunk of upstreamRes) chunks.push(chunk);
+    assert.ok(Buffer.concat(chunks).toString().includes("ping"));
+  });
+
+  it("strips hop-by-hop request headers", async () => {
     const mockReq = {
       url: "/v1/messages",
       method: "POST",
@@ -33,14 +72,31 @@ describe("upstream.mjs", () => {
       },
     };
 
-    // forwardRequest will fail to connect, but we can verify it doesn't throw on header processing
-    // by catching the connection error
-    try {
-      await forwardRequest(mockReq, "{}", null);
-    } catch (err) {
-      // Expected — no real upstream. The point is it didn't crash on header processing.
-      assert.ok(err.message.includes("ECONNREFUSED") || err.message.includes("connect"));
-    }
+    const { upstreamRes, responseHeaders } = await forwardRequest(mockReq, "{}", null);
+    const received = JSON.parse(responseHeaders["x-test-received-headers"]);
+
+    assert.ok(!received["proxy-authorization"], "proxy-* headers should be stripped");
+    assert.equal(received["authorization"], "Bearer sk-test");
+    assert.equal(received["content-type"], "application/json");
+    assert.equal(received["accept-encoding"], "identity");
+    assert.equal(received["x-stainless-timeout"], "600");
+
+    for await (const _ of upstreamRes) {}
+  });
+
+  it("strips hop-by-hop response headers", async () => {
+    const mockReq = {
+      url: "/v1/messages",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    };
+
+    const { upstreamRes, responseHeaders } = await forwardRequest(mockReq, "{}", null);
+
+    assert.ok(!responseHeaders["connection"], "connection should be stripped from response");
+    assert.ok(!responseHeaders["transfer-encoding"], "transfer-encoding should be stripped from response");
+
+    for await (const _ of upstreamRes) {}
   });
 
   it("respects abort signal", async () => {
@@ -48,20 +104,17 @@ describe("upstream.mjs", () => {
     const mockReq = {
       url: "/v1/messages",
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", "x-test-delay": "5000" },
     };
 
-    // Abort shortly after request starts (before connection completes to real upstream)
-    setTimeout(() => controller.abort(), 10);
+    setTimeout(() => controller.abort(), 50);
 
     try {
       await forwardRequest(mockReq, "{}", controller.signal);
       assert.fail("Should have thrown");
     } catch (err) {
-      // Either aborted or connection refused — both are acceptable
       assert.ok(
         err.message.includes("abort") ||
-        err.message.includes("ECONNREFUSED") ||
         err.message.includes("destroyed") ||
         err.message.includes("socket hang up")
       );

--- a/test/proxy-wrapper.test.mjs
+++ b/test/proxy-wrapper.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { fork } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { writeFileSync, mkdirSync, chmodSync, unlinkSync, rmdirSync } from "node:fs";
+import { writeFileSync, unlinkSync } from "node:fs";
 import http from "node:http";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -27,9 +27,9 @@ describe("proxy server lifecycle", () => {
       });
       proxyProc.on("error", reject);
       proxyProc.on("exit", (code) => {
-        if (!port) reject(new Error(`Proxy exited (code ${code}) before ready. Output: ${output}`));
+        if (!port) reject(new Error(`Proxy exited (code ${code}) before ready`));
       });
-      setTimeout(() => reject(new Error(`Proxy startup timeout. Output: ${output}`)), 10000);
+      setTimeout(() => reject(new Error("Proxy startup timeout")), 10000);
     });
 
     const res = await new Promise((resolve, reject) => {
@@ -61,28 +61,13 @@ describe("proxy server lifecycle", () => {
 });
 
 describe("launch wrapper (claude-via-proxy)", () => {
-  const fakeBinDir = resolve(__dirname, "../.test-bin");
-  const fakeClaude = resolve(fakeBinDir, "claude");
-
-  function setupFakeClaude(script) {
-    mkdirSync(fakeBinDir, { recursive: true });
-    writeFileSync(fakeClaude, `#!/bin/bash\n${script}`);
-    chmodSync(fakeClaude, 0o755);
-  }
-
-  function cleanupFakeClaude() {
-    try { unlinkSync(fakeClaude); } catch {}
-    try { rmdirSync(fakeBinDir); } catch {}
-  }
-
-  it("exits with error when claude is not found", async () => {
-    const nodeBin = dirname(process.execPath);
+  it("exits with error when claude command is not found", async () => {
     const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
       stdio: ["ignore", "pipe", "pipe", "ipc"],
       env: {
         ...process.env,
         CACHE_FIX_PROXY_BIND: "127.0.0.1",
-        PATH: nodeBin,
+        CACHE_FIX_CLAUDE_CMD: "/nonexistent/path/to/claude",
       },
     });
 
@@ -94,56 +79,60 @@ describe("launch wrapper (claude-via-proxy)", () => {
       setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
     });
 
-    assert.ok(code !== 0, `Wrapper should exit non-zero when claude is missing. stderr: ${stderr}`);
+    assert.ok(code !== 0, `Wrapper should exit non-zero. stderr: ${stderr}`);
   });
 
   it("sets ANTHROPIC_BASE_URL and forwards to child process", async () => {
-    setupFakeClaude(
-      'echo "BASE_URL=$ANTHROPIC_BASE_URL"\n' +
-      'curl -s "$ANTHROPIC_BASE_URL/health" && echo "HEALTH_OK"\n' +
-      'exit 0'
-    );
+    const script = resolve(__dirname, ".fake-claude-env.mjs");
+    writeFileSync(script, 'process.stdout.write("BASE_URL=" + process.env.ANTHROPIC_BASE_URL + "\\n");\nprocess.exit(0);\n');
 
-    const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
-      stdio: ["ignore", "pipe", "pipe", "ipc"],
-      env: {
-        ...process.env,
-        CACHE_FIX_PROXY_BIND: "127.0.0.1",
-        PATH: `${fakeBinDir}:${process.env.PATH}`,
-      },
-    });
+    try {
+      const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
+        stdio: ["ignore", "pipe", "pipe", "ipc"],
+        env: {
+          ...process.env,
+          CACHE_FIX_PROXY_BIND: "127.0.0.1",
+          CACHE_FIX_CLAUDE_CMD: `${process.execPath} ${script}`,
+        },
+      });
 
-    let stdout = "";
-    wrapperProc.stdout.on("data", (c) => { stdout += c.toString(); });
+      let stdout = "";
+      wrapperProc.stdout.on("data", (c) => { stdout += c.toString(); });
 
-    const code = await new Promise((resolve) => {
-      wrapperProc.on("exit", (c) => resolve(c));
-      setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
-    });
+      const code = await new Promise((resolve) => {
+        wrapperProc.on("exit", (c) => resolve(c));
+        setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
+      });
 
-    cleanupFakeClaude();
-    assert.ok(stdout.includes("BASE_URL=http://127.0.0.1:"), `Expected BASE_URL in output, got: ${stdout}`);
-    assert.equal(code, 0);
+      assert.ok(stdout.includes("BASE_URL=http://127.0.0.1:"), `Expected BASE_URL in output, got: ${stdout}`);
+      assert.equal(code, 0);
+    } finally {
+      try { unlinkSync(script); } catch {}
+    }
   });
 
   it("propagates claude exit code", async () => {
-    setupFakeClaude("exit 42");
+    const script = resolve(__dirname, ".fake-claude-exit.mjs");
+    writeFileSync(script, "process.exit(42);\n");
 
-    const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
-      stdio: ["ignore", "pipe", "pipe", "ipc"],
-      env: {
-        ...process.env,
-        CACHE_FIX_PROXY_BIND: "127.0.0.1",
-        PATH: `${fakeBinDir}:${process.env.PATH}`,
-      },
-    });
+    try {
+      const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
+        stdio: ["ignore", "pipe", "pipe", "ipc"],
+        env: {
+          ...process.env,
+          CACHE_FIX_PROXY_BIND: "127.0.0.1",
+          CACHE_FIX_CLAUDE_CMD: `${process.execPath} ${script}`,
+        },
+      });
 
-    const code = await new Promise((resolve) => {
-      wrapperProc.on("exit", (c) => resolve(c));
-      setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
-    });
+      const code = await new Promise((resolve) => {
+        wrapperProc.on("exit", (c) => resolve(c));
+        setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
+      });
 
-    cleanupFakeClaude();
-    assert.equal(code, 42);
+      assert.equal(code, 42);
+    } finally {
+      try { unlinkSync(script); } catch {}
+    }
   });
 });

--- a/test/proxy-wrapper.test.mjs
+++ b/test/proxy-wrapper.test.mjs
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { fork } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import http from "node:http";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WRAPPER_PATH = resolve(__dirname, "../bin/claude-via-proxy.mjs");
+const SERVER_PATH = resolve(__dirname, "../proxy/server.mjs");
+
+describe("launch wrapper", () => {
+  it("proxy server starts and responds to health check", async () => {
+    const proxyProc = fork(SERVER_PATH, [], {
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+      env: { ...process.env, CACHE_FIX_PROXY_PORT: "0", CACHE_FIX_PROXY_BIND: "127.0.0.1" },
+      silent: false,
+    });
+
+    let port;
+    await new Promise((resolve, reject) => {
+      let output = "";
+      proxyProc.stdout.on("data", (chunk) => {
+        output += chunk.toString();
+        const match = output.match(/:(\d+)/);
+        if (match) {
+          port = parseInt(match[1], 10);
+          resolve();
+        }
+      });
+      proxyProc.on("error", reject);
+      proxyProc.on("exit", (code) => {
+        if (!port) reject(new Error(`Proxy exited (code ${code}) before ready. Output: ${output}`));
+      });
+      setTimeout(() => reject(new Error(`Proxy startup timeout. Output: ${output}`)), 10000);
+    });
+
+    const res = await new Promise((resolve, reject) => {
+      http.get(`http://127.0.0.1:${port}/health`, resolve).on("error", reject);
+    });
+    assert.equal(res.statusCode, 200);
+
+    proxyProc.kill("SIGTERM");
+    await new Promise((resolve) => proxyProc.on("exit", resolve));
+  });
+
+  it("proxy shuts down cleanly on SIGTERM", async () => {
+    const proxyProc = fork(SERVER_PATH, [], {
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+      env: { ...process.env, CACHE_FIX_PROXY_PORT: "0", CACHE_FIX_PROXY_BIND: "127.0.0.1" },
+    });
+
+    await new Promise((resolve) => {
+      proxyProc.stdout.on("data", (chunk) => {
+        if (chunk.toString().includes("listening")) resolve();
+      });
+      setTimeout(resolve, 2000);
+    });
+
+    proxyProc.kill("SIGTERM");
+    const code = await new Promise((resolve) => proxyProc.on("exit", (c) => resolve(c)));
+    assert.equal(code, 0);
+  });
+});

--- a/test/proxy-wrapper.test.mjs
+++ b/test/proxy-wrapper.test.mjs
@@ -3,18 +3,18 @@ import assert from "node:assert/strict";
 import { fork } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { writeFileSync, mkdirSync, chmodSync, unlinkSync, rmdirSync } from "node:fs";
 import http from "node:http";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WRAPPER_PATH = resolve(__dirname, "../bin/claude-via-proxy.mjs");
 const SERVER_PATH = resolve(__dirname, "../proxy/server.mjs");
 
-describe("launch wrapper", () => {
-  it("proxy server starts and responds to health check", async () => {
+describe("proxy server lifecycle", () => {
+  it("starts and responds to health check", async () => {
     const proxyProc = fork(SERVER_PATH, [], {
       stdio: ["ignore", "pipe", "pipe", "ipc"],
       env: { ...process.env, CACHE_FIX_PROXY_PORT: "0", CACHE_FIX_PROXY_BIND: "127.0.0.1" },
-      silent: false,
     });
 
     let port;
@@ -23,10 +23,7 @@ describe("launch wrapper", () => {
       proxyProc.stdout.on("data", (chunk) => {
         output += chunk.toString();
         const match = output.match(/:(\d+)/);
-        if (match) {
-          port = parseInt(match[1], 10);
-          resolve();
-        }
+        if (match) { port = parseInt(match[1], 10); resolve(); }
       });
       proxyProc.on("error", reject);
       proxyProc.on("exit", (code) => {
@@ -44,7 +41,7 @@ describe("launch wrapper", () => {
     await new Promise((resolve) => proxyProc.on("exit", resolve));
   });
 
-  it("proxy shuts down cleanly on SIGTERM", async () => {
+  it("shuts down cleanly on SIGTERM", async () => {
     const proxyProc = fork(SERVER_PATH, [], {
       stdio: ["ignore", "pipe", "pipe", "ipc"],
       env: { ...process.env, CACHE_FIX_PROXY_PORT: "0", CACHE_FIX_PROXY_BIND: "127.0.0.1" },
@@ -60,5 +57,93 @@ describe("launch wrapper", () => {
     proxyProc.kill("SIGTERM");
     const code = await new Promise((resolve) => proxyProc.on("exit", (c) => resolve(c)));
     assert.equal(code, 0);
+  });
+});
+
+describe("launch wrapper (claude-via-proxy)", () => {
+  const fakeBinDir = resolve(__dirname, "../.test-bin");
+  const fakeClaude = resolve(fakeBinDir, "claude");
+
+  function setupFakeClaude(script) {
+    mkdirSync(fakeBinDir, { recursive: true });
+    writeFileSync(fakeClaude, `#!/bin/bash\n${script}`);
+    chmodSync(fakeClaude, 0o755);
+  }
+
+  function cleanupFakeClaude() {
+    try { unlinkSync(fakeClaude); } catch {}
+    try { rmdirSync(fakeBinDir); } catch {}
+  }
+
+  it("exits with error when claude is not found", async () => {
+    const nodeBin = dirname(process.execPath);
+    const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+      env: {
+        ...process.env,
+        CACHE_FIX_PROXY_BIND: "127.0.0.1",
+        PATH: nodeBin,
+      },
+    });
+
+    let stderr = "";
+    wrapperProc.stderr.on("data", (c) => { stderr += c.toString(); });
+
+    const code = await new Promise((resolve) => {
+      wrapperProc.on("exit", (c) => resolve(c));
+      setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
+    });
+
+    assert.ok(code !== 0, `Wrapper should exit non-zero when claude is missing. stderr: ${stderr}`);
+  });
+
+  it("sets ANTHROPIC_BASE_URL and forwards to child process", async () => {
+    setupFakeClaude(
+      'echo "BASE_URL=$ANTHROPIC_BASE_URL"\n' +
+      'curl -s "$ANTHROPIC_BASE_URL/health" && echo "HEALTH_OK"\n' +
+      'exit 0'
+    );
+
+    const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+      env: {
+        ...process.env,
+        CACHE_FIX_PROXY_BIND: "127.0.0.1",
+        PATH: `${fakeBinDir}:${process.env.PATH}`,
+      },
+    });
+
+    let stdout = "";
+    wrapperProc.stdout.on("data", (c) => { stdout += c.toString(); });
+
+    const code = await new Promise((resolve) => {
+      wrapperProc.on("exit", (c) => resolve(c));
+      setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
+    });
+
+    cleanupFakeClaude();
+    assert.ok(stdout.includes("BASE_URL=http://127.0.0.1:"), `Expected BASE_URL in output, got: ${stdout}`);
+    assert.equal(code, 0);
+  });
+
+  it("propagates claude exit code", async () => {
+    setupFakeClaude("exit 42");
+
+    const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+      env: {
+        ...process.env,
+        CACHE_FIX_PROXY_BIND: "127.0.0.1",
+        PATH: `${fakeBinDir}:${process.env.PATH}`,
+      },
+    });
+
+    const code = await new Promise((resolve) => {
+      wrapperProc.on("exit", (c) => resolve(c));
+      setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
+    });
+
+    cleanupFakeClaude();
+    assert.equal(code, 42);
   });
 });

--- a/test/proxy-wrapper.test.mjs
+++ b/test/proxy-wrapper.test.mjs
@@ -3,7 +3,6 @@ import assert from "node:assert/strict";
 import { fork } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { writeFileSync, unlinkSync } from "node:fs";
 import http from "node:http";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -68,7 +67,9 @@ function cleanEnv(overrides) {
   return env;
 }
 
-describe("launch wrapper (claude-via-proxy)", () => {
+const NODE = process.execPath;
+
+describe("launch wrapper (claude-via-proxy)", { concurrency: 1 }, () => {
   it("exits with error when claude command is not found", async () => {
     const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
       stdio: ["ignore", "pipe", "pipe", "ipc"],
@@ -87,53 +88,38 @@ describe("launch wrapper (claude-via-proxy)", () => {
   });
 
   it("sets ANTHROPIC_BASE_URL and forwards to child process", async () => {
-    const script = resolve(__dirname, ".fake-claude-env.mjs");
-    writeFileSync(script, 'process.stdout.write("BASE_URL=" + process.env.ANTHROPIC_BASE_URL + "\\n");\nprocess.exit(0);\n');
+    const script = 'process.stdout.write("BASE_URL="+process.env.ANTHROPIC_BASE_URL+"\\n")';
+    const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+      env: cleanEnv({ CACHE_FIX_CLAUDE_CMD: `${NODE} -e ${script}` }),
+    });
 
-    try {
-      const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
-        stdio: ["ignore", "pipe", "pipe", "ipc"],
-        env: cleanEnv({ CACHE_FIX_CLAUDE_CMD: `${process.execPath} ${script}` }),
-      });
+    let stdout = "";
+    wrapperProc.stdout.on("data", (c) => { stdout += c.toString(); });
 
-      let stdout = "";
-      wrapperProc.stdout.on("data", (c) => { stdout += c.toString(); });
+    const code = await new Promise((resolve) => {
+      wrapperProc.on("exit", (c) => resolve(c));
+      setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
+    });
 
-      const code = await new Promise((resolve) => {
-        wrapperProc.on("exit", (c) => resolve(c));
-        setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
-      });
-
-      assert.ok(stdout.includes("BASE_URL=http://127.0.0.1:"), `Expected BASE_URL in output, got: ${stdout}`);
-      assert.equal(code, 0);
-    } finally {
-      try { unlinkSync(script); } catch {}
-    }
+    assert.ok(stdout.includes("BASE_URL=http://127.0.0.1:"), `Expected BASE_URL in output, got: ${stdout}`);
+    assert.equal(code, 0);
   });
 
   it("propagates claude exit code", async () => {
-    const script = resolve(__dirname, ".fake-claude-exit.mjs");
-    writeFileSync(script, "process.exit(42);\n");
+    const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+      env: cleanEnv({ CACHE_FIX_CLAUDE_CMD: `${NODE} -e process.exit(42)` }),
+    });
 
-    try {
-      const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
-        stdio: ["ignore", "pipe", "pipe", "ipc"],
-        env: cleanEnv({ CACHE_FIX_CLAUDE_CMD: `${process.execPath} ${script}` }),
-      });
+    let stderr = "";
+    wrapperProc.stderr.on("data", (c) => { stderr += c.toString(); });
 
-      let stderr = "";
-      wrapperProc.stderr.on("data", (c) => { stderr += c.toString(); });
-      let stdout = "";
-      wrapperProc.stdout.on("data", (c) => { stdout += c.toString(); });
+    const code = await new Promise((resolve) => {
+      wrapperProc.on("exit", (c) => resolve(c));
+      setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
+    });
 
-      const code = await new Promise((resolve) => {
-        wrapperProc.on("exit", (c) => resolve(c));
-        setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
-      });
-
-      assert.equal(code, 42, `Expected exit 42, got ${code}. stderr: ${stderr} stdout: ${stdout}`);
-    } finally {
-      try { unlinkSync(script); } catch {}
-    }
+    assert.equal(code, 42, `Expected exit 42, got ${code}. stderr: ${stderr}`);
   });
 });

--- a/test/proxy-wrapper.test.mjs
+++ b/test/proxy-wrapper.test.mjs
@@ -60,15 +60,19 @@ describe("proxy server lifecycle", () => {
   });
 });
 
+function cleanEnv(overrides) {
+  const env = { ...process.env, ...overrides };
+  delete env.CACHE_FIX_PROXY_PORT;
+  delete env.CACHE_FIX_PROXY_UPSTREAM;
+  env.CACHE_FIX_PROXY_BIND = "127.0.0.1";
+  return env;
+}
+
 describe("launch wrapper (claude-via-proxy)", () => {
   it("exits with error when claude command is not found", async () => {
     const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
       stdio: ["ignore", "pipe", "pipe", "ipc"],
-      env: {
-        ...process.env,
-        CACHE_FIX_PROXY_BIND: "127.0.0.1",
-        CACHE_FIX_CLAUDE_CMD: "/nonexistent/path/to/claude",
-      },
+      env: cleanEnv({ CACHE_FIX_CLAUDE_CMD: "/nonexistent/path/to/claude" }),
     });
 
     let stderr = "";
@@ -89,11 +93,7 @@ describe("launch wrapper (claude-via-proxy)", () => {
     try {
       const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
         stdio: ["ignore", "pipe", "pipe", "ipc"],
-        env: {
-          ...process.env,
-          CACHE_FIX_PROXY_BIND: "127.0.0.1",
-          CACHE_FIX_CLAUDE_CMD: `${process.execPath} ${script}`,
-        },
+        env: cleanEnv({ CACHE_FIX_CLAUDE_CMD: `${process.execPath} ${script}` }),
       });
 
       let stdout = "";
@@ -118,19 +118,20 @@ describe("launch wrapper (claude-via-proxy)", () => {
     try {
       const wrapperProc = fork(WRAPPER_PATH, ["--proxy-port", "0"], {
         stdio: ["ignore", "pipe", "pipe", "ipc"],
-        env: {
-          ...process.env,
-          CACHE_FIX_PROXY_BIND: "127.0.0.1",
-          CACHE_FIX_CLAUDE_CMD: `${process.execPath} ${script}`,
-        },
+        env: cleanEnv({ CACHE_FIX_CLAUDE_CMD: `${process.execPath} ${script}` }),
       });
+
+      let stderr = "";
+      wrapperProc.stderr.on("data", (c) => { stderr += c.toString(); });
+      let stdout = "";
+      wrapperProc.stdout.on("data", (c) => { stdout += c.toString(); });
 
       const code = await new Promise((resolve) => {
         wrapperProc.on("exit", (c) => resolve(c));
         setTimeout(() => { wrapperProc.kill("SIGTERM"); resolve(null); }, 15000);
       });
 
-      assert.equal(code, 42);
+      assert.equal(code, 42, `Expected exit 42, got ${code}. stderr: ${stderr} stdout: ${stdout}`);
     } finally {
       try { unlinkSync(script); } catch {}
     }


### PR DESCRIPTION
## v3.0.0: Proxy Architecture — Full Stack

Local HTTP proxy replacing the `--import` preload interceptor. Works with Claude Code v2.1.113+ (Bun binary) via `ANTHROPIC_BASE_URL`.

### What shipped

**Phase 1-2: Proxy Server + Launch Wrapper**
- `proxy/server.mjs` — HTTP server on loopback, routes `/v1/messages` and `/health`, abort propagation, graceful shutdown
- `proxy/upstream.mjs` — HTTPS/HTTP client with header policy, forces `accept-encoding: identity`
- `proxy/stream.mjs` — SSE forwarder with backpressure, telemetry extraction
- `proxy/config.mjs` — env-based config
- `bin/claude-via-proxy.mjs` — launch wrapper with lifecycle management

**Phase 3a: Extension Pipeline**
- `proxy/pipeline.mjs` — hot-reloadable extension loader, registry, executor
- `proxy/watcher.mjs` — file watcher for live extension reload
- 7 extensions ported from preload.mjs:
  - `fingerprint-strip` — remove cc_version fingerprint
  - `sort-stabilization` — deterministic tool/MCP ordering
  - `ttl-management` — detect server TTL tier, inject correct cache_control
  - `identity-normalization` — normalize message identity fields
  - `fresh-session-sort` — fix non-deterministic first-turn ordering
  - `cache-control-normalize` — normalize cache_control markers
  - `cache-telemetry` — extract cache stats from response headers
  - `request-log` — optional NDJSON request log
- `proxy/extensions.json` — per-extension enable/disable + order config

### Testing

- 181 tests passing (162 existing + 19 proxy)
- Sim-validated against real CC traffic (Opus 4.6, 99.9% cache hit rate)
- A/B tested on v2.1.117 (latest Bun binary): 95.5% hit rate through proxy vs 82.3% direct on first warm turn

### Review history

- Phase 1-2: 8 Codex review rounds, all blockers resolved
- Phase 3a: 3 Codex review rounds, all blockers resolved (SSE reserialization, onResponseStart hook, fresh-session-sort)
- Labels: `approved-by-codex-agent`, `approved-by-lead`, `sim-validated`

### Upgrade path for preload users

```bash
# Start proxy
node proxy/server.mjs &

# Launch CC (any version, including Bun binary)
ANTHROPIC_BASE_URL=http://127.0.0.1:9801 claude
```

Ref #40