### PR TITLE
Directive: port prefix-diff to proxy extension (#59 item 9)

### DIFF
--- a/docs/code-reviews/pr-65-prefix-diff-impl-review-2026-04-24.md
+++ b/docs/code-reviews/pr-65-prefix-diff-impl-review-2026-04-24.md
@@ -39,3 +39,6 @@ None.
 
 Approve for merge. The implementation is correct, non-mutating, fail-open, and well-covered on the important behavioral paths. The only material mismatch I found is between the written directive and the loader realities around `enabled`; that is a spec/documentation consistency issue, not an implementation blocker.
 
+## Follow-up verified
+
+2026-04-24: Verified commit `d480ef0` addressed the three nits and two nice-to-haves from this review. Confirmed the orphan `.tmp` comment and named-export test-seam note in [proxy/extensions/prefix-diff.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/prefix-diff.mjs), the deterministic debug-log and stronger concurrency assertions in [test/proxy-prefix-diff.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/proxy-prefix-diff.test.mjs), and the `enabled: true` directive reconciliation in [docs/directives/proxy-prefix-diff.md](/home/manager/git_repos/claude-code-cache-fix/docs/directives/proxy-prefix-diff.md). Targeted test file passes locally.

--- a/docs/code-reviews/pr-65-prefix-diff-impl-review-2026-04-24.md
+++ b/docs/code-reviews/pr-65-prefix-diff-impl-review-2026-04-24.md
@@ -1,0 +1,41 @@
+# Review: prefix-diff proxy extension implementation
+
+Date: 2026-04-24
+Reviewed: `proxy/extensions/prefix-diff.mjs`, `test/proxy-prefix-diff.test.mjs`, `docs/directives/proxy-prefix-diff.md`
+Label applied: `approved-by-codex-agent`
+
+## What Is Correct
+
+- The core port is faithful to the directive's intended behavior: the extension snapshots only diagnostic state, never mutates `ctx.body`, computes per-call diffs against the prior on-disk snapshot, and keeps failures fail-open inside `onRequest()` and `snapshotPrefix()` ([proxy/extensions/prefix-diff.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/prefix-diff.mjs:175), [proxy/extensions/prefix-diff.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/prefix-diff.mjs:261)).
+- The pure helper/test-seam split is functionally correct. The runtime pipeline contract is the `default` export, while the named exports exist to support direct tests of the helper logic. The implementation does not leak those helpers into pipeline loading because the loader only consumes `mod.default` ([proxy/extensions/prefix-diff.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/prefix-diff.mjs:242), [proxy/pipeline.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/pipeline.mjs:20)).
+- The atomic-write approach is sound for the problem it needs to solve. Writing to a unique temp path and then renaming prevents torn visibility of `*-last.json` / `*-diff.json` while also avoiding a shared-temp-path collision between concurrent calls. This does not serialize writers, but it does preserve the important invariant: readers either see the old complete file or the new complete file, never a partial JSON blob ([proxy/extensions/prefix-diff.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/prefix-diff.mjs:144)).
+- The `enabled: true` deviation is reasonable under the current extension loader. `loadExtensions()` only registers modules whose default export resolves enabled, so `enabled: false` would prevent `CACHE_FIX_PREFIXDIFF=1` from ever taking effect unless `extensions.json` were also changed. Given the directive's acceptance criterion that the env var alone should activate the diagnostic, the code's behavior is the coherent one and the directive text is the part that needs reconciliation ([docs/directives/proxy-prefix-diff.md](/home/manager/git_repos/claude-code-cache-fix/docs/directives/proxy-prefix-diff.md:71), [proxy/extensions/prefix-diff.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/prefix-diff.mjs:255), [proxy/pipeline.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/pipeline.mjs:24)).
+- Test coverage is good on the main acceptance path. The new suite exercises snapshot construction, diffing, corruption tolerance, rename failure, concurrent writes, hot-reload behavior, and no-mutation behavior; the full repository test run is also green.
+
+## Findings
+
+### Blockers
+
+None.
+
+### Nits
+
+- The directive and implementation still disagree on activation semantics. The code's `enabled: true` choice is correct for the current loader, but the directive still says `enabled: false`, so the written spec no longer matches the shipped behavior ([docs/directives/proxy-prefix-diff.md](/home/manager/git_repos/claude-code-cache-fix/docs/directives/proxy-prefix-diff.md:71), [proxy/extensions/prefix-diff.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/prefix-diff.mjs:258)).
+- The debug-log acceptance case is not deterministically asserted. The directive asked for a test that proves swallowed mkdir/write failures log when `CACHE_FIX_DEBUG=1`, but the current test only checks stderr conditionally if that env var happened to be set before module import, so this requirement is effectively unverified in normal CI runs ([docs/directives/proxy-prefix-diff.md](/home/manager/git_repos/claude-code-cache-fix/docs/directives/proxy-prefix-diff.md:100), [test/proxy-prefix-diff.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/proxy-prefix-diff.test.mjs:380)).
+- The temp-file comment slightly overstates cleanup behavior. With unique temp names, a failed rename leaves an orphan `.tmp` that will not be "cleaned up implicitly by overwriting" on a later call; later calls create different temp names. The implementation is still acceptable, but the comment should describe the leak accurately ([proxy/extensions/prefix-diff.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/prefix-diff.mjs:149)).
+
+### Nice-to-haves
+
+- Add a short comment above the named exports clarifying that they are internal test seams and not part of the proxy extension contract. The current distinction is inferable from the loader and from the JSDoc, but not stated plainly at the export site ([proxy/extensions/prefix-diff.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/prefix-diff.mjs:242)).
+- Strengthen the concurrency test so it asserts the final `*-last.json` matches one of the two candidate snapshots instead of only asserting that the JSON parses. The current test proves no torn write, but not that the final winner is one of the expected payloads ([test/proxy-prefix-diff.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/proxy-prefix-diff.test.mjs:318)).
+
+## Recommendations
+
+- Update the directive text to match the implementation's `enabled: true` runtime-gated activation model, unless the project wants to change pipeline semantics globally.
+- Make the debug-path test deterministic by re-importing the module with `CACHE_FIX_DEBUG=1` set, the same way the hot-reload test already re-imports to validate state-free behavior.
+- Tighten the temp-file comment and, if desired later, add best-effort orphan cleanup as a follow-up rather than in this PR.
+
+## Bottom Line
+
+Approve for merge. The implementation is correct, non-mutating, fail-open, and well-covered on the important behavioral paths. The only material mismatch I found is between the written directive and the loader realities around `enabled`; that is a spec/documentation consistency issue, not an implementation blocker.
+

--- a/docs/directives/proxy-prefix-diff.md
+++ b/docs/directives/proxy-prefix-diff.md
@@ -68,7 +68,7 @@ Trade-off: more disk writes, but the writes are tiny (one small JSON per call wh
 - File: `proxy/extensions/prefix-diff.mjs`
 - `name`: `"prefix-diff"`
 - `description`: `"Snapshot prefix (first 5 msgs + system + tools) and diff against previous run for cache-bust hunting"`
-- `enabled`: `false` (opt-in via `CACHE_FIX_PREFIXDIFF=1`)
+- `enabled`: `true` (module default). The extension is cheap to load but does nothing unless `CACHE_FIX_PREFIXDIFF=1` is set — the env var is the only user-facing gate. (Original draft specified `enabled: false`, but that would require a second opt-in via `extensions.json`; the acceptance criterion — env var alone activates — is cleaner and matches how `image-strip` / `usage-log` similarly gate at runtime.)
 - `order`: `680` (sits between `usage-log` at 650 and `request-log` at 700 — observability, not request mutation)
 - Hook: `onRequest(ctx)` — read `ctx.body`, compute snapshot/diff, write to disk, never mutate `ctx.body`
 

--- a/docs/directives/proxy-prefix-diff.md
+++ b/docs/directives/proxy-prefix-diff.md
@@ -1,0 +1,92 @@
+# Directive: Port `prefix-diff` to proxy extension
+
+**Issue:** #59 item 9
+**Branch:** `feature/proxy-prefix-diff`
+**Stage:** directive
+
+## Goal
+
+Port the `CACHE_FIX_PREFIXDIFF` diagnostic from `preload.mjs` to a proxy extension. Pure observability — no request modification.
+
+## Why
+
+Users on CC v2.1.113+ (Bun binary) cannot load the Node `--import` preload, so all preload-only diagnostics are invisible to them. Prefix-diff is the most useful tool we have for hunting cache-bust sources at the prefix level (first 5 messages + system + tools), and it deserves to work for proxy users.
+
+## Reference (preload behavior to mirror)
+
+- `preload.mjs` lines ~1656–1742 (`snapshotPrefix(payload)`)
+- Env var: `CACHE_FIX_PREFIXDIFF=1` (opt-in, off by default)
+- Snapshot dir: `~/.claude/cache-fix-snapshots/`
+- Session key: `sha256(JSON.stringify(payload.system).slice(0, 2000)).slice(0, 12)` — stable across restarts for the same project, different per project
+- On every call: write current snapshot to `<key>-last.json`
+- On the **first call after extension boot only**: read previous `<key>-last.json`, compute diff against current, write to `<key>-diff.json`, log a one-line debug summary
+
+### Snapshot shape
+
+```json
+{
+  "timestamp": "<ISO>",
+  "messageCount": <int>,
+  "toolsHash": "<sha256(tool names).slice(0,16)>",
+  "systemHash": "<sha256(system).slice(0,16)>",
+  "prefixMessages": [
+    { "role": "...", "content": [/* first 5 msgs, cache_control stripped, text >500 chars truncated with `...[N chars]` marker */] }
+  ]
+}
+```
+
+### Diff shape
+
+```json
+{
+  "timestamp": "<ISO>",
+  "prevTimestamp": "<ISO>",
+  "toolsMatch": <bool>,
+  "systemMatch": <bool>,
+  "messageCountPrev": <int>,
+  "messageCountNow": <int>,
+  "prefixDiffs": [
+    { "index": <int>, "prev": <msg|null>, "now": <msg|null> }
+  ]
+}
+```
+
+## Extension contract
+
+- File: `proxy/extensions/prefix-diff.mjs`
+- `name`: `"prefix-diff"`
+- `description`: `"Snapshot prefix (first 5 msgs + system + tools) and diff against previous run for cache-bust hunting"`
+- `enabled`: `false` (opt-in via `CACHE_FIX_PREFIXDIFF=1` — extension is always loaded but no-ops unless env var is set, matching the preload pattern)
+- `order`: `750` (after `usage-log` at 650, before `request-log` at 700 — actually pick `680` to sit between them; this is observability, not request mutation)
+- Hook: `onRequest(ctx)` — read `ctx.body`, compute snapshot/diff, write to disk, never mutate `ctx.body`
+
+**Important:** must not throw on any I/O failure. Wrap snapshot/diff writes in try/catch and silently swallow. The preload version does the same — the diagnostic is best-effort.
+
+## Tests (in `test/proxy-prefix-diff.test.mjs`)
+
+1. Returns silently when `CACHE_FIX_PREFIXDIFF` is unset
+2. Writes `<key>-last.json` to a temp snapshot dir on first call when enabled
+3. Session key derives from `system` content (same system → same key, different system → different key)
+4. Truncates message text >500 chars with `...[N chars]` marker
+5. Strips `cache_control` from snapshotted blocks
+6. On second call (after temp file exists), produces a `<key>-diff.json` with non-zero `prefixDiffs` when prefix changed
+7. `toolsHash` / `systemHash` mismatch flips `toolsMatch` / `systemMatch` flags correctly
+8. Diff fires only on the first call per extension lifetime (subsequent calls only update `<key>-last.json`)
+9. Does not mutate `ctx.body` (assert structural equality before/after)
+10. Swallows write errors (point snapshot dir at `/dev/null/nope` and assert no throw)
+
+Use a per-test temp snapshot dir via `process.env.HOME = tmpdir()` or by exposing the snapshot dir path through env (preferred — add `CACHE_FIX_PREFIXDIFF_DIR` for test override; if unset, default to `~/.claude/cache-fix-snapshots/`).
+
+## Out of scope
+
+- No registration in `extensions.json` (extensions auto-load from `proxy/extensions/`)
+- No README changes (the README's "Diagnostic env vars" section will be touched in the deferred-tools-restore PR alongside the #10 update)
+
+## Acceptance
+
+- All new tests pass; full proxy test suite green
+- `CACHE_FIX_PREFIXDIFF=1 ANTHROPIC_BASE_URL=http://localhost:9801 claude` produces snapshot and diff files in `~/.claude/cache-fix-snapshots/`
+- `ctx.body` is never modified by this extension
+- Codex review with no blockers
+
+— AI Team Lead

--- a/docs/directives/proxy-prefix-diff.md
+++ b/docs/directives/proxy-prefix-diff.md
@@ -2,7 +2,7 @@
 
 **Issue:** #59 item 9
 **Branch:** `feature/proxy-prefix-diff`
-**Stage:** directive
+**Stage:** directive (revised after Codex review — see `docs/code-reviews/`)
 
 ## Goal
 
@@ -12,14 +12,26 @@ Port the `CACHE_FIX_PREFIXDIFF` diagnostic from `preload.mjs` to a proxy extensi
 
 Users on CC v2.1.113+ (Bun binary) cannot load the Node `--import` preload, so all preload-only diagnostics are invisible to them. Prefix-diff is the most useful tool we have for hunting cache-bust sources at the prefix level (first 5 messages + system + tools), and it deserves to work for proxy users.
 
-## Reference (preload behavior to mirror)
+## Adaptation from preload behavior
+
+The preload version's "diff fires once on the first API call after process restart" semantics do not translate cleanly to a long-lived proxy that supports hot-reload. The "first call" gate would either fire on every reload (false signal) or never fire after the initial boot (silent diagnostic). **The proxy version drops the first-call flag entirely and runs the diff comparison on every call**, writing a diff file only when there are actual differences.
+
+Trade-off: more disk writes, but the writes are tiny (one small JSON per call when something changed) and the diagnostic value is higher — drift can be observed across every turn, not just at startup. There is no concurrency race because each call's snapshot/diff is independent of the previous call's success.
+
+### Reference (preload behavior to mirror in spirit, not literally)
 
 - `preload.mjs` lines ~1656–1742 (`snapshotPrefix(payload)`)
 - Env var: `CACHE_FIX_PREFIXDIFF=1` (opt-in, off by default)
 - Snapshot dir: `~/.claude/cache-fix-snapshots/`
 - Session key: `sha256(JSON.stringify(payload.system).slice(0, 2000)).slice(0, 12)` — stable across restarts for the same project, different per project
-- On every call: write current snapshot to `<key>-last.json`
-- On the **first call after extension boot only**: read previous `<key>-last.json`, compute diff against current, write to `<key>-diff.json`, log a one-line debug summary
+
+### Per-call algorithm (revised)
+
+1. Build current snapshot from `ctx.body` (system hash, tools hash, first-5 messages with `cache_control` stripped and text >500 chars truncated).
+2. Read prior `<key>-last.json` if it exists. Treat unreadable/corrupt JSON as "no prior snapshot" (skip diff, proceed to write).
+3. If a prior snapshot existed and content differs from current → compute and write `<key>-diff.json`. Emit one-line debug log via `[prefix-diff] <key>: N differences, tools=match/DIFFER, system=match/DIFFER`.
+4. Atomically write the new `<key>-last.json` (write to `<key>-last.json.tmp`, then `rename` to final path) so a partial write never leaves a corrupt snapshot for the next call.
+5. Never throw. Wrap I/O in try/catch. **When `CACHE_FIX_DEBUG=1` is set, debug-log the swallowed error** so silent failures are still observable to users diagnosing the diagnostic.
 
 ### Snapshot shape
 
@@ -56,37 +68,47 @@ Users on CC v2.1.113+ (Bun binary) cannot load the Node `--import` preload, so a
 - File: `proxy/extensions/prefix-diff.mjs`
 - `name`: `"prefix-diff"`
 - `description`: `"Snapshot prefix (first 5 msgs + system + tools) and diff against previous run for cache-bust hunting"`
-- `enabled`: `false` (opt-in via `CACHE_FIX_PREFIXDIFF=1` — extension is always loaded but no-ops unless env var is set, matching the preload pattern)
-- `order`: `750` (after `usage-log` at 650, before `request-log` at 700 — actually pick `680` to sit between them; this is observability, not request mutation)
+- `enabled`: `false` (opt-in via `CACHE_FIX_PREFIXDIFF=1`)
+- `order`: `680` (sits between `usage-log` at 650 and `request-log` at 700 — observability, not request mutation)
 - Hook: `onRequest(ctx)` — read `ctx.body`, compute snapshot/diff, write to disk, never mutate `ctx.body`
 
-**Important:** must not throw on any I/O failure. Wrap snapshot/diff writes in try/catch and silently swallow. The preload version does the same — the diagnostic is best-effort.
+### Test seam (no public env var)
+
+The previous draft proposed `CACHE_FIX_PREFIXDIFF_DIR` for test isolation. **Drop it** — it's a test-only seam and shouldn't be a public runtime config knob. Instead:
+
+- The snapshot directory is computed by an internal helper `getSnapshotDir()` (not exported in `default`). The extension's `default` export is the production-shaped pipeline interface.
+- For tests, **export the underlying `snapshotPrefix(payload, options)` pure function** alongside `default`, where `options.dir` overrides the snapshot directory. Tests call this directly with a per-test `tmpdir()`. The default export's `onRequest` calls `snapshotPrefix(ctx.body, { dir: getSnapshotDir() })` internally.
+- This is the same pattern `image-strip.mjs` uses (exports `stripOldToolResultImages` alongside `default`).
 
 ## Tests (in `test/proxy-prefix-diff.test.mjs`)
 
-1. Returns silently when `CACHE_FIX_PREFIXDIFF` is unset
-2. Writes `<key>-last.json` to a temp snapshot dir on first call when enabled
-3. Session key derives from `system` content (same system → same key, different system → different key)
+Unit tests on the exported `snapshotPrefix(payload, options)`:
+
+1. No-op when env var unset (asserts via `default.onRequest` with env clean)
+2. Writes `<key>-last.json` to `options.dir` on first invocation
+3. Session key derives from `system` content (same system → same key; different system → different key)
 4. Truncates message text >500 chars with `...[N chars]` marker
 5. Strips `cache_control` from snapshotted blocks
-6. On second call (after temp file exists), produces a `<key>-diff.json` with non-zero `prefixDiffs` when prefix changed
-7. `toolsHash` / `systemHash` mismatch flips `toolsMatch` / `systemMatch` flags correctly
-8. Diff fires only on the first call per extension lifetime (subsequent calls only update `<key>-last.json`)
-9. Does not mutate `ctx.body` (assert structural equality before/after)
-10. Swallows write errors (point snapshot dir at `/dev/null/nope` and assert no throw)
-
-Use a per-test temp snapshot dir via `process.env.HOME = tmpdir()` or by exposing the snapshot dir path through env (preferred — add `CACHE_FIX_PREFIXDIFF_DIR` for test override; if unset, default to `~/.claude/cache-fix-snapshots/`).
+6. On second call when snapshot is unchanged → no diff file written; `<key>-last.json` is still rewritten (atomic)
+7. On second call when snapshot differs → `<key>-diff.json` written with non-zero `prefixDiffs`
+8. `toolsHash` / `systemHash` mismatch flips `toolsMatch` / `systemMatch` flags
+9. Atomic write: simulate a write that fails after `.tmp` exists (e.g., monkey-patch `rename` to throw); assert the prior `<key>-last.json` is still intact
+10. Corrupt prior snapshot (write `{not json` to `<key>-last.json`); next call must skip the diff and overwrite the snapshot, never throw
+11. Concurrent invocations on the same `payload`/`options.dir` — fire two `snapshotPrefix` calls in parallel, await both; assert no throw and final snapshot is consistent (one of the two, not corrupted)
+12. Hot-reload semantics — after writing snapshot N, simulate a fresh extension load (re-import) and call `snapshotPrefix` with N+1; assert diff fires correctly (no module-level state required)
+13. Does not mutate `ctx.body` (assert structural equality before/after `default.onRequest`)
+14. mkdir/write failure with `CACHE_FIX_DEBUG=1` set: capture stderr, assert error logged but no throw and request flow uninterrupted
 
 ## Out of scope
 
 - No registration in `extensions.json` (extensions auto-load from `proxy/extensions/`)
-- No README changes (the README's "Diagnostic env vars" section will be touched in the deferred-tools-restore PR alongside the #10 update)
+- No README changes in this PR (the README's diagnostic section will be touched in PR #66 alongside the #10 update)
 
 ## Acceptance
 
 - All new tests pass; full proxy test suite green
-- `CACHE_FIX_PREFIXDIFF=1 ANTHROPIC_BASE_URL=http://localhost:9801 claude` produces snapshot and diff files in `~/.claude/cache-fix-snapshots/`
-- `ctx.body` is never modified by this extension
-- Codex review with no blockers
+- `CACHE_FIX_PREFIXDIFF=1 CACHE_FIX_DEBUG=1 ANTHROPIC_BASE_URL=http://localhost:9801 claude` produces snapshot and (when prefix changes) diff files in `~/.claude/cache-fix-snapshots/`
+- `ctx.body` is never modified
+- Codex re-review with no blockers
 
 — AI Team Lead

--- a/proxy/extensions/prefix-diff.mjs
+++ b/proxy/extensions/prefix-diff.mjs
@@ -146,10 +146,11 @@ function diffHasChanges(diff) {
 // parallel callers writing to the same finalPath would otherwise share
 // a single .tmp and corrupt each other's content.
 //
-// On rename failure the prior final-path file (if any) remains intact,
-// and the orphan .tmp is left for the next call to clean up implicitly
-// by overwriting (cleanup is best-effort; we don't unlink on failure
-// because that hides the original error).
+// On rename failure the prior final-path file (if any) remains intact.
+// The orphan .tmp persists on disk — because each invocation uses a
+// unique temp name, later calls do NOT implicitly overwrite it. This is
+// a small leak (accepted: failures are rare, files are tiny) rather than
+// a correctness issue. A follow-up could add best-effort cleanup.
 async function atomicWriteJson(finalPath, obj, fs) {
   const tmpPath = `${finalPath}.${process.pid}.${Date.now()}.${Math.random()
     .toString(36)
@@ -239,6 +240,11 @@ async function snapshotPrefix(payload, options = {}) {
   return { key: sessionKey, wroteSnapshot, wroteDiff };
 }
 
+// The named exports below are internal test seams, not part of the
+// proxy extension contract. Pipeline loading consumes only `default`.
+// They're exposed so tests can call the helpers directly with their own
+// options (tmpdir, failing fs mocks) instead of mutating process env or
+// monkey-patching node:fs/promises at module scope.
 export {
   snapshotPrefix,
   buildSnapshot,

--- a/proxy/extensions/prefix-diff.mjs
+++ b/proxy/extensions/prefix-diff.mjs
@@ -1,0 +1,271 @@
+// prefix-diff — diagnostic extension for hunting cache-bust sources.
+//
+// On every request, snapshots a small projection of the prefix (system
+// prompt + tools + first 5 messages) and writes it to
+// `~/.claude/cache-fix-snapshots/<key>-last.json`. If a prior snapshot
+// exists and differs, also writes a `<key>-diff.json` and emits a
+// one-line stderr summary.
+//
+// No request mutation. The diagnostic is fail-open: any I/O error is
+// swallowed silently in production. Set CACHE_FIX_DEBUG=1 to also log
+// swallowed errors so silent failures stay observable.
+//
+// Adaptation from preload's `snapshotPrefix(payload)` (preload.mjs ~1656):
+// preload fired the diff once per process restart. The proxy is long-lived
+// and supports hot-reload, so we drop the "first call" gate and run the
+// diff per call. Trade-off: more disk writes, but each is tiny and the
+// diagnostic value is higher (drift visible across every turn, not just
+// at startup).
+
+import {
+  mkdir as _mkdir,
+  readFile as _readFile,
+  writeFile as _writeFile,
+  rename as _rename,
+} from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createHash } from "node:crypto";
+
+const ENABLED = process.env.CACHE_FIX_PREFIXDIFF === "1";
+const DEBUG = process.env.CACHE_FIX_DEBUG === "1";
+
+const DEFAULT_FS = {
+  mkdir: _mkdir,
+  readFile: _readFile,
+  writeFile: _writeFile,
+  rename: _rename,
+};
+
+function getSnapshotDir() {
+  return join(homedir(), ".claude", "cache-fix-snapshots");
+}
+
+function debug(msg) {
+  if (DEBUG) process.stderr.write(`[prefix-diff] ${msg}\n`);
+}
+
+function computeSessionKey(system) {
+  return createHash("sha256")
+    .update(JSON.stringify(system).slice(0, 2000))
+    .digest("hex")
+    .slice(0, 12);
+}
+
+function computeToolsHash(tools) {
+  if (!Array.isArray(tools) || tools.length === 0) return "none";
+  // Match preload behavior: hash unsorted tool names so order changes
+  // surface as hash mismatches (a real cache-bust signal).
+  return createHash("sha256")
+    .update(JSON.stringify(tools.map((t) => t?.name ?? "")))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function computeSystemHash(system) {
+  if (!system) return "none";
+  return createHash("sha256")
+    .update(JSON.stringify(system))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+// Project the first 5 user/assistant messages: strip cache_control,
+// truncate text >500 chars with `...[N chars]` marker. Pure: returns
+// new objects, never mutates input.
+function truncatePrefixMessages(messages) {
+  if (!Array.isArray(messages)) return [];
+  return messages.slice(0, 5).map((msg) => {
+    if (!msg || !Array.isArray(msg.content)) {
+      return { role: msg?.role, content: msg?.content };
+    }
+    const cleanedContent = msg.content.map((block) => {
+      if (!block || typeof block !== "object") return block;
+      const { cache_control, ...rest } = block;
+      if (typeof rest.text === "string" && rest.text.length > 500) {
+        return {
+          ...rest,
+          text: rest.text.slice(0, 500) + `...[${rest.text.length} chars]`,
+        };
+      }
+      return rest;
+    });
+    return { role: msg.role, content: cleanedContent };
+  });
+}
+
+function buildSnapshot(payload) {
+  if (!payload || !payload.system) return null;
+  return {
+    timestamp: new Date().toISOString(),
+    messageCount: Array.isArray(payload.messages) ? payload.messages.length : 0,
+    toolsHash: computeToolsHash(payload.tools),
+    systemHash: computeSystemHash(payload.system),
+    prefixMessages: truncatePrefixMessages(payload.messages),
+  };
+}
+
+function computeDiff(prev, current) {
+  const diff = {
+    timestamp: current.timestamp,
+    prevTimestamp: prev.timestamp,
+    toolsMatch: prev.toolsHash === current.toolsHash,
+    systemMatch: prev.systemHash === current.systemHash,
+    messageCountPrev: prev.messageCount,
+    messageCountNow: current.messageCount,
+    prefixDiffs: [],
+  };
+  const prevMsgs = Array.isArray(prev.prefixMessages) ? prev.prefixMessages : [];
+  const nowMsgs = Array.isArray(current.prefixMessages) ? current.prefixMessages : [];
+  const maxIdx = Math.max(prevMsgs.length, nowMsgs.length);
+  for (let i = 0; i < maxIdx; i++) {
+    const prevSer = JSON.stringify(prevMsgs[i] ?? null);
+    const nowSer = JSON.stringify(nowMsgs[i] ?? null);
+    if (prevSer !== nowSer) {
+      diff.prefixDiffs.push({
+        index: i,
+        prev: prevMsgs[i] ?? null,
+        now: nowMsgs[i] ?? null,
+      });
+    }
+  }
+  return diff;
+}
+
+function diffHasChanges(diff) {
+  return (
+    diff.prefixDiffs.length > 0 ||
+    !diff.toolsMatch ||
+    !diff.systemMatch ||
+    diff.messageCountPrev !== diff.messageCountNow
+  );
+}
+
+// Atomic write: stage to a unique-per-invocation .tmp, then rename to
+// final path. The unique suffix is essential under concurrency — two
+// parallel callers writing to the same finalPath would otherwise share
+// a single .tmp and corrupt each other's content.
+//
+// On rename failure the prior final-path file (if any) remains intact,
+// and the orphan .tmp is left for the next call to clean up implicitly
+// by overwriting (cleanup is best-effort; we don't unlink on failure
+// because that hides the original error).
+async function atomicWriteJson(finalPath, obj, fs) {
+  const tmpPath = `${finalPath}.${process.pid}.${Date.now()}.${Math.random()
+    .toString(36)
+    .slice(2, 10)}.tmp`;
+  await fs.writeFile(tmpPath, JSON.stringify(obj, null, 2));
+  await fs.rename(tmpPath, finalPath);
+}
+
+/**
+ * Snapshot the prefix of `payload` and diff against the prior snapshot.
+ *
+ * Pure-ish: never throws, never mutates `payload`. All I/O is gated by
+ * try/catch; failures are debug-logged when CACHE_FIX_DEBUG=1.
+ *
+ * @param {object} payload  The request body (system, tools, messages).
+ * @param {object} options
+ * @param {string} [options.dir] Snapshot directory. Defaults to ~/.claude/cache-fix-snapshots.
+ * @param {object} [options.fs]  fs/promises overrides for tests:
+ *                               { mkdir, readFile, writeFile, rename }.
+ *                               Any subset replaces the corresponding default.
+ * @returns {Promise<{ key, wroteSnapshot, wroteDiff } | null>} Result for tests; null if no system.
+ */
+async function snapshotPrefix(payload, options = {}) {
+  const current = buildSnapshot(payload);
+  if (!current) return null;
+
+  const dir = options.dir || getSnapshotDir();
+  const fs = { ...DEFAULT_FS, ...(options.fs || {}) };
+
+  const sessionKey = computeSessionKey(payload.system);
+  const lastPath = join(dir, `${sessionKey}-last.json`);
+  const diffPath = join(dir, `${sessionKey}-diff.json`);
+
+  // Ensure directory exists. mkdir failure aborts — without dir, nothing
+  // else can succeed.
+  try {
+    await fs.mkdir(dir, { recursive: true });
+  } catch (err) {
+    debug(`mkdir failed for ${dir}: ${err?.message ?? err}`);
+    return { key: sessionKey, wroteSnapshot: false, wroteDiff: false };
+  }
+
+  // Read prior snapshot if it exists. Missing file is normal; corrupt
+  // file is treated as no prior (skip diff, proceed to overwrite).
+  let prev = null;
+  try {
+    const txt = await fs.readFile(lastPath, "utf-8");
+    prev = JSON.parse(txt);
+  } catch (err) {
+    if (err && err.code !== "ENOENT") {
+      debug(`prior snapshot unreadable at ${lastPath}: ${err?.message ?? err}`);
+    }
+  }
+
+  // Compute and write diff if anything changed.
+  let wroteDiff = false;
+  if (prev) {
+    const diff = computeDiff(prev, current);
+    if (diffHasChanges(diff)) {
+      try {
+        await atomicWriteJson(diffPath, diff, fs);
+        wroteDiff = true;
+        // Always log the summary line when a diff fires (not just under
+        // CACHE_FIX_DEBUG) — this is the diagnostic's whole purpose.
+        process.stderr.write(
+          `[prefix-diff] ${sessionKey}: ${diff.prefixDiffs.length} differences, ` +
+            `tools=${diff.toolsMatch ? "match" : "DIFFER"}, ` +
+            `system=${diff.systemMatch ? "match" : "DIFFER"}, ` +
+            `messages=${diff.messageCountPrev}→${diff.messageCountNow}\n`,
+        );
+      } catch (err) {
+        debug(`diff write failed at ${diffPath}: ${err?.message ?? err}`);
+      }
+    }
+  }
+
+  // Always write the new snapshot atomically so the next call has a
+  // fresh baseline. On failure, prior snapshot is intact.
+  let wroteSnapshot = false;
+  try {
+    await atomicWriteJson(lastPath, current, fs);
+    wroteSnapshot = true;
+  } catch (err) {
+    debug(`snapshot write failed at ${lastPath}: ${err?.message ?? err}`);
+  }
+
+  return { key: sessionKey, wroteSnapshot, wroteDiff };
+}
+
+export {
+  snapshotPrefix,
+  buildSnapshot,
+  computeDiff,
+  computeSessionKey,
+  truncatePrefixMessages,
+  diffHasChanges,
+};
+
+export default {
+  name: "prefix-diff",
+  description:
+    "Snapshot prefix (first 5 msgs + system + tools) and diff against previous run for cache-bust hunting",
+  // Always loaded; gated at runtime by CACHE_FIX_PREFIXDIFF=1 inside onRequest.
+  // This matches the acceptance criteria (env var alone activates) — the
+  // extension is cheap to load (one no-op check per request when disabled).
+  enabled: true,
+  order: 680,
+
+  async onRequest(ctx) {
+    if (!ENABLED) return;
+    if (!ctx || !ctx.body) return;
+    // snapshotPrefix never throws; double-belt try/catch is defense in depth.
+    try {
+      await snapshotPrefix(ctx.body);
+    } catch (err) {
+      debug(`onRequest unexpected: ${err?.message ?? err}`);
+    }
+  },
+};

--- a/test/proxy-prefix-diff.test.mjs
+++ b/test/proxy-prefix-diff.test.mjs
@@ -2,8 +2,8 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, writeFile, rm, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import ext, {
   snapshotPrefix,
@@ -13,6 +13,10 @@ import ext, {
   truncatePrefixMessages,
   diffHasChanges,
 } from "../proxy/extensions/prefix-diff.mjs";
+
+// `import.meta.dirname` requires Node 20.11+; CI matrix includes Node 18,
+// so derive the directory from import.meta.url for portability.
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // --- Helpers ---
 
@@ -371,7 +375,7 @@ test("snapshotPrefix: hot-reload — re-importing module preserves disk-based di
     // Re-import the module with cache-busting query string
     const url =
       pathToFileURL(
-        join(import.meta.dirname, "..", "proxy", "extensions", "prefix-diff.mjs"),
+        join(__dirname, "..", "proxy", "extensions", "prefix-diff.mjs"),
       ).href + "?reload=" + Date.now();
     const reloaded = await import(url);
 
@@ -403,7 +407,7 @@ test("snapshotPrefix: mkdir failure with debug=1 logs but does not throw", async
     process.env.CACHE_FIX_DEBUG = "1";
     const url =
       pathToFileURL(
-        join(import.meta.dirname, "..", "proxy", "extensions", "prefix-diff.mjs"),
+        join(__dirname, "..", "proxy", "extensions", "prefix-diff.mjs"),
       ).href + "?debugReload=" + Date.now();
     const reloaded = await import(url);
 

--- a/test/proxy-prefix-diff.test.mjs
+++ b/test/proxy-prefix-diff.test.mjs
@@ -1,0 +1,445 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile, rm, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import ext, {
+  snapshotPrefix,
+  buildSnapshot,
+  computeDiff,
+  computeSessionKey,
+  truncatePrefixMessages,
+  diffHasChanges,
+} from "../proxy/extensions/prefix-diff.mjs";
+
+// --- Helpers ---
+
+async function newTmp() {
+  return mkdtemp(join(tmpdir(), "prefix-diff-test-"));
+}
+
+function makePayload({
+  system = [{ type: "text", text: "you are claude" }],
+  tools = [{ name: "Read" }, { name: "Bash" }],
+  messages = [
+    { role: "user", content: [{ type: "text", text: "hello" }] },
+    { role: "assistant", content: [{ type: "text", text: "hi" }] },
+  ],
+} = {}) {
+  return { system, tools, messages };
+}
+
+async function listFiles(dir) {
+  try {
+    return (await readdir(dir)).sort();
+  } catch {
+    return [];
+  }
+}
+
+// Capture stderr from a function. Restores before returning.
+async function captureStderr(fn) {
+  const chunks = [];
+  const orig = process.stderr.write;
+  process.stderr.write = (chunk) => {
+    chunks.push(chunk.toString());
+    return true;
+  };
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = orig;
+  }
+  return chunks.join("");
+}
+
+// --- Pure helper tests ---
+
+test("computeSessionKey is deterministic and 12 chars", () => {
+  const sys = [{ type: "text", text: "you are claude" }];
+  const k1 = computeSessionKey(sys);
+  const k2 = computeSessionKey(sys);
+  assert.equal(k1, k2);
+  assert.equal(k1.length, 12);
+});
+
+test("computeSessionKey differs for different system content", () => {
+  const a = computeSessionKey([{ type: "text", text: "system A" }]);
+  const b = computeSessionKey([{ type: "text", text: "system B" }]);
+  assert.notEqual(a, b);
+});
+
+test("truncatePrefixMessages strips cache_control from blocks", () => {
+  const messages = [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "hello", cache_control: { type: "ephemeral" } },
+        { type: "text", text: "world" },
+      ],
+    },
+  ];
+  const out = truncatePrefixMessages(messages);
+  assert.equal(out[0].content[0].text, "hello");
+  assert.equal(out[0].content[0].cache_control, undefined);
+  assert.equal(out[0].content[1].cache_control, undefined);
+});
+
+test("truncatePrefixMessages truncates text >500 chars with N marker", () => {
+  const longText = "x".repeat(600);
+  const messages = [
+    { role: "user", content: [{ type: "text", text: longText }] },
+  ];
+  const out = truncatePrefixMessages(messages);
+  const t = out[0].content[0].text;
+  assert.equal(t.length, 500 + `...[600 chars]`.length);
+  assert.ok(t.endsWith("...[600 chars]"));
+  assert.ok(t.startsWith("xxxxxxxxxx"));
+});
+
+test("truncatePrefixMessages keeps short text untouched", () => {
+  const messages = [
+    { role: "user", content: [{ type: "text", text: "short" }] },
+  ];
+  const out = truncatePrefixMessages(messages);
+  assert.equal(out[0].content[0].text, "short");
+});
+
+test("truncatePrefixMessages slices to first 5 messages", () => {
+  const messages = Array.from({ length: 10 }, (_, i) => ({
+    role: i % 2 === 0 ? "user" : "assistant",
+    content: [{ type: "text", text: `msg ${i}` }],
+  }));
+  const out = truncatePrefixMessages(messages);
+  assert.equal(out.length, 5);
+  assert.equal(out[4].content[0].text, "msg 4");
+});
+
+test("buildSnapshot returns null when payload has no system", () => {
+  assert.equal(buildSnapshot({ messages: [] }), null);
+  assert.equal(buildSnapshot({ system: null }), null);
+  assert.equal(buildSnapshot({}), null);
+});
+
+test("buildSnapshot includes systemHash, toolsHash, messageCount, prefixMessages", () => {
+  const snap = buildSnapshot(makePayload());
+  assert.equal(typeof snap.timestamp, "string");
+  assert.equal(snap.messageCount, 2);
+  assert.equal(snap.toolsHash.length, 16);
+  assert.equal(snap.systemHash.length, 16);
+  assert.equal(snap.prefixMessages.length, 2);
+});
+
+test("computeDiff: identical snapshots → no differences", () => {
+  const snap = buildSnapshot(makePayload());
+  const diff = computeDiff(snap, snap);
+  assert.equal(diff.prefixDiffs.length, 0);
+  assert.equal(diff.toolsMatch, true);
+  assert.equal(diff.systemMatch, true);
+  assert.equal(diffHasChanges(diff), false);
+});
+
+test("computeDiff: tools/system hash mismatch flips the corresponding flag", () => {
+  const a = buildSnapshot(makePayload());
+  const b = buildSnapshot(
+    makePayload({ tools: [{ name: "Read" }, { name: "Edit" }] }),
+  );
+  const diff = computeDiff(a, b);
+  assert.equal(diff.toolsMatch, false);
+  assert.equal(diff.systemMatch, true);
+  assert.equal(diffHasChanges(diff), true);
+});
+
+test("computeDiff: differing prefixMessages produce indexed diff entries", () => {
+  const a = buildSnapshot(makePayload());
+  const b = buildSnapshot(
+    makePayload({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "DIFFERENT" }] },
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    }),
+  );
+  const diff = computeDiff(a, b);
+  assert.equal(diff.prefixDiffs.length, 1);
+  assert.equal(diff.prefixDiffs[0].index, 0);
+});
+
+test("computeDiff: messageCount change is reflected", () => {
+  const a = buildSnapshot(makePayload());
+  const b = buildSnapshot(
+    makePayload({
+      messages: [...makePayload().messages, { role: "user", content: [{ type: "text", text: "third" }] }],
+    }),
+  );
+  const diff = computeDiff(a, b);
+  assert.equal(diff.messageCountPrev, 2);
+  assert.equal(diff.messageCountNow, 3);
+  assert.equal(diffHasChanges(diff), true);
+});
+
+// --- Integration tests on snapshotPrefix ---
+
+test("snapshotPrefix: returns null when no system", async () => {
+  const dir = await newTmp();
+  try {
+    const result = await snapshotPrefix({ messages: [] }, { dir });
+    assert.equal(result, null);
+    assert.deepEqual(await listFiles(dir), []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snapshotPrefix: writes <key>-last.json on first invocation", async () => {
+  const dir = await newTmp();
+  try {
+    const payload = makePayload();
+    const result = await snapshotPrefix(payload, { dir });
+    assert.ok(result?.wroteSnapshot);
+    assert.equal(result.wroteDiff, false);
+    const expected = `${result.key}-last.json`;
+    const files = await listFiles(dir);
+    assert.deepEqual(files, [expected]);
+    const json = JSON.parse(await readFile(join(dir, expected), "utf-8"));
+    assert.equal(json.messageCount, 2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snapshotPrefix: identical second call rewrites last.json, no diff file", async () => {
+  const dir = await newTmp();
+  try {
+    const payload = makePayload();
+    const r1 = await snapshotPrefix(payload, { dir });
+    const r2 = await snapshotPrefix(payload, { dir });
+    assert.ok(r2.wroteSnapshot);
+    assert.equal(r2.wroteDiff, false);
+    const files = await listFiles(dir);
+    assert.deepEqual(files, [`${r1.key}-last.json`]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snapshotPrefix: differing second call writes <key>-diff.json with prefixDiffs", async () => {
+  const dir = await newTmp();
+  try {
+    const r1 = await snapshotPrefix(makePayload(), { dir });
+    // Suppress the success-summary stderr write during the diff call.
+    let r2;
+    await captureStderr(async () => {
+      r2 = await snapshotPrefix(
+        makePayload({
+          messages: [
+            { role: "user", content: [{ type: "text", text: "CHANGED" }] },
+            { role: "assistant", content: [{ type: "text", text: "hi" }] },
+          ],
+        }),
+        { dir },
+      );
+    });
+    assert.ok(r2.wroteSnapshot);
+    assert.ok(r2.wroteDiff);
+    const files = await listFiles(dir);
+    assert.deepEqual(files, [`${r1.key}-diff.json`, `${r1.key}-last.json`]);
+    const diff = JSON.parse(await readFile(join(dir, `${r1.key}-diff.json`), "utf-8"));
+    assert.ok(diff.prefixDiffs.length > 0);
+    assert.equal(diff.prefixDiffs[0].index, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snapshotPrefix: rename failure leaves prior last.json intact", async () => {
+  const dir = await newTmp();
+  try {
+    // Seed a known prior snapshot
+    const payload = makePayload();
+    await snapshotPrefix(payload, { dir });
+    const key = computeSessionKey(payload.system);
+    const lastPath = join(dir, `${key}-last.json`);
+    const priorContent = await readFile(lastPath, "utf-8");
+
+    // Now monkey-patch rename to throw; both diff and snapshot writes hit it
+    const failingFs = {
+      rename: async () => {
+        throw new Error("simulated rename failure");
+      },
+    };
+
+    let result;
+    await captureStderr(async () => {
+      result = await snapshotPrefix(
+        makePayload({
+          messages: [
+            { role: "user", content: [{ type: "text", text: "CHANGED" }] },
+          ],
+        }),
+        { dir, fs: failingFs },
+      );
+    });
+    assert.equal(result.wroteSnapshot, false);
+    assert.equal(result.wroteDiff, false);
+    // Prior snapshot must still match what we seeded
+    const after = await readFile(lastPath, "utf-8");
+    assert.equal(after, priorContent);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snapshotPrefix: corrupt prior snapshot is treated as no-prior", async () => {
+  const dir = await newTmp();
+  try {
+    const payload = makePayload();
+    const key = computeSessionKey(payload.system);
+    const lastPath = join(dir, `${key}-last.json`);
+    // Write garbage that is not valid JSON
+    await writeFile(lastPath, "{not json", "utf-8");
+
+    let result;
+    await captureStderr(async () => {
+      result = await snapshotPrefix(payload, { dir });
+    });
+    assert.ok(result.wroteSnapshot);
+    assert.equal(result.wroteDiff, false);
+    // Last.json should now be valid JSON
+    const json = JSON.parse(await readFile(lastPath, "utf-8"));
+    assert.equal(json.messageCount, 2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snapshotPrefix: concurrent invocations both succeed; final snapshot is valid", async () => {
+  const dir = await newTmp();
+  try {
+    const payloadA = makePayload();
+    const payloadB = makePayload({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "OTHER" }] },
+      ],
+    });
+    let results;
+    await captureStderr(async () => {
+      results = await Promise.all([
+        snapshotPrefix(payloadA, { dir }),
+        snapshotPrefix(payloadB, { dir }),
+      ]);
+    });
+    // Both same key (same system), so both write to same last.json
+    assert.equal(results[0].key, results[1].key);
+    // At least one succeeded
+    assert.ok(results.some((r) => r.wroteSnapshot));
+    // Final last.json must be valid JSON, not partial
+    const lastPath = join(dir, `${results[0].key}-last.json`);
+    const json = JSON.parse(await readFile(lastPath, "utf-8"));
+    assert.equal(typeof json.timestamp, "string");
+    assert.ok(["payloadA", "payloadB"].length > 0); // sanity placeholder
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snapshotPrefix: hot-reload — re-importing module preserves disk-based diff behavior", async () => {
+  const dir = await newTmp();
+  try {
+    // Use the already-imported snapshotPrefix for the seed
+    const payloadV1 = makePayload();
+    await snapshotPrefix(payloadV1, { dir });
+
+    // Re-import the module with cache-busting query string
+    const url =
+      pathToFileURL(
+        join(import.meta.dirname, "..", "proxy", "extensions", "prefix-diff.mjs"),
+      ).href + "?reload=" + Date.now();
+    const reloaded = await import(url);
+
+    // Use the freshly-imported snapshotPrefix with a mutated payload
+    let result;
+    await captureStderr(async () => {
+      result = await reloaded.snapshotPrefix(
+        makePayload({
+          messages: [
+            { role: "user", content: [{ type: "text", text: "POST_RELOAD_CHANGE" }] },
+          ],
+        }),
+        { dir },
+      );
+    });
+    assert.ok(result.wroteDiff, "diff should fire across module re-imports");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snapshotPrefix: mkdir failure with debug=1 logs but does not throw", async () => {
+  const dir = await newTmp();
+  try {
+    const failingFs = {
+      mkdir: async () => {
+        const err = new Error("simulated mkdir failure");
+        throw err;
+      },
+    };
+    // Force the debug path: temporarily set env (module-level DEBUG is read at
+    // import; test the runtime debug() call via stderr capture regardless)
+    const stderr = await captureStderr(async () => {
+      const result = await snapshotPrefix(makePayload(), {
+        dir: join(dir, "subdir"),
+        fs: failingFs,
+      });
+      assert.equal(result.wroteSnapshot, false);
+    });
+    // We don't assert on the stderr content unconditionally because DEBUG
+    // is set at module import. We DO assert that the call didn't throw,
+    // which is the critical fail-open property.
+    // (If CACHE_FIX_DEBUG=1 was set when this test was loaded, stderr will
+    //  contain the mkdir failure message.)
+    if (process.env.CACHE_FIX_DEBUG === "1") {
+      assert.ok(stderr.includes("mkdir failed"));
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- default.onRequest tests ---
+
+test("default.onRequest: no-op when CACHE_FIX_PREFIXDIFF unset (module-time check)", async () => {
+  // The extension reads ENABLED at module import time. If the env var was
+  // unset when the test process started, ext.onRequest is a no-op regardless
+  // of what we do at test time. We assert that calling onRequest does not
+  // throw and does not mutate ctx.body.
+  const ctx = { body: makePayload() };
+  const before = JSON.stringify(ctx.body);
+  await ext.onRequest(ctx);
+  const after = JSON.stringify(ctx.body);
+  assert.equal(after, before);
+});
+
+test("default.onRequest: never mutates ctx.body", async () => {
+  const ctx = { body: makePayload() };
+  const before = JSON.stringify(ctx.body);
+  await ext.onRequest(ctx);
+  const after = JSON.stringify(ctx.body);
+  assert.equal(after, before);
+});
+
+test("default.onRequest: tolerates missing ctx and missing body", async () => {
+  await ext.onRequest({});
+  await ext.onRequest({ body: null });
+  // No throw = pass
+  assert.ok(true);
+});
+
+test("default has correct extension contract metadata", () => {
+  assert.equal(ext.name, "prefix-diff");
+  assert.equal(ext.order, 680);
+  assert.equal(typeof ext.onRequest, "function");
+  assert.equal(typeof ext.description, "string");
+});

--- a/test/proxy-prefix-diff.test.mjs
+++ b/test/proxy-prefix-diff.test.mjs
@@ -315,7 +315,7 @@ test("snapshotPrefix: corrupt prior snapshot is treated as no-prior", async () =
   }
 });
 
-test("snapshotPrefix: concurrent invocations both succeed; final snapshot is valid", async () => {
+test("snapshotPrefix: concurrent invocations both succeed; final snapshot matches one of the two payloads", async () => {
   const dir = await newTmp();
   try {
     const payloadA = makePayload();
@@ -333,13 +333,29 @@ test("snapshotPrefix: concurrent invocations both succeed; final snapshot is val
     });
     // Both same key (same system), so both write to same last.json
     assert.equal(results[0].key, results[1].key);
-    // At least one succeeded
+    // At least one succeeded (the other may have lost the rename race)
     assert.ok(results.some((r) => r.wroteSnapshot));
-    // Final last.json must be valid JSON, not partial
+    // Final last.json must be valid JSON (no torn write)
     const lastPath = join(dir, `${results[0].key}-last.json`);
     const json = JSON.parse(await readFile(lastPath, "utf-8"));
-    assert.equal(typeof json.timestamp, "string");
-    assert.ok(["payloadA", "payloadB"].length > 0); // sanity placeholder
+    // Stronger: the final file must equal one of the two candidate snapshots
+    // — not a mix of A and B, not a corrupt partial.
+    const snapshotA = buildSnapshot(payloadA);
+    const snapshotB = buildSnapshot(payloadB);
+    // Timestamps are generated at build time and will differ; compare the
+    // deterministic content fields (prefixMessages + counts/hashes).
+    const deterministic = ({ prefixMessages, messageCount, toolsHash, systemHash }) => ({
+      prefixMessages,
+      messageCount,
+      toolsHash,
+      systemHash,
+    });
+    const actual = JSON.stringify(deterministic(json));
+    assert.ok(
+      actual === JSON.stringify(deterministic(snapshotA)) ||
+        actual === JSON.stringify(deterministic(snapshotB)),
+      "final snapshot content must match exactly one of the two candidate payloads",
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -379,31 +395,39 @@ test("snapshotPrefix: hot-reload — re-importing module preserves disk-based di
 
 test("snapshotPrefix: mkdir failure with debug=1 logs but does not throw", async () => {
   const dir = await newTmp();
+  const prevDebug = process.env.CACHE_FIX_DEBUG;
   try {
+    // DEBUG is read at module-import time, so to test the logging path
+    // deterministically we set the env var then re-import the module with
+    // a cache-busting query string. This mirrors the hot-reload test.
+    process.env.CACHE_FIX_DEBUG = "1";
+    const url =
+      pathToFileURL(
+        join(import.meta.dirname, "..", "proxy", "extensions", "prefix-diff.mjs"),
+      ).href + "?debugReload=" + Date.now();
+    const reloaded = await import(url);
+
     const failingFs = {
       mkdir: async () => {
-        const err = new Error("simulated mkdir failure");
-        throw err;
+        throw new Error("simulated mkdir failure");
       },
     };
-    // Force the debug path: temporarily set env (module-level DEBUG is read at
-    // import; test the runtime debug() call via stderr capture regardless)
     const stderr = await captureStderr(async () => {
-      const result = await snapshotPrefix(makePayload(), {
+      const result = await reloaded.snapshotPrefix(makePayload(), {
         dir: join(dir, "subdir"),
         fs: failingFs,
       });
       assert.equal(result.wroteSnapshot, false);
+      assert.equal(result.wroteDiff, false);
     });
-    // We don't assert on the stderr content unconditionally because DEBUG
-    // is set at module import. We DO assert that the call didn't throw,
-    // which is the critical fail-open property.
-    // (If CACHE_FIX_DEBUG=1 was set when this test was loaded, stderr will
-    //  contain the mkdir failure message.)
-    if (process.env.CACHE_FIX_DEBUG === "1") {
-      assert.ok(stderr.includes("mkdir failed"));
-    }
+    // With DEBUG=1 at import time, the mkdir failure MUST be logged.
+    assert.ok(
+      stderr.includes("mkdir failed") && stderr.includes("simulated mkdir failure"),
+      `expected mkdir failure in stderr, got: ${JSON.stringify(stderr)}`,
+    );
   } finally {
+    if (prevDebug === undefined) delete process.env.CACHE_FIX_DEBUG;
+    else process.env.CACHE_FIX_DEBUG = prevDebug;
     await rm(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Pure-diagnostic port of `CACHE_FIX_PREFIXDIFF` from `preload.mjs` to a proxy extension so v2.1.113+ (Bun binary) users get the same cache-bust hunting tool as preload users.

**Stage:** directive — see `docs/directives/proxy-prefix-diff.md` for the full spec.

## TL;DR

- New extension `proxy/extensions/prefix-diff.mjs`, order 680, opt-in via `CACHE_FIX_PREFIXDIFF=1`
- Snapshots first 5 messages + system hash + tools hash to `~/.claude/cache-fix-snapshots/<key>-last.json`
- On first call after boot only, diffs against previous snapshot → writes `<key>-diff.json` + one-line debug log
- No request modification (asserted in tests)
- New env override `CACHE_FIX_PREFIXDIFF_DIR` for test isolation
- 10 tests covering enable gate, snapshot shape, session keying, truncation, cache_control stripping, diff firing, no-mutation, error swallowing

Ref: #59

— AI Team Lead