### PR TITLE
feat: output-efficiency-rewrite proxy extension (#59 item 2)

### DIFF
--- a/docs/code-reviews/pr-61-output-efficiency-rewrite-review-2026-04-24.md
+++ b/docs/code-reviews/pr-61-output-efficiency-rewrite-review-2026-04-24.md
@@ -1,0 +1,26 @@
+# Review: output-efficiency-rewrite proxy extension
+
+Date: 2026-04-24
+Reviewed: PR #61 (`feature/proxy-output-efficiency`)
+Label applied: reviewed-by-codex-agent
+
+## What Is Correct
+- The proxy port preserves the preload implementation's narrow rewrite scope: it searches for `# Output efficiency`, replaces only that section, and leaves the rest of the system block intact.
+- Section boundary handling is correct for the documented prompt shapes. `replaceSection()` stops at the next top-level `# ...` heading when present, or rewrites through end-of-text when the section is last.
+- Header normalization is correct. `normalizeReplacement()` trims input and prepends `# Output efficiency` when the caller supplies only body text.
+- `cache_control` preservation is correct. The rewrite returns `{ ...block, text: nextText }`, so existing marker objects survive unchanged on rewritten system blocks.
+- No-op behavior is correct in the implemented paths: `onRequest()` exits when no replacement is configured or `ctx.body.system` is absent, and `rewriteOutputEfficiency()` returns `null` when the target section is not found.
+- Test coverage is solid for the feature itself. The new suite covers normalization, section replacement through next heading and end-of-text, cache marker preservation, no-match/no-replacement behavior, and `onRequest()` integration. The disabled-path invariant is already covered at the pipeline layer by `test/proxy-pipeline.test.mjs`, which verifies `enabled: false` extensions are not loaded.
+
+## Blockers
+None
+
+## What Needs Attention
+- The section boundary matcher remains intentionally narrow: it only stops on the next top-level `# ...` heading, not `## ...` or other markdown constructs. That matches the existing preload behavior and the documented prompt variants, so this is not a regression, but it remains coupled to current prompt formatting.
+
+## Recommendations
+- Ship this as-is.
+- If Claude Code starts emitting subsection headings inside or after the output-efficiency block, add one regression test first and then widen the boundary matcher deliberately rather than changing it preemptively now.
+
+## Bottom Line
+Approve. The proxy extension is a faithful port of the preload rewrite, preserves cache markers, no-ops safely when inactive or unmatched, and has adequate targeted tests for the current prompt contract.

--- a/proxy/extensions/output-efficiency-rewrite.mjs
+++ b/proxy/extensions/output-efficiency-rewrite.mjs
@@ -1,0 +1,64 @@
+const SECTION_HEADER = "# Output efficiency";
+const REPLACEMENT_RAW = process.env.CACHE_FIX_OUTPUT_EFFICIENCY_REPLACEMENT || "";
+
+function normalizeReplacement(text) {
+  const trimmed = typeof text === "string" ? text.trim() : "";
+  if (!trimmed) return "";
+  return trimmed.startsWith(SECTION_HEADER) ? trimmed : `${SECTION_HEADER}\n\n${trimmed}`;
+}
+
+function replaceSection(text, replacement) {
+  const start = text.indexOf(SECTION_HEADER);
+  if (start === -1) return null;
+
+  const afterHeader = start + SECTION_HEADER.length;
+  const remainder = text.slice(afterHeader);
+  const nextHeadingMatch = remainder.match(/\n# [^\n]+/);
+
+  if (!nextHeadingMatch || nextHeadingMatch.index == null) {
+    return text.slice(0, start) + replacement;
+  }
+
+  const nextHeadingStart = afterHeader + nextHeadingMatch.index + 1;
+  return text.slice(0, start) + replacement + "\n\n" + text.slice(nextHeadingStart);
+}
+
+function rewriteOutputEfficiency(system, replacement) {
+  if (!Array.isArray(system) || !replacement) return null;
+
+  let changed = false;
+  const rewritten = system.map((block) => {
+    if (block?.type !== "text" || typeof block.text !== "string" || !block.text.includes(SECTION_HEADER)) {
+      return block;
+    }
+
+    const nextText = replaceSection(block.text, replacement);
+    if (!nextText || nextText === block.text) return block;
+
+    changed = true;
+    return { ...block, text: nextText };
+  });
+
+  return changed ? rewritten : null;
+}
+
+export { normalizeReplacement, replaceSection, rewriteOutputEfficiency, SECTION_HEADER };
+
+export default {
+  name: "output-efficiency-rewrite",
+  description: "Replace Claude Code's # Output efficiency system prompt section with custom text",
+  enabled: false,
+  order: 90,
+
+  async onRequest(ctx) {
+    const raw = ctx.meta.outputEfficiencyReplacement ?? REPLACEMENT_RAW;
+    const replacement = normalizeReplacement(raw);
+    if (!replacement) return;
+    if (!ctx.body.system) return;
+
+    const result = rewriteOutputEfficiency(ctx.body.system, replacement);
+    if (result) {
+      ctx.body.system = result;
+    }
+  },
+};

--- a/test/proxy-output-efficiency-rewrite.test.mjs
+++ b/test/proxy-output-efficiency-rewrite.test.mjs
@@ -1,0 +1,131 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import ext, {
+  normalizeReplacement,
+  replaceSection,
+  rewriteOutputEfficiency,
+  SECTION_HEADER,
+} from "../proxy/extensions/output-efficiency-rewrite.mjs";
+
+// --- Unit tests: normalizeReplacement ---
+
+test("normalizeReplacement: prepends header if missing", () => {
+  const result = normalizeReplacement("Be concise and direct.");
+  assert.ok(result.startsWith(SECTION_HEADER));
+  assert.ok(result.includes("Be concise and direct."));
+});
+
+test("normalizeReplacement: keeps header if already present", () => {
+  const input = "# Output efficiency\n\nBe concise.";
+  assert.equal(normalizeReplacement(input), input);
+});
+
+test("normalizeReplacement: returns empty for empty input", () => {
+  assert.equal(normalizeReplacement(""), "");
+  assert.equal(normalizeReplacement(null), "");
+  assert.equal(normalizeReplacement(undefined), "");
+});
+
+// --- Unit tests: replaceSection ---
+
+test("replaceSection: replaces section up to next heading", () => {
+  const text = "Before\n\n# Output efficiency\n\nOld content here.\n\n# Next section\n\nKeep this.";
+  const replacement = "# Output efficiency\n\nNew content.";
+  const result = replaceSection(text, replacement);
+  assert.ok(result.includes("New content."));
+  assert.ok(result.includes("Keep this."));
+  assert.ok(!result.includes("Old content"));
+});
+
+test("replaceSection: replaces section at end of text (no next heading)", () => {
+  const text = "Before\n\n# Output efficiency\n\nOld trailing content.";
+  const replacement = "# Output efficiency\n\nReplaced.";
+  const result = replaceSection(text, replacement);
+  assert.equal(result, "Before\n\n# Output efficiency\n\nReplaced.");
+});
+
+test("replaceSection: returns null if section not found", () => {
+  assert.equal(replaceSection("no such section", "replacement"), null);
+});
+
+test("replaceSection: preserves content before the section", () => {
+  const text = "# System prompt\n\nImportant stuff.\n\n# Output efficiency\n\nReplace me.";
+  const result = replaceSection(text, "# Output efficiency\n\nNew.");
+  assert.ok(result.startsWith("# System prompt\n\nImportant stuff."));
+});
+
+// --- Unit tests: rewriteOutputEfficiency ---
+
+test("rewriteOutputEfficiency: rewrites matching system block", () => {
+  const system = [
+    { type: "text", text: "# System\n\nPreamble.\n\n# Output efficiency\n\nOld." },
+  ];
+  const result = rewriteOutputEfficiency(system, "# Output efficiency\n\nNew.");
+  assert.ok(result);
+  assert.ok(result[0].text.includes("New."));
+  assert.ok(!result[0].text.includes("Old."));
+});
+
+test("rewriteOutputEfficiency: preserves cache_control on rewritten block", () => {
+  const system = [
+    {
+      type: "text",
+      text: "# Output efficiency\n\nOld content.",
+      cache_control: { type: "ephemeral" },
+    },
+  ];
+  const result = rewriteOutputEfficiency(system, "# Output efficiency\n\nNew.");
+  assert.ok(result);
+  assert.deepEqual(result[0].cache_control, { type: "ephemeral" });
+});
+
+test("rewriteOutputEfficiency: returns null when no match", () => {
+  const system = [{ type: "text", text: "no output efficiency section" }];
+  assert.equal(rewriteOutputEfficiency(system, "replacement"), null);
+});
+
+test("rewriteOutputEfficiency: returns null when replacement is empty", () => {
+  const system = [{ type: "text", text: "# Output efficiency\n\nContent." }];
+  assert.equal(rewriteOutputEfficiency(system, ""), null);
+});
+
+test("rewriteOutputEfficiency: returns null for non-array system", () => {
+  assert.equal(rewriteOutputEfficiency(null, "replacement"), null);
+  assert.equal(rewriteOutputEfficiency("string", "replacement"), null);
+});
+
+// --- Integration tests: onRequest ---
+
+test("onRequest: rewrites when replacement is provided via meta", async () => {
+  const ctx = {
+    body: {
+      system: [
+        { type: "text", text: "# Preamble\n\nStuff.\n\n# Output efficiency\n\nDefault verbose instructions." },
+      ],
+    },
+    headers: {},
+    meta: { outputEfficiencyReplacement: "Be concise. No fluff." },
+  };
+
+  await ext.onRequest(ctx);
+  assert.ok(ctx.body.system[0].text.includes("Be concise"));
+  assert.ok(!ctx.body.system[0].text.includes("Default verbose"));
+});
+
+test("onRequest: no-op when no replacement configured", async () => {
+  const original = "# Output efficiency\n\nKeep this.";
+  const ctx = {
+    body: { system: [{ type: "text", text: original }] },
+    headers: {},
+    meta: {},
+  };
+
+  await ext.onRequest(ctx);
+  assert.equal(ctx.body.system[0].text, original);
+});
+
+test("onRequest: no-op when system is missing", async () => {
+  const ctx = { body: {}, headers: {}, meta: { outputEfficiencyReplacement: "text" } };
+  await ext.onRequest(ctx);
+  assert.equal(ctx.body.system, undefined);
+});


### PR DESCRIPTION
Ports `CACHE_FIX_OUTPUT_EFFICIENCY_REPLACEMENT` from preload to proxy. Second of 10 features from #59.

Replaces the `# Output efficiency` section in the system prompt with custom text. Preserves surrounding sections and `cache_control` markers. Disabled by default.

**15 tests** covering: normalization, section replacement (mid-text and trailing), cache_control preservation, no-op cases, onRequest integration.

Ref: #59

— AI Team Lead