### PR TITLE
feat: content-strip + tool-input-normalize proxy extensions (#59 items 3,4,7)

### DIFF
--- a/docs/code-reviews/pr-62-proxy-trailer-reminder-strip-rereview-2026-04-24.md
+++ b/docs/code-reviews/pr-62-proxy-trailer-reminder-strip-rereview-2026-04-24.md
@@ -1,0 +1,23 @@
+# Review: content-strip + tool-input-normalize
+
+Date: 2026-04-24
+Reviewed: PR #62 re-review at `0aa01ff`
+Label applied: approved-by-codex-agent
+
+## What Is Correct
+- `content-strip` now matches the full documented bookkeeping reminder set already defined in `preload.mjs`, including `TodoWrite`, `Remaining conversation turns`, and `Messages until auto-compact`.
+- Strip counters now only increment when a message is actually rewritten, so the empty-content safeguard no longer reports removals that were not applied.
+- The added tests cover the previously missing bookkeeping variants and the guard-path counter behavior.
+- Full repository test coverage is green on this head: `323` tests passed, `0` failed.
+
+## Blockers
+None
+
+## What Needs Attention
+- None
+
+## Recommendations
+- Keep the `content-strip` bookkeeping matcher aligned with the canonical matcher in `preload.mjs` when future reminder formats are added.
+
+## Bottom Line
+Ship it. The prior blocker is resolved on `0aa01ff`: the matcher now covers the full bookkeeping set, the stats behavior matches the applied transformation, and both targeted and full-suite tests pass cleanly.

--- a/docs/code-reviews/pr-62-proxy-trailer-reminder-strip-review-2026-04-24.md
+++ b/docs/code-reviews/pr-62-proxy-trailer-reminder-strip-review-2026-04-24.md
@@ -1,0 +1,30 @@
+# Review: content-strip + tool-input-normalize
+
+Date: 2026-04-24
+Reviewed: PR #62 (`feature/proxy-trailer-reminder-strip`)
+Label applied: changes-requested
+
+## What Is Correct
+- `content-strip` uses exact text equality for the continue trailer, so longer or variant user text is not stripped accidentally.
+- `content-strip` preserves the original message when filtering would empty `content`, which avoids producing invalid empty user content arrays.
+- `tool-input-normalize` rebuilds `tool_use.input` in declared schema property order and drops non-schema keys.
+- Both new extensions are disabled by default (`enabled: false`), which is the right rollout posture for new cache-normalization behavior.
+- Focused tests cover the main happy paths for trailer stripping, reminder stripping, key reordering, and extra-key removal.
+
+## Blockers
+- `content-strip` does not match the full documented bookkeeping reminder set already defined in [preload.mjs](/home/manager/git_repos/claude-code-cache-fix/preload.mjs:518). The new matcher only handles token usage, output tokens, USD budget, and the task-tools nudge in [proxy/extensions/content-strip.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/content-strip.mjs:4), but omits:
+  - `The TodoWrite tool hasn't been used recently. …`
+  - `Remaining conversation turns: <N>`
+  - `Messages until auto-compact: <N>` / `Message until auto-compact: <N>`
+  This means PR #62 would leave part of the documented bookkeeping churn in place, and the new tests would still pass because they only assert the reduced subset in [test/proxy-content-strip.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/proxy-content-strip.test.mjs:30).
+
+## What Needs Attention
+- `stripContentBlocks()` increments `trailerCount` / `reminderCount` before the empty-array guard. If a message consists only of removable blocks, the function returns the original message unchanged but still reports non-zero strip stats, so `onRequest()` records `ctx.meta.contentStripStats` for a no-op request. That is an observability bug, not a payload corruption bug.
+- The new `content-strip` tests do not cover the documented reminder variants above, so the current regression escaped easily.
+
+## Recommendations
+- Align `BOOKKEEPING_PATTERNS` in `content-strip` with the documented bookkeeping matcher already used in `preload.mjs`, then add tests for TodoWrite, remaining-turn counters, and auto-compact counters.
+- Change the strip counters to increment only when a block is actually removed from the outbound payload after the empty-content safeguard is applied, or recompute stats from the final transformed message set.
+
+## Bottom Line
+Revise before approval. `tool-input-normalize` looks correct for the requested behavior, and `content-strip` gets the continue-trailer handling right, but the reminder matcher is incomplete relative to the repo’s documented bookkeeping formats and should be fixed before this ships.

--- a/proxy/extensions/content-strip.mjs
+++ b/proxy/extensions/content-strip.mjs
@@ -6,6 +6,9 @@ const BOOKKEEPING_PATTERNS = [
   /^Output tokens — turn: [^\n]+ · session: [^\n]+\s*$/,
   /^USD budget: \$[\d.]+\/\$[\d.]+; \$[\d.]+ remaining\s*$/,
   /^The task tools haven't been used recently\./,
+  /^The TodoWrite tool hasn't been used recently\./,
+  /^Remaining conversation turns: /,
+  /^Messages? until auto-compact: /,
 ];
 
 function isContinueTrailerBlock(block) {
@@ -37,20 +40,25 @@ function stripContentBlocks(messages) {
   const result = messages.map((msg) => {
     if (msg.role !== "user" || !Array.isArray(msg.content)) return msg;
 
+    let msgTrailers = 0;
+    let msgReminders = 0;
+
     const kept = msg.content.filter((block) => {
       if (isContinueTrailerBlock(block)) {
-        trailerCount++;
+        msgTrailers++;
         return false;
       }
       if (block.type === "text" && isBookkeepingReminder(block.text)) {
-        reminderCount++;
+        msgReminders++;
         return false;
       }
       return true;
     });
 
-    if (kept.length === 0) return msg;
-    if (kept.length === msg.content.length) return msg;
+    if (kept.length === 0 || kept.length === msg.content.length) return msg;
+
+    trailerCount += msgTrailers;
+    reminderCount += msgReminders;
     return { ...msg, content: kept };
   });
 

--- a/proxy/extensions/content-strip.mjs
+++ b/proxy/extensions/content-strip.mjs
@@ -1,0 +1,81 @@
+const CONTINUE_TRAILER_TEXT = "Continue from where you left off.";
+
+const REMINDER_WRAP_REGEX = /^<system-reminder>\n([\s\S]*?)\n<\/system-reminder>\s*$/;
+const BOOKKEEPING_PATTERNS = [
+  /^Token usage: \d+\/\d+; \d+ remaining\s*$/,
+  /^Output tokens — turn: [^\n]+ · session: [^\n]+\s*$/,
+  /^USD budget: \$[\d.]+\/\$[\d.]+; \$[\d.]+ remaining\s*$/,
+  /^The task tools haven't been used recently\./,
+];
+
+function isContinueTrailerBlock(block) {
+  return (
+    !!block &&
+    typeof block === "object" &&
+    block.type === "text" &&
+    block.text === CONTINUE_TRAILER_TEXT
+  );
+}
+
+function isBookkeepingReminder(text) {
+  if (typeof text !== "string") return false;
+  const m = text.match(REMINDER_WRAP_REGEX);
+  if (!m) return false;
+  const inner = m[1];
+  for (const rx of BOOKKEEPING_PATTERNS) {
+    if (rx.test(inner)) return true;
+  }
+  return false;
+}
+
+function stripContentBlocks(messages) {
+  if (!Array.isArray(messages)) return { messages, stats: null };
+
+  let trailerCount = 0;
+  let reminderCount = 0;
+
+  const result = messages.map((msg) => {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) return msg;
+
+    const kept = msg.content.filter((block) => {
+      if (isContinueTrailerBlock(block)) {
+        trailerCount++;
+        return false;
+      }
+      if (block.type === "text" && isBookkeepingReminder(block.text)) {
+        reminderCount++;
+        return false;
+      }
+      return true;
+    });
+
+    if (kept.length === 0) return msg;
+    if (kept.length === msg.content.length) return msg;
+    return { ...msg, content: kept };
+  });
+
+  const total = trailerCount + reminderCount;
+  return {
+    messages: total > 0 ? result : messages,
+    stats: total > 0 ? { trailerCount, reminderCount } : null,
+  };
+}
+
+export { isContinueTrailerBlock, isBookkeepingReminder, stripContentBlocks };
+
+export default {
+  name: "content-strip",
+  description: "Strip continue trailers and bookkeeping system-reminders from user messages",
+  enabled: false,
+  order: 350,
+
+  async onRequest(ctx) {
+    if (!ctx.body.messages) return;
+
+    const { messages, stats } = stripContentBlocks(ctx.body.messages);
+    if (stats) {
+      ctx.body.messages = messages;
+      ctx.meta.contentStripStats = stats;
+    }
+  },
+};

--- a/proxy/extensions/tool-input-normalize.mjs
+++ b/proxy/extensions/tool-input-normalize.mjs
@@ -1,0 +1,73 @@
+function normalizeToolUseInputs(body) {
+  if (!body || typeof body !== "object") return 0;
+  if (!Array.isArray(body.messages) || !Array.isArray(body.tools)) return 0;
+
+  const toolSchemas = Object.create(null);
+  for (const tool of body.tools) {
+    if (!tool || typeof tool !== "object") continue;
+    const name = tool.name;
+    if (typeof name !== "string") continue;
+    const props = tool.input_schema?.properties;
+    if (!props || typeof props !== "object") continue;
+    toolSchemas[name] = Object.keys(props);
+  }
+
+  let modified = 0;
+  for (const msg of body.messages) {
+    if (!msg || msg.role !== "assistant") continue;
+    if (!Array.isArray(msg.content)) continue;
+    for (let i = 0; i < msg.content.length; i++) {
+      const block = msg.content[i];
+      if (!block || block.type !== "tool_use") continue;
+      if (!block.input || typeof block.input !== "object" || Array.isArray(block.input)) continue;
+      const schemaKeys = toolSchemas[block.name];
+      if (!schemaKeys) continue;
+
+      const currentKeys = Object.keys(block.input);
+      const schemaKeySet = new Set(schemaKeys);
+      const hasExtras = currentKeys.some((k) => !schemaKeySet.has(k));
+
+      const presentSchemaKeys = schemaKeys.filter((k) =>
+        Object.prototype.hasOwnProperty.call(block.input, k)
+      );
+      const currentInSchema = currentKeys.filter((k) => schemaKeySet.has(k));
+
+      let orderDiffers = presentSchemaKeys.length !== currentInSchema.length;
+      if (!orderDiffers) {
+        for (let j = 0; j < presentSchemaKeys.length; j++) {
+          if (presentSchemaKeys[j] !== currentInSchema[j]) {
+            orderDiffers = true;
+            break;
+          }
+        }
+      }
+
+      if (!hasExtras && !orderDiffers) continue;
+
+      const newInput = {};
+      for (const k of presentSchemaKeys) {
+        newInput[k] = block.input[k];
+      }
+      msg.content[i] = { ...block, input: newInput };
+      modified++;
+    }
+  }
+  return modified;
+}
+
+export { normalizeToolUseInputs };
+
+export default {
+  name: "tool-input-normalize",
+  description: "Normalize tool_use input field ordering to match schema for cache stability",
+  enabled: false,
+  order: 280,
+
+  async onRequest(ctx) {
+    if (!ctx.body.messages || !ctx.body.tools) return;
+    const count = normalizeToolUseInputs(ctx.body);
+    if (count > 0) {
+      ctx.meta.toolInputNormalizeCount = count;
+    }
+  },
+};

--- a/test/proxy-content-strip.test.mjs
+++ b/test/proxy-content-strip.test.mjs
@@ -1,0 +1,173 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import ext, {
+  isContinueTrailerBlock,
+  isBookkeepingReminder,
+  stripContentBlocks,
+} from "../proxy/extensions/content-strip.mjs";
+
+// --- isContinueTrailerBlock ---
+
+test("isContinueTrailerBlock: exact match", () => {
+  assert.ok(isContinueTrailerBlock({ type: "text", text: "Continue from where you left off." }));
+});
+
+test("isContinueTrailerBlock: rejects longer text", () => {
+  assert.ok(!isContinueTrailerBlock({ type: "text", text: "Continue from where you left off. Also do X." }));
+});
+
+test("isContinueTrailerBlock: rejects non-text type", () => {
+  assert.ok(!isContinueTrailerBlock({ type: "image", text: "Continue from where you left off." }));
+});
+
+test("isContinueTrailerBlock: rejects null/undefined", () => {
+  assert.ok(!isContinueTrailerBlock(null));
+  assert.ok(!isContinueTrailerBlock(undefined));
+});
+
+// --- isBookkeepingReminder ---
+
+test("isBookkeepingReminder: token usage", () => {
+  assert.ok(isBookkeepingReminder("<system-reminder>\nToken usage: 50000/200000; 150000 remaining\n</system-reminder>"));
+});
+
+test("isBookkeepingReminder: output tokens", () => {
+  assert.ok(isBookkeepingReminder("<system-reminder>\nOutput tokens — turn: 500 · session: 3000\n</system-reminder>"));
+});
+
+test("isBookkeepingReminder: USD budget", () => {
+  assert.ok(isBookkeepingReminder("<system-reminder>\nUSD budget: $5.00/$10.00; $5.00 remaining\n</system-reminder>"));
+});
+
+test("isBookkeepingReminder: task tools reminder", () => {
+  assert.ok(isBookkeepingReminder("<system-reminder>\nThe task tools haven't been used recently.\n</system-reminder>"));
+});
+
+test("isBookkeepingReminder: rejects non-bookkeeping", () => {
+  assert.ok(!isBookkeepingReminder("<system-reminder>\nImportant project context.\n</system-reminder>"));
+});
+
+test("isBookkeepingReminder: rejects non-reminder text", () => {
+  assert.ok(!isBookkeepingReminder("plain text"));
+});
+
+// --- stripContentBlocks ---
+
+test("stripContentBlocks: strips trailers", () => {
+  const messages = [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "real prompt" },
+        { type: "text", text: "Continue from where you left off." },
+      ],
+    },
+  ];
+  const { messages: result, stats } = stripContentBlocks(messages);
+  assert.equal(stats.trailerCount, 1);
+  assert.equal(result[0].content.length, 1);
+  assert.equal(result[0].content[0].text, "real prompt");
+});
+
+test("stripContentBlocks: strips reminders", () => {
+  const messages = [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "real prompt" },
+        { type: "text", text: "<system-reminder>\nToken usage: 100/200; 100 remaining\n</system-reminder>" },
+      ],
+    },
+  ];
+  const { messages: result, stats } = stripContentBlocks(messages);
+  assert.equal(stats.reminderCount, 1);
+  assert.equal(result[0].content.length, 1);
+});
+
+test("stripContentBlocks: does not empty message content", () => {
+  const messages = [
+    {
+      role: "user",
+      content: [{ type: "text", text: "Continue from where you left off." }],
+    },
+  ];
+  const { messages: result } = stripContentBlocks(messages);
+  assert.equal(result[0].content.length, 1, "should preserve when stripping would empty");
+});
+
+test("stripContentBlocks: no-op on assistant messages", () => {
+  const messages = [
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "Continue from where you left off." }],
+    },
+  ];
+  const { stats } = stripContentBlocks(messages);
+  assert.equal(stats, null);
+});
+
+test("stripContentBlocks: strips both trailers and reminders in same message", () => {
+  const messages = [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "real content" },
+        { type: "text", text: "Continue from where you left off." },
+        { type: "text", text: "<system-reminder>\nUSD budget: $1.00/$10.00; $9.00 remaining\n</system-reminder>" },
+      ],
+    },
+  ];
+  const { messages: result, stats } = stripContentBlocks(messages);
+  assert.equal(stats.trailerCount, 1);
+  assert.equal(stats.reminderCount, 1);
+  assert.equal(result[0].content.length, 1);
+});
+
+test("stripContentBlocks: no-op when nothing to strip", () => {
+  const messages = [
+    { role: "user", content: [{ type: "text", text: "normal message" }] },
+  ];
+  const { stats } = stripContentBlocks(messages);
+  assert.equal(stats, null);
+});
+
+test("stripContentBlocks: handles null input", () => {
+  const { stats } = stripContentBlocks(null);
+  assert.equal(stats, null);
+});
+
+// --- onRequest ---
+
+test("onRequest: strips content and sets stats", async () => {
+  const ctx = {
+    body: {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "prompt" },
+            { type: "text", text: "Continue from where you left off." },
+          ],
+        },
+      ],
+    },
+    headers: {},
+    meta: {},
+  };
+
+  await ext.onRequest(ctx);
+  assert.ok(ctx.meta.contentStripStats);
+  assert.equal(ctx.meta.contentStripStats.trailerCount, 1);
+  assert.equal(ctx.body.messages[0].content.length, 1);
+});
+
+test("onRequest: no-op when nothing to strip", async () => {
+  const ctx = {
+    body: { messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }] },
+    headers: {},
+    meta: {},
+  };
+
+  await ext.onRequest(ctx);
+  assert.equal(ctx.meta.contentStripStats, undefined);
+});

--- a/test/proxy-content-strip.test.mjs
+++ b/test/proxy-content-strip.test.mjs
@@ -43,6 +43,18 @@ test("isBookkeepingReminder: task tools reminder", () => {
   assert.ok(isBookkeepingReminder("<system-reminder>\nThe task tools haven't been used recently.\n</system-reminder>"));
 });
 
+test("isBookkeepingReminder: TodoWrite reminder", () => {
+  assert.ok(isBookkeepingReminder("<system-reminder>\nThe TodoWrite tool hasn't been used recently.\n</system-reminder>"));
+});
+
+test("isBookkeepingReminder: remaining turns", () => {
+  assert.ok(isBookkeepingReminder("<system-reminder>\nRemaining conversation turns: 42\n</system-reminder>"));
+});
+
+test("isBookkeepingReminder: messages until auto-compact", () => {
+  assert.ok(isBookkeepingReminder("<system-reminder>\nMessages until auto-compact: 5\n</system-reminder>"));
+});
+
 test("isBookkeepingReminder: rejects non-bookkeeping", () => {
   assert.ok(!isBookkeepingReminder("<system-reminder>\nImportant project context.\n</system-reminder>"));
 });
@@ -84,15 +96,16 @@ test("stripContentBlocks: strips reminders", () => {
   assert.equal(result[0].content.length, 1);
 });
 
-test("stripContentBlocks: does not empty message content", () => {
+test("stripContentBlocks: does not empty message content and does not count", () => {
   const messages = [
     {
       role: "user",
       content: [{ type: "text", text: "Continue from where you left off." }],
     },
   ];
-  const { messages: result } = stripContentBlocks(messages);
+  const { messages: result, stats } = stripContentBlocks(messages);
   assert.equal(result[0].content.length, 1, "should preserve when stripping would empty");
+  assert.equal(stats, null, "should not report stats when nothing was actually stripped");
 });
 
 test("stripContentBlocks: no-op on assistant messages", () => {

--- a/test/proxy-tool-input-normalize.test.mjs
+++ b/test/proxy-tool-input-normalize.test.mjs
@@ -1,0 +1,131 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import ext, { normalizeToolUseInputs } from "../proxy/extensions/tool-input-normalize.mjs";
+
+function makeBody(tools, messages) {
+  return { tools, messages };
+}
+
+const TOOLS = [
+  { name: "Read", input_schema: { properties: { file_path: {}, offset: {}, limit: {} } } },
+  { name: "Write", input_schema: { properties: { file_path: {}, content: {} } } },
+];
+
+// --- Unit tests ---
+
+test("normalizeToolUseInputs: reorders keys to match schema", () => {
+  const body = makeBody(TOOLS, [
+    {
+      role: "assistant",
+      content: [
+        { type: "tool_use", name: "Read", input: { limit: 10, file_path: "/tmp/x", offset: 0 } },
+      ],
+    },
+  ]);
+
+  const count = normalizeToolUseInputs(body);
+  assert.equal(count, 1);
+  const keys = Object.keys(body.messages[0].content[0].input);
+  assert.deepEqual(keys, ["file_path", "offset", "limit"]);
+});
+
+test("normalizeToolUseInputs: strips extra keys not in schema", () => {
+  const body = makeBody(TOOLS, [
+    {
+      role: "assistant",
+      content: [
+        { type: "tool_use", name: "Write", input: { content: "hi", file_path: "/tmp/x", _extra: true } },
+      ],
+    },
+  ]);
+
+  const count = normalizeToolUseInputs(body);
+  assert.equal(count, 1);
+  const input = body.messages[0].content[0].input;
+  assert.ok(!("_extra" in input), "extra key should be stripped");
+  assert.deepEqual(Object.keys(input), ["file_path", "content"]);
+});
+
+test("normalizeToolUseInputs: no-op when already canonical", () => {
+  const body = makeBody(TOOLS, [
+    {
+      role: "assistant",
+      content: [
+        { type: "tool_use", name: "Read", input: { file_path: "/tmp/x", offset: 0, limit: 10 } },
+      ],
+    },
+  ]);
+
+  assert.equal(normalizeToolUseInputs(body), 0);
+});
+
+test("normalizeToolUseInputs: skips unknown tools", () => {
+  const body = makeBody(TOOLS, [
+    {
+      role: "assistant",
+      content: [
+        { type: "tool_use", name: "UnknownTool", input: { z: 1, a: 2 } },
+      ],
+    },
+  ]);
+
+  assert.equal(normalizeToolUseInputs(body), 0);
+});
+
+test("normalizeToolUseInputs: skips user messages", () => {
+  const body = makeBody(TOOLS, [
+    {
+      role: "user",
+      content: [
+        { type: "tool_use", name: "Read", input: { limit: 1, file_path: "/x" } },
+      ],
+    },
+  ]);
+
+  assert.equal(normalizeToolUseInputs(body), 0);
+});
+
+test("normalizeToolUseInputs: handles missing/null body", () => {
+  assert.equal(normalizeToolUseInputs(null), 0);
+  assert.equal(normalizeToolUseInputs({}), 0);
+  assert.equal(normalizeToolUseInputs({ messages: [], tools: [] }), 0);
+});
+
+test("normalizeToolUseInputs: handles partial schema keys", () => {
+  const body = makeBody(TOOLS, [
+    {
+      role: "assistant",
+      content: [
+        { type: "tool_use", name: "Read", input: { file_path: "/tmp/x" } },
+      ],
+    },
+  ]);
+
+  assert.equal(normalizeToolUseInputs(body), 0, "subset in correct order = no-op");
+});
+
+// --- onRequest ---
+
+test("onRequest: normalizes and sets count in meta", async () => {
+  const ctx = {
+    body: makeBody(TOOLS, [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", name: "Read", input: { limit: 5, offset: 0, file_path: "/x" } },
+        ],
+      },
+    ]),
+    headers: {},
+    meta: {},
+  };
+
+  await ext.onRequest(ctx);
+  assert.equal(ctx.meta.toolInputNormalizeCount, 1);
+});
+
+test("onRequest: no-op when no tools or messages", async () => {
+  const ctx = { body: {}, headers: {}, meta: {} };
+  await ext.onRequest(ctx);
+  assert.equal(ctx.meta.toolInputNormalizeCount, undefined);
+});


### PR DESCRIPTION
Ports three preload features to proxy extensions. Items 3, 4, and 7 from #59.

**content-strip** (order 350): Strips continue trailers (`Continue from where you left off.`) and bookkeeping system-reminders (token usage, output tokens, USD budget, task tools nudge) from user messages. Guards against emptying content arrays. 19 tests.

**tool-input-normalize** (order 280): Reorders `tool_use` input keys to match schema declaration order, strips extra keys not in schema. Ensures cache-stable JSON serialization across turns. 9 tests.

Both disabled by default. 320 total tests, 0 failures.

Ref: #59

— AI Team Lead