### PR TITLE
feat: image-strip proxy extension (#59 item 1)

### DIFF
--- a/docs/code-reviews/pr-60-image-strip-codex-review-2026-04-24.md
+++ b/docs/code-reviews/pr-60-image-strip-codex-review-2026-04-24.md
@@ -1,0 +1,26 @@
+# Review: image-strip proxy extension
+
+Date: 2026-04-24
+Reviewed: PR #60 (`feature/proxy-image-strip`)
+Label applied: reviewed-by-codex-agent
+
+## What Is Correct
+- The stripping helper preserves direct user image blocks and only rewrites `image` items nested inside `tool_result.content`, which matches the stated requirement and the existing `preload.mjs` behavior.
+- The cutoff calculation is correct for "keep the last N user messages": it collects user-message indices, selects the earliest index that should remain intact, and strips only earlier user messages.
+- Stats accounting matches the preload implementation: `strippedCount` increments per stripped image, `strippedBytes` sums `source.data.length` when present, and `estimatedTokens` is derived as `Math.ceil(strippedBytes * 0.125)`.
+- The new extension is disabled by default via `enabled: false`, and the proxy pipeline honors extension defaults unless config enables them.
+- Named exports are provided for the stripping helper and placeholder string, which makes the unit tests straightforward and keeps the core logic directly testable.
+
+## Blockers
+None
+
+## What Needs Attention
+- Test coverage is solid for the main success path and key regressions, but it does not currently exercise mixed old/recent histories where some old user messages have no `content` array or where `tool_result.content` is non-array. The implementation already guards these cases, so this is a coverage gap, not a correctness issue.
+- The tests validate `strippedCount` and `strippedBytes` directly, but they only verify the token estimate indirectly. A direct assertion on `estimatedTokens` would make future refactors safer.
+
+## Recommendations
+- Approve and merge as-is.
+- When convenient, add one small unit test that asserts `estimatedTokens` exactly and one guard-path test for malformed `tool_result.content`.
+
+## Bottom Line
+This is a clean proxy port of the preload image-stripping behavior. The logic is correctly scoped to old `tool_result` images, the cutoff math is sound, the metrics match the existing implementation, the extension is testable via named exports, and it remains opt-in by default. I found no blocking issues.

--- a/proxy/extensions/image-strip.mjs
+++ b/proxy/extensions/image-strip.mjs
@@ -1,0 +1,83 @@
+const KEEP_LAST = parseInt(process.env.CACHE_FIX_IMAGE_KEEP_LAST || "0", 10);
+const PLACEHOLDER = "[image stripped from history — file may still be on disk]";
+
+function stripOldToolResultImages(messages, keepLast) {
+  if (!keepLast || keepLast <= 0 || !Array.isArray(messages)) {
+    return { messages, stats: null };
+  }
+
+  const userMsgIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "user") userMsgIndices.push(i);
+  }
+
+  if (userMsgIndices.length <= keepLast) {
+    return { messages, stats: null };
+  }
+
+  const cutoffIdx = userMsgIndices[userMsgIndices.length - keepLast];
+
+  let strippedCount = 0;
+  let strippedBytes = 0;
+
+  const result = messages.map((msg, msgIdx) => {
+    if (msg.role !== "user" || msgIdx >= cutoffIdx || !Array.isArray(msg.content)) {
+      return msg;
+    }
+
+    let msgModified = false;
+    const newContent = msg.content.map((block) => {
+      if (block.type === "tool_result" && Array.isArray(block.content)) {
+        let toolModified = false;
+        const newToolContent = block.content.map((item) => {
+          if (item.type === "image") {
+            strippedCount++;
+            if (item.source?.data) {
+              strippedBytes += item.source.data.length;
+            }
+            toolModified = true;
+            return { type: "text", text: PLACEHOLDER };
+          }
+          return item;
+        });
+        if (toolModified) {
+          msgModified = true;
+          return { ...block, content: newToolContent };
+        }
+      }
+      return block;
+    });
+
+    return msgModified ? { ...msg, content: newContent } : msg;
+  });
+
+  const stats = strippedCount > 0
+    ? { strippedCount, strippedBytes, estimatedTokens: Math.ceil(strippedBytes * 0.125) }
+    : null;
+
+  return { messages: strippedCount > 0 ? result : messages, stats };
+}
+
+export { stripOldToolResultImages, PLACEHOLDER };
+
+export default {
+  name: "image-strip",
+  description: "Strip base64 images from old tool results to reduce token waste",
+  enabled: false,
+  order: 150,
+
+  async onRequest(ctx) {
+    const keepLast = parseInt(ctx.meta.imageKeepLast ?? KEEP_LAST, 10);
+    if (!keepLast || keepLast <= 0) return;
+    if (!ctx.body.messages) return;
+
+    const { messages, stats } = stripOldToolResultImages(ctx.body.messages, keepLast);
+    if (stats) {
+      ctx.body.messages = messages;
+      ctx.meta.imageStripStats = stats;
+      process.stderr.write(
+        `[image-strip] stripped ${stats.strippedCount} images (~${stats.estimatedTokens} tokens saved)\n`
+      );
+    }
+  },
+};

--- a/test/proxy-image-strip.test.mjs
+++ b/test/proxy-image-strip.test.mjs
@@ -1,0 +1,179 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import ext, { stripOldToolResultImages, PLACEHOLDER } from "../proxy/extensions/image-strip.mjs";
+
+function userMsg(content) {
+  return { role: "user", content };
+}
+
+function assistantMsg(text) {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}
+
+function toolResultWithImage(toolUseId, base64Data) {
+  return {
+    type: "tool_result",
+    tool_use_id: toolUseId,
+    content: [
+      { type: "image", source: { type: "base64", media_type: "image/png", data: base64Data } },
+      { type: "text", text: "File read successfully" },
+    ],
+  };
+}
+
+function toolResultTextOnly(toolUseId, text) {
+  return {
+    type: "tool_result",
+    tool_use_id: toolUseId,
+    content: [{ type: "text", text }],
+  };
+}
+
+// --- Unit tests: stripOldToolResultImages ---
+
+test("stripOldToolResultImages: strips images from old user messages", () => {
+  const fakeBase64 = "A".repeat(1000);
+  const messages = [
+    userMsg([toolResultWithImage("t1", fakeBase64), { type: "text", text: "prompt 1" }]),
+    assistantMsg("reply 1"),
+    userMsg([toolResultWithImage("t2", fakeBase64), { type: "text", text: "prompt 2" }]),
+    assistantMsg("reply 2"),
+    userMsg([toolResultWithImage("t3", fakeBase64), { type: "text", text: "prompt 3" }]),
+  ];
+
+  const { messages: result, stats } = stripOldToolResultImages(messages, 1);
+
+  assert.ok(stats, "should have stripping stats");
+  assert.equal(stats.strippedCount, 2, "should strip 2 images from old messages");
+  assert.equal(stats.strippedBytes, 2000);
+
+  // First two user messages should have images stripped
+  assert.equal(result[0].content[0].content[0].type, "text");
+  assert.equal(result[0].content[0].content[0].text, PLACEHOLDER);
+  assert.equal(result[2].content[0].content[0].type, "text");
+  assert.equal(result[2].content[0].content[0].text, PLACEHOLDER);
+
+  // Last user message should keep its image
+  assert.equal(result[4].content[0].content[0].type, "image");
+});
+
+test("stripOldToolResultImages: keeps images in recent N messages", () => {
+  const fakeBase64 = "B".repeat(500);
+  const messages = [
+    userMsg([toolResultWithImage("t1", fakeBase64)]),
+    assistantMsg("r1"),
+    userMsg([toolResultWithImage("t2", fakeBase64)]),
+    assistantMsg("r2"),
+    userMsg([toolResultWithImage("t3", fakeBase64)]),
+    assistantMsg("r3"),
+    userMsg([toolResultWithImage("t4", fakeBase64)]),
+  ];
+
+  const { messages: result, stats } = stripOldToolResultImages(messages, 3);
+
+  assert.ok(stats);
+  assert.equal(stats.strippedCount, 1, "should only strip the oldest");
+  assert.equal(result[0].content[0].content[0].text, PLACEHOLDER);
+  // Messages 2, 4, 6 (last 3 user messages) should keep images
+  assert.equal(result[2].content[0].content[0].type, "image");
+  assert.equal(result[4].content[0].content[0].type, "image");
+  assert.equal(result[6].content[0].content[0].type, "image");
+});
+
+test("stripOldToolResultImages: no-op when keepLast is 0", () => {
+  const messages = [userMsg([toolResultWithImage("t1", "data")])];
+  const { stats } = stripOldToolResultImages(messages, 0);
+  assert.equal(stats, null);
+});
+
+test("stripOldToolResultImages: no-op when not enough messages", () => {
+  const messages = [
+    userMsg([toolResultWithImage("t1", "data")]),
+    assistantMsg("reply"),
+    userMsg([{ type: "text", text: "hi" }]),
+  ];
+  const { stats } = stripOldToolResultImages(messages, 3);
+  assert.equal(stats, null);
+});
+
+test("stripOldToolResultImages: does not strip user-pasted images", () => {
+  const messages = [
+    userMsg([
+      { type: "image", source: { type: "base64", media_type: "image/png", data: "userPasted" } },
+      { type: "text", text: "what is this image?" },
+    ]),
+    assistantMsg("reply"),
+    userMsg([{ type: "text", text: "follow up" }]),
+    assistantMsg("reply2"),
+    userMsg([{ type: "text", text: "another" }]),
+  ];
+
+  const { messages: result, stats } = stripOldToolResultImages(messages, 1);
+  assert.equal(stats, null, "user-pasted images should not be stripped");
+  assert.equal(result[0].content[0].type, "image");
+});
+
+test("stripOldToolResultImages: preserves non-image tool_result content", () => {
+  const messages = [
+    userMsg([
+      toolResultWithImage("t1", "imgdata"),
+      toolResultTextOnly("t2", "text result"),
+    ]),
+    assistantMsg("reply"),
+    userMsg([{ type: "text", text: "recent" }]),
+    assistantMsg("reply2"),
+    userMsg([{ type: "text", text: "current" }]),
+  ];
+
+  const { messages: result, stats } = stripOldToolResultImages(messages, 1);
+  assert.equal(stats.strippedCount, 1);
+  // Text-only tool result should be untouched
+  assert.equal(result[0].content[1].content[0].text, "text result");
+});
+
+test("stripOldToolResultImages: handles null/undefined input", () => {
+  assert.deepEqual(stripOldToolResultImages(null, 3), { messages: null, stats: null });
+  assert.deepEqual(stripOldToolResultImages(undefined, 3), { messages: undefined, stats: null });
+});
+
+// --- Integration tests: onRequest ---
+
+test("onRequest: strips images when CACHE_FIX_IMAGE_KEEP_LAST is set via meta", async () => {
+  const fakeBase64 = "C".repeat(800);
+  const ctx = {
+    body: {
+      messages: [
+        userMsg([toolResultWithImage("t1", fakeBase64)]),
+        assistantMsg("r1"),
+        userMsg([toolResultWithImage("t2", fakeBase64)]),
+        assistantMsg("r2"),
+        userMsg([{ type: "text", text: "current prompt" }]),
+      ],
+    },
+    headers: {},
+    meta: { imageKeepLast: 1 },
+  };
+
+  await ext.onRequest(ctx);
+
+  assert.ok(ctx.meta.imageStripStats, "should have stats");
+  assert.equal(ctx.meta.imageStripStats.strippedCount, 2);
+  assert.equal(ctx.body.messages[0].content[0].content[0].text, PLACEHOLDER);
+});
+
+test("onRequest: no-op when keepLast is 0 or unset", async () => {
+  const ctx = {
+    body: {
+      messages: [
+        userMsg([toolResultWithImage("t1", "data")]),
+        assistantMsg("r1"),
+        userMsg([{ type: "text", text: "prompt" }]),
+      ],
+    },
+    headers: {},
+    meta: {},
+  };
+
+  await ext.onRequest(ctx);
+  assert.equal(ctx.meta.imageStripStats, undefined);
+});


### PR DESCRIPTION
Ports `CACHE_FIX_IMAGE_KEEP_LAST` from preload to proxy. First of 10 features from #59.

Replaces base64 image blocks in `tool_result` content older than N user messages with a text placeholder. User-pasted images are never touched. Disabled by default.

**9 tests** covering: strip logic, recent-message preservation, user-image safety, null input, onRequest integration.

301 total tests, 0 failures.

— AI Team Lead