### PR TITLE
feat: smoosh-split + usage-log proxy extensions (#59 items 5,8)

### DIFF
--- a/proxy/extensions/smoosh-split.mjs
+++ b/proxy/extensions/smoosh-split.mjs
@@ -1,0 +1,68 @@
+const TRAILING_SMOOSH = /\n\n(<system-reminder>\n(?:(?!<\/system-reminder>)[\s\S])*?\n<\/system-reminder>)\s*$/;
+
+function splitSmooshedReminders(messages) {
+  if (!Array.isArray(messages)) return { messages, stats: null };
+
+  let totalPeeled = 0;
+
+  const result = messages.map((msg) => {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) return msg;
+
+    const out = [];
+    const peeledReminders = [];
+    let mutated = false;
+
+    for (const block of msg.content) {
+      if (block?.type === "tool_result" && typeof block.content === "string") {
+        const reminders = [];
+        let s = block.content;
+        while (true) {
+          const m = s.match(TRAILING_SMOOSH);
+          if (!m) break;
+          reminders.unshift(m[1]);
+          s = s.slice(0, m.index);
+        }
+        if (reminders.length > 0) {
+          out.push({ ...block, content: s });
+          for (const r of reminders) peeledReminders.push({ type: "text", text: r });
+          totalPeeled += reminders.length;
+          mutated = true;
+          continue;
+        }
+      }
+      out.push(block);
+    }
+
+    if (mutated) {
+      return { ...msg, content: [...out, ...peeledReminders] };
+    }
+    return msg;
+  });
+
+  return {
+    messages: totalPeeled > 0 ? result : messages,
+    stats: totalPeeled > 0 ? { peeled: totalPeeled } : null,
+  };
+}
+
+export { splitSmooshedReminders, TRAILING_SMOOSH };
+
+export default {
+  name: "smoosh-split",
+  description: "Peel smooshed system-reminders from tool_result content into standalone blocks",
+  enabled: false,
+  order: 320,
+
+  async onRequest(ctx) {
+    if (!ctx.body.messages) return;
+
+    const { messages, stats } = splitSmooshedReminders(ctx.body.messages);
+    if (stats) {
+      ctx.body.messages = messages;
+      ctx.meta.smooshSplitStats = stats;
+      process.stderr.write(
+        `[smoosh-split] peeled ${stats.peeled} reminder(s) from tool_result.content\n`
+      );
+    }
+  },
+};

--- a/proxy/extensions/usage-log.mjs
+++ b/proxy/extensions/usage-log.mjs
@@ -1,0 +1,46 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const LOG_PATH = process.env.CACHE_FIX_USAGE_LOG || join(homedir(), ".claude", "usage.jsonl");
+
+function buildRecord(meta, telemetry, responseHeaders) {
+  const now = new Date();
+  const utcHour = now.getUTCHours();
+  const utcDay = now.getUTCDay();
+
+  const stats = meta.cacheStats || {};
+  const quota = meta._quotaData || {};
+
+  return {
+    timestamp: now.toISOString(),
+    model: telemetry.model || "unknown",
+    input_tokens: stats.inputTokens || 0,
+    output_tokens: stats.outputTokens || 0,
+    cache_read_input_tokens: stats.cacheRead || 0,
+    cache_creation_input_tokens: stats.cacheCreation || 0,
+    q5h_pct: quota.five_hour ? quota.five_hour.pct : null,
+    q7d_pct: quota.seven_day ? quota.seven_day.pct : null,
+    peak_hour: utcDay >= 1 && utcDay <= 5 && utcHour >= 13 && utcHour < 19,
+  };
+}
+
+export { buildRecord, LOG_PATH };
+
+export default {
+  name: "usage-log",
+  description: "Append per-call usage record to ~/.claude/usage.jsonl",
+  enabled: false,
+  order: 650,
+
+  async onStreamEvent(ctx) {
+    if (!ctx.event || ctx.event.type !== "message_delta" || !ctx.event.usage) return;
+
+    const record = buildRecord(ctx.meta, ctx.telemetry || {}, ctx.responseHeaders);
+
+    try {
+      await mkdir(join(homedir(), ".claude"), { recursive: true });
+      await appendFile(LOG_PATH, JSON.stringify(record) + "\n");
+    } catch {}
+  },
+};

--- a/test/proxy-smoosh-split.test.mjs
+++ b/test/proxy-smoosh-split.test.mjs
@@ -1,0 +1,177 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import ext, { splitSmooshedReminders } from "../proxy/extensions/smoosh-split.mjs";
+
+function toolResult(id, content) {
+  return { type: "tool_result", tool_use_id: id, content };
+}
+
+const REMINDER = "<system-reminder>\nToken usage: 50000/200000; 150000 remaining\n</system-reminder>";
+const HOOK_REMINDER = "<system-reminder>\nHook output: custom data here\n</system-reminder>";
+
+// --- Unit tests ---
+
+test("splitSmooshedReminders: peels single trailing reminder", () => {
+  const messages = [
+    {
+      role: "user",
+      content: [
+        toolResult("t1", "tool output text\n\n" + REMINDER),
+      ],
+    },
+  ];
+  const { messages: result, stats } = splitSmooshedReminders(messages);
+  assert.ok(stats);
+  assert.equal(stats.peeled, 1);
+  assert.equal(result[0].content[0].content, "tool output text");
+  assert.equal(result[0].content[1].type, "text");
+  assert.ok(result[0].content[1].text.includes("Token usage"));
+});
+
+test("splitSmooshedReminders: peels multiple trailing reminders", () => {
+  const messages = [
+    {
+      role: "user",
+      content: [
+        toolResult("t1", "output\n\n" + REMINDER + "\n\n" + HOOK_REMINDER),
+      ],
+    },
+  ];
+  const { messages: result, stats } = splitSmooshedReminders(messages);
+  assert.equal(stats.peeled, 2);
+  assert.equal(result[0].content[0].content, "output");
+  assert.equal(result[0].content.length, 3); // original + 2 peeled
+});
+
+test("splitSmooshedReminders: preserves peeled reminder order", () => {
+  const messages = [
+    {
+      role: "user",
+      content: [
+        toolResult("t1", "output\n\n" + REMINDER + "\n\n" + HOOK_REMINDER),
+      ],
+    },
+  ];
+  const { messages: result } = splitSmooshedReminders(messages);
+  assert.ok(result[0].content[1].text.includes("Token usage"), "first peeled should be token usage");
+  assert.ok(result[0].content[2].text.includes("Hook output"), "second peeled should be hook");
+});
+
+test("splitSmooshedReminders: no-op when no smooshed content", () => {
+  const messages = [
+    {
+      role: "user",
+      content: [
+        toolResult("t1", "clean tool output with no reminders"),
+      ],
+    },
+  ];
+  const { stats } = splitSmooshedReminders(messages);
+  assert.equal(stats, null);
+});
+
+test("splitSmooshedReminders: no-op for array tool_result content", () => {
+  const messages = [
+    {
+      role: "user",
+      content: [
+        { type: "tool_result", tool_use_id: "t1", content: [{ type: "text", text: "array content" }] },
+      ],
+    },
+  ];
+  const { stats } = splitSmooshedReminders(messages);
+  assert.equal(stats, null);
+});
+
+test("splitSmooshedReminders: skips assistant messages", () => {
+  const messages = [
+    {
+      role: "assistant",
+      content: [
+        toolResult("t1", "output\n\n" + REMINDER),
+      ],
+    },
+  ];
+  const { stats } = splitSmooshedReminders(messages);
+  assert.equal(stats, null);
+});
+
+test("splitSmooshedReminders: peeled reminders go after all tool_results", () => {
+  const messages = [
+    {
+      role: "user",
+      content: [
+        toolResult("t1", "output1\n\n" + REMINDER),
+        toolResult("t2", "output2"),
+        { type: "text", text: "user prompt" },
+      ],
+    },
+  ];
+  const { messages: result } = splitSmooshedReminders(messages);
+  // Order: t1 (cleaned), t2, user prompt, peeled reminder
+  assert.equal(result[0].content[0].type, "tool_result");
+  assert.equal(result[0].content[0].content, "output1");
+  assert.equal(result[0].content[1].type, "tool_result");
+  assert.equal(result[0].content[2].type, "text");
+  assert.equal(result[0].content[2].text, "user prompt");
+  assert.equal(result[0].content[3].type, "text");
+  assert.ok(result[0].content[3].text.includes("Token usage"));
+});
+
+test("splitSmooshedReminders: does not match mid-content reminders", () => {
+  const content = REMINDER + "\n\nsome text after reminder";
+  const messages = [
+    { role: "user", content: [toolResult("t1", content)] },
+  ];
+  const { stats } = splitSmooshedReminders(messages);
+  assert.equal(stats, null, "should only match trailing reminders");
+});
+
+test("splitSmooshedReminders: handles null input", () => {
+  const { stats } = splitSmooshedReminders(null);
+  assert.equal(stats, null);
+});
+
+test("splitSmooshedReminders: handles empty messages", () => {
+  const { stats } = splitSmooshedReminders([]);
+  assert.equal(stats, null);
+});
+
+// --- onRequest ---
+
+test("onRequest: splits and sets stats", async () => {
+  const ctx = {
+    body: {
+      messages: [
+        {
+          role: "user",
+          content: [
+            toolResult("t1", "output\n\n" + REMINDER),
+          ],
+        },
+      ],
+    },
+    headers: {},
+    meta: {},
+  };
+
+  await ext.onRequest(ctx);
+  assert.ok(ctx.meta.smooshSplitStats);
+  assert.equal(ctx.meta.smooshSplitStats.peeled, 1);
+  assert.equal(ctx.body.messages[0].content.length, 2);
+});
+
+test("onRequest: no-op when nothing to split", async () => {
+  const ctx = {
+    body: {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+      ],
+    },
+    headers: {},
+    meta: {},
+  };
+
+  await ext.onRequest(ctx);
+  assert.equal(ctx.meta.smooshSplitStats, undefined);
+});

--- a/test/proxy-usage-log.test.mjs
+++ b/test/proxy-usage-log.test.mjs
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import ext, { buildRecord } from "../proxy/extensions/usage-log.mjs";
+
+// --- Unit tests ---
+
+test("buildRecord: produces complete record with all fields", () => {
+  const meta = {
+    cacheStats: { inputTokens: 5, outputTokens: 100, cacheRead: 300000, cacheCreation: 500 },
+    _quotaData: {
+      five_hour: { pct: 25 },
+      seven_day: { pct: 5 },
+    },
+  };
+  const telemetry = { model: "claude-opus-4-7" };
+
+  const record = buildRecord(meta, telemetry, {});
+
+  assert.equal(record.model, "claude-opus-4-7");
+  assert.equal(record.input_tokens, 5);
+  assert.equal(record.output_tokens, 100);
+  assert.equal(record.cache_read_input_tokens, 300000);
+  assert.equal(record.cache_creation_input_tokens, 500);
+  assert.equal(record.q5h_pct, 25);
+  assert.equal(record.q7d_pct, 5);
+  assert.equal(typeof record.timestamp, "string");
+  assert.equal(typeof record.peak_hour, "boolean");
+});
+
+test("buildRecord: handles missing cache stats", () => {
+  const record = buildRecord({}, {}, {});
+  assert.equal(record.input_tokens, 0);
+  assert.equal(record.output_tokens, 0);
+  assert.equal(record.cache_read_input_tokens, 0);
+  assert.equal(record.model, "unknown");
+  assert.equal(record.q5h_pct, null);
+});
+
+test("buildRecord: handles missing quota data", () => {
+  const meta = {
+    cacheStats: { cacheRead: 100 },
+  };
+  const record = buildRecord(meta, { model: "test" }, {});
+  assert.equal(record.q5h_pct, null);
+  assert.equal(record.q7d_pct, null);
+});
+
+// --- onStreamEvent ---
+
+test("onStreamEvent: triggers on message_delta with usage", async () => {
+  const ctx = {
+    event: { type: "message_delta", usage: { output_tokens: 50 } },
+    telemetry: { model: "claude-opus-4-7" },
+    meta: {
+      cacheStats: { inputTokens: 1, outputTokens: 50, cacheRead: 200000, cacheCreation: 300 },
+      _quotaData: { five_hour: { pct: 10 }, seven_day: { pct: 3 } },
+    },
+    responseHeaders: {},
+  };
+
+  // Extension writes to file — just verify it doesn't throw
+  await ext.onStreamEvent(ctx);
+});
+
+test("onStreamEvent: skips non-message_delta events", async () => {
+  const ctx = {
+    event: { type: "message_start", message: {} },
+    telemetry: {},
+    meta: {},
+  };
+
+  await ext.onStreamEvent(ctx);
+  // No error = pass
+});
+
+test("onStreamEvent: skips message_delta without usage", async () => {
+  const ctx = {
+    event: { type: "message_delta" },
+    telemetry: {},
+    meta: {},
+  };
+
+  await ext.onStreamEvent(ctx);
+});
+
+test("onStreamEvent: skips null event", async () => {
+  const ctx = { event: null, telemetry: {}, meta: {} };
+  await ext.onStreamEvent(ctx);
+});


### PR DESCRIPTION
Ports two more preload features to proxy extensions. Items 5 and 8 from #59.

**smoosh-split** (order 320): CC's `smooshSystemReminderSiblings` folds `<system-reminder>` text blocks adjacent to `tool_result` into the tool result's content string. This extension peels them back out into standalone text blocks — the pre-smoosh shape. Dynamic reminder drift now lives in small blocks instead of multi-KB tool result strings, improving cache prefix stability. 12 tests.

**usage-log** (order 650): Appends a per-call JSONL record to `~/.claude/usage.jsonl` with model, token counts, cache stats, Q5h/Q7d quota, and peak hour flag. Replaces claude-meter's JSONL logging for Bun binary users who can't load NODE_OPTIONS preloads. 7 tests.

Both disabled by default. 311 total tests, 0 failures.

Ref: #59

— AI Team Lead