### PR TITLE
Directive: port deferred-tools-restore + close #59 (#59 items 6, 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ export CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1
 
 Or add `"includeGitInstructions": false` to `~/.claude/settings.json`. Claude Code can still run `git status` via the Bash tool when it needs context. Community-validated by [@wadabum](https://github.com/cnighswonger/claude-code-cache-fix/issues/11): 18-token cache creation across git state changes (vs thousands without the flag).
 
+**Why we don't ship a proxy extension for this:** the proxy intercepts requests after Claude Code has already composed the system prompt — by then the volatile `git status` text is already part of the prefix that the model conditioned on in the previous turn, and stripping it post-hoc would itself bust the cache. The fix has to happen at the source. `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` prevents the injection before the prompt is composed, which is why the native flag is the right tool. Stripping post-hoc would also remove model-visible context that an explicit Bash call can recover, and would risk false-positive matches against assistant-written text.
+
 ## Image stripping (preload mode)
 
 Images read via the Read tool persist as base64 in conversation history, riding along on every subsequent API call. A single 500KB image costs ~62,500 tokens per turn on Opus 4.6, and **~85,000+ on Opus 4.7** due to the new tokenizer. Image stripping is strongly recommended on 4.7.

--- a/docs/code-reviews/pr-66-deferred-tools-restore-impl-review-2026-04-24.md
+++ b/docs/code-reviews/pr-66-deferred-tools-restore-impl-review-2026-04-24.md
@@ -1,0 +1,44 @@
+# Review: deferred-tools-restore proxy extension implementation
+
+Date: 2026-04-24
+Reviewed: `proxy/extensions/deferred-tools-restore.mjs`, `test/proxy-deferred-tools-restore.test.mjs`, `docs/directives/proxy-deferred-tools-restore.md`, `README.md`
+Label applied: `changes-requested`
+
+## What Is Correct
+
+- The core persist/restore flow is otherwise faithful to the final directive. The extension only persists clean baseline blocks, only attempts restore when the current block carries the UNAVAILABLE marker, validates the snapshot before use, and keeps the strict `snapshot.length > current.length` downgrade guard ([proxy/extensions/deferred-tools-restore.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/deferred-tools-restore.mjs:223), [proxy/extensions/deferred-tools-restore.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/deferred-tools-restore.mjs:260)).
+- The restore mutation itself is structurally sound. It replaces the targeted content block via a new `content` array and a new message object, rather than mutating the existing content entry in place, which is the right shape for this extension's one necessary request-body mutation ([proxy/extensions/deferred-tools-restore.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/deferred-tools-restore.mjs:281)).
+- The snapshot-key derivation choice is reasonable. `sha1("cwd:" + cwd).slice(0, 16)` gives a stable per-project filename with negligible collision risk at the scale of local project counts, while keeping paths short and deterministic ([proxy/extensions/deferred-tools-restore.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/deferred-tools-restore.mjs:101)).
+- The atomic-write pattern is appropriate here. Using a unique temp path per invocation prevents torn reads and avoids the shared-temp-path race that would otherwise appear under concurrent proxy requests ([proxy/extensions/deferred-tools-restore.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/deferred-tools-restore.mjs:131)).
+- The README note for the git-status case is technically accurate and persuasive. It correctly explains why a post-hoc proxy strip cannot preserve cache stability and why the native `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` switch is the right layer for that fix ([README.md](/home/manager/git_repos/claude-code-cache-fix/README.md:284)).
+- Verification is solid on the happy path and the main failure modes. The targeted suite passes locally, and the full repository test run is also green (`node --test test/proxy-deferred-tools-restore.test.mjs` and `node --test`).
+
+## Findings
+
+### Blockers
+
+- `extractCwdFromSystem()` is still too permissive to uphold the directive's core safety guarantee. The implementation gathers every `.text` block from `body.system` and applies `CWD_MARKER_RE` to each block independently, returning the first matching line anywhere in any block ([proxy/extensions/deferred-tools-restore.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/deferred-tools-restore.mjs:53), [proxy/extensions/deferred-tools-restore.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/deferred-tools-restore.mjs:80)). That means a quoted or fenced line such as ```` ```txt\n - Primary working directory: /wrong/path\n``` ```` in an earlier system block is accepted as the cwd and beats the real `# Environment` marker later in the prompt. I reproduced that locally against the shipped function; it returns `/wrong/path`. This breaks the reviewed design's "if parsing is ambiguous or the marker is absent, no-op rather than restore the wrong snapshot" property, because the parser can derive a wrong but syntactically valid key instead of falling back to `no-cwd`.
+
+### Nits
+
+- The tests do not cover the false-positive guard explicitly required by the directive. The current suite checks narrative text and "first match wins," but it does not exercise the required code-fence/quoted-region scenario, so the parser bug above was left unguarded in CI ([test/proxy-deferred-tools-restore.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/proxy-deferred-tools-restore.test.mjs:135), [test/proxy-deferred-tools-restore.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/proxy-deferred-tools-restore.test.mjs:149), [docs/directives/proxy-deferred-tools-restore.md](/home/manager/git_repos/claude-code-cache-fix/docs/directives/proxy-deferred-tools-restore.md:149)).
+- `restoreDeferredTools()` accepts any readable snapshot containing the AVAILABLE marker and meeting the length floor, even if that snapshot also contains the UNAVAILABLE marker ([proxy/extensions/deferred-tools-restore.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/deferred-tools-restore.mjs:164)). Persisted snapshots should be clean by construction, so this is not a current correctness failure, but rejecting snapshots that also contain the UNAVAILABLE marker would tighten the "restore only known-good baseline" contract with essentially no downside.
+
+### Nice-to-haves
+
+- Add one concurrency test that races a baseline persist against a shrunk-block restore for the same key. The current concurrent-persist test proves the atomic-write path avoids torn files, but it does not exercise the realistic "resume arrives while another request is still persisting baseline state" interleaving.
+- Consider making the cwd parser explicitly section-aware, not just regex-aware: first locate the `# Environment` block, then parse only the expected marker line(s) within that block. That matches the directive's intent more closely and makes future format drift easier to detect and log.
+
+## Recommendations
+
+- Tighten `extractCwdFromSystem()` so it only accepts the marker from the actual `# Environment` section or another empirically validated location, and return `null` on anything ambiguous instead of "first standalone match anywhere."
+- Add the missing false-positive regression tests from the directive: at minimum a code-fenced marker case and a quoted-marker case that should both produce `null` or at least ignore the false positive in favor of the real environment block.
+- Add a small defense-in-depth check that rejects snapshots containing the UNAVAILABLE marker during restore.
+
+## Bottom Line
+
+Request changes. The persist/restore mechanics, downgrade guard, mutation shape, concurrency story, and README rationale are all in good shape, but the cwd parser is not yet safe enough for the design this PR claims to implement. Until the parser is narrowed to the real environment marker location, the extension can derive the wrong project key from unrelated system text and restore the wrong snapshot instead of failing open.
+
+## Recommendation
+
+REQUEST CHANGES

--- a/docs/code-reviews/pr-66-deferred-tools-restore-impl-review-2026-04-24.md
+++ b/docs/code-reviews/pr-66-deferred-tools-restore-impl-review-2026-04-24.md
@@ -42,3 +42,17 @@ Request changes. The persist/restore mechanics, downgrade guard, mutation shape,
 ## Recommendation
 
 REQUEST CHANGES
+
+## Follow-up Verified
+
+Date: 2026-04-24
+Reviewed commit: `a158a4f`
+Reviewer: Codex Review Agent
+
+Re-checked the parser rewrite in `extractCwdFromSystem()` and reproduced the three false-positive shapes called out in the prior re-review.
+
+1. Fake marker inside a code fence after the real `# Environment` section in the same block now resolves to the real cwd (`/real/cwd`), not the fenced fake.
+2. A fenced fake `# Environment` block in an earlier system block plus a distinct real block later now returns `null` via the ambiguity guard instead of selecting the earlier fake cwd.
+3. Two structurally valid `# Environment` sections in one block where the first is fake and the second is real now return `null` via the ambiguity guard instead of selecting the first section.
+
+This closes the prior blocker. The parser is now bounded to the expected section shape and fails open on ambiguity, which matches the reviewed safety requirement.

--- a/docs/directives/proxy-deferred-tools-restore.md
+++ b/docs/directives/proxy-deferred-tools-restore.md
@@ -2,7 +2,7 @@
 
 **Issues:** #59 item 6 (deferred-tools-restore), #59 item 10 (git-status strip — closed via README, not ported)
 **Branch:** `feature/proxy-deferred-tools-restore`
-**Stage:** directive
+**Stage:** directive (revised after Codex review — see `docs/code-reviews/`)
 
 This is the **final PR for #59**. It ports the last behavior-bearing item, documents why item 10 is intentionally not ported, and closes #59.
 
@@ -16,27 +16,63 @@ Observed empirically: on `claude --continue`, if MCP servers haven't finished re
 
 That block change at the root of the message array busts the cache at the very top — the entire ~940K prompt re-caches. By the time the second post-resume request fires, MCPs are usually reconnected and the block is full again, but the cache is already committed to the shrunk version for this session.
 
+## Adaptation from preload behavior (snapshot key change)
+
+The preload version uses `process.cwd()` as the snapshot key. **This does not translate to the proxy:**
+
+- In preload, `process.cwd()` is the Claude Code process's CWD — different per CC session per project.
+- In the proxy, `process.cwd()` is the long-lived proxy daemon's CWD — **shared across all CC sessions on the host**. Two unrelated projects would collide onto the same snapshot file.
+
+The proxy version derives the snapshot key from the **system prompt content**, not the proxy's CWD:
+
+```
+key = sha1(JSON.stringify(payload.system).slice(0, 2000)).slice(0, 16)
+```
+
+Same project (same CC project root, same CLAUDE.md, same skills) → same system prompt → same key. Different projects → different system prompts → different keys. This matches the keying scheme that `prefix-diff` (PR #65) uses, with the same rationale.
+
+If `payload.system` is absent or empty, the extension no-ops (no key → no snapshot work). This is correct behavior: a request with no system prompt has no project identity for the proxy to key on.
+
 ## Reference (preload behavior to mirror)
 
-- `preload.mjs` lines ~429–518 (helpers + constants)
-- `preload.mjs` lines ~2286–2322 (integration block)
+- `preload.mjs` lines ~429–518 (helpers + constants — `findDeferredToolsBlockInBody`, marker constants, `deferredToolsSnapshotPath`)
+- `preload.mjs` lines ~2286–2322 (integration block — persist-or-restore decision)
 - Env var: `CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1` to opt out (extension defaults **ON**)
 - Snapshot dir: `~/.claude/cache-fix-state/`
-- Snapshot file: `deferred-tools-<sha1(key).slice(0,16)>.txt`
-- Snapshot key: `process.cwd()` (one snapshot per project)
-- Markers:
+- Snapshot file: `deferred-tools-<key>.txt` where `<key>` is the system-hash described above
+- Markers (unchanged from preload):
   - AVAILABLE: `"The following deferred tools are now available via ToolSearch"`
   - UNAVAILABLE: `"The following deferred tools are no longer available"`
 
 ### Algorithm
 
-1. Walk `body.messages` to locate the deferred-tools block — only `role: "user"` messages, only `type: "text"` blocks containing the AVAILABLE marker. Return `{ msgIdx, blockIdx, text }` or `null`. (Skip assistant messages so the agent quoting the marker doesn't trigger a false match.)
-2. If no block found → no-op, return.
-3. If block exists and does **not** contain the UNAVAILABLE marker → it's a clean baseline. Persist it to the snapshot file (best-effort; swallow I/O errors). Done.
-4. If block exists and **does** contain the UNAVAILABLE marker → attempt restore:
-   - Read snapshot file.
-   - **Only substitute if the snapshot is strictly longer than the current block.** Never downgrade to a stale shorter snapshot. (This is the safety guard from the preload version — keep it.)
+1. Compute snapshot key from `payload.system`. If empty/absent → no-op.
+2. Walk `body.messages` to locate the deferred-tools block — only `role: "user"` messages, only `type: "text"` blocks containing the AVAILABLE marker. Return `{ msgIdx, blockIdx, text }` or `null`. (Skip assistant messages so the agent quoting the marker doesn't trigger a false match.)
+3. If no block found → no-op.
+4. If block exists and does **not** contain the UNAVAILABLE marker → it's a clean baseline. Persist it (best-effort, atomic write — see below).
+5. If block exists and **does** contain the UNAVAILABLE marker → attempt restore:
+   - Read snapshot file. If unreadable, malformed, or shorter than a sane minimum (e.g., < length of `AVAILABLE` marker) → skip restore (treat as no snapshot).
+   - **Only substitute if the snapshot is strictly longer than the current block.** Never downgrade.
    - Substitute by replacing `messages[msgIdx].content[blockIdx].text` with the snapshotted bytes.
+
+### Atomic write requirement (revised)
+
+A truncated-but-readable snapshot can still pass the length check and corrupt the next session. Persistence MUST use atomic write:
+
+```
+write to <path>.tmp
+fsync (best-effort; ignore if not supported)
+rename <path>.tmp -> <path>
+```
+
+`rename` on the same filesystem is atomic; partial writes are confined to the `.tmp` file and never observed by readers. On rename failure, leave the previous snapshot intact (do not delete it).
+
+Snapshot integrity validation on read is also tightened:
+
+- File must exist and be readable
+- File length must be at least `AVAILABLE_MARKER.length` bytes
+- File content must contain the AVAILABLE marker (sanity check that we're reading what we think we're reading)
+- If any check fails → treat as "no snapshot," skip restore
 
 ### Trade-off (document in extension header comment, mirroring preload)
 
@@ -50,39 +86,64 @@ The restored block may reference MCP tools that haven't actually reconnected yet
 - `enabled`: `true` (defaults ON, mirroring preload — opt out via `CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1`)
 - `order`: `350` (after `identity-normalization` at 300, before `cache-control-normalize` at 400 — block content must be stable before cache_control marker placement)
 - Hook: `onRequest(ctx)` — locates block, persists or restores
-- Snapshot dir override (for tests): `CACHE_FIX_DEFERRED_TOOLS_DIR` env var; default `~/.claude/cache-fix-state/`
 
-**Error handling:** mirror preload — wrap all I/O in try/catch and silently swallow. Snapshot write failure must not block the request. Snapshot read failure is treated as "no snapshot" (skip restore).
+### Test seam (no public env var)
 
-**Telemetry:** emit a `process.stderr.write` line on `applied` and `persisted` events, matching the existing extension style:
-- `[deferred-tools-restore] persisted N bytes to <path>`
-- `[deferred-tools-restore] restored N→M bytes at msg[X].content[Y]`
+Match the prefix-diff revision: **do not** introduce `CACHE_FIX_DEFERRED_TOOLS_DIR` as a runtime env var. Instead, export the underlying pure functions alongside `default`:
 
-Set `ctx.meta.deferredToolsRestoreStats = { action: "persisted"|"restored"|"skipped", bytes: <N> }` for observability.
+- `deriveSnapshotKey(systemPrompt)` — returns the sha1 hash key, exposed for tests
+- `findDeferredToolsBlockInBody(body)` — returns `{ msgIdx, blockIdx, text } | null`
+- `persistDeferredTools(text, options)` — atomic write to `options.dir`
+- `restoreDeferredTools(options)` — read + validate; returns `string | null`
+- `default.onRequest(ctx)` orchestrates with `options.dir = getSnapshotDir()` (internal, default `~/.claude/cache-fix-state/`)
+
+Tests call the pure functions with their own `tmpdir()`-based options. Same pattern as `image-strip.mjs`.
+
+### Error handling
+
+- Wrap all I/O in try/catch.
+- Snapshot write failure → silent in production; `process.stderr.write("[deferred-tools-restore] write failed: <err>\n")` when `CACHE_FIX_DEBUG=1`.
+- Snapshot read failure → silent in production; same debug-gated stderr line.
+- Never throw out of `onRequest`; never block the request.
+
+### Telemetry
+
+Emit a `process.stderr.write` line on `applied` and `persisted` events, matching the existing extension style:
+- `[deferred-tools-restore] persisted N bytes (key=<key>)`
+- `[deferred-tools-restore] restored N→M bytes at msg[X].content[Y] (key=<key>)`
+
+Set `ctx.meta.deferredToolsRestoreStats = { action: "persisted"|"restored"|"skipped", bytes: <N>, key: <key> }` for observability.
 
 ## Tests (in `test/proxy-deferred-tools-restore.test.mjs`)
 
 1. No-op when `CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1`
 2. No-op when no deferred-tools block exists in `body.messages`
-3. Persists snapshot when block is clean (no UNAVAILABLE marker)
-4. Snapshot path derives correctly from `CACHE_FIX_DEFERRED_TOOLS_DIR` + sha1(cwd) hash
-5. Restores from snapshot when current block has UNAVAILABLE marker AND snapshot is longer
-6. **Does not** restore when snapshot exists but is shorter than current block (downgrade guard)
-7. **Does not** restore when no snapshot file exists
-8. Skips assistant messages (block in assistant content does not trigger detection)
-9. Locates block at `messages[N].content[M]` for arbitrary N, M (not just `[0][0]`)
-10. Snapshot read failure does not throw; results in skipped restore
-11. Snapshot write failure (point dir at `/dev/null/nope`) does not throw
-
-Use `CACHE_FIX_DEFERRED_TOOLS_DIR=<tmpdir>` for test isolation.
+3. No-op when `payload.system` is absent (no key)
+4. Persists snapshot when block is clean (no UNAVAILABLE marker)
+5. `deriveSnapshotKey` is deterministic for identical system prompts and differs for distinct system prompts
+6. Restores from snapshot when current block has UNAVAILABLE marker AND snapshot is longer
+7. **Downgrade guard — exhaustive boundary tests:**
+   - Snapshot exactly 1 byte shorter than current → skip restore
+   - Snapshot many bytes shorter than current → skip restore
+   - Snapshot exactly equal length to current → skip restore (must be **strictly** longer)
+   - Snapshot 1 byte longer → restore
+8. Skips restore when no snapshot file exists
+9. Skips assistant messages (block in assistant content does not trigger detection)
+10. Locates block at `messages[N].content[M]` for arbitrary N, M (not just `[0][0]`)
+11. **Atomic write under failure:** simulate `rename` throwing after `.tmp` write succeeds; assert the prior snapshot file is intact and unchanged
+12. **Truncated snapshot rejection:** write a snapshot file shorter than `AVAILABLE_MARKER.length`; next call must skip restore (never substitute a truncated value)
+13. **Missing-marker rejection:** write a same-length snapshot that doesn't contain the AVAILABLE marker; next call must skip restore
+14. **Concurrent invocations:** fire two `default.onRequest` calls in parallel against the same key; assert no throw, snapshot file is one of the two valid versions (not partial), and at least one call's stats reflect the persistence
+15. Snapshot read failure (point dir at unreadable path) does not throw; debug-logs when `CACHE_FIX_DEBUG=1`
+16. Snapshot write failure (point dir at `/dev/null/nope`) does not throw; debug-logs when `CACHE_FIX_DEBUG=1`
 
 ## README update (handles #59 item 10)
 
-Edit `README.md`'s "Recommended: disable git-status injection" section (line ~274) to add an explicit note:
+Edit `README.md`'s "Recommended: disable git-status injection" section (line ~274) to add an explicit note. Phrasing must reflect the **technical reason** (we can't), not just preference (we chose not to):
 
-> **Why we don't ship a proxy extension for this:** `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` is the right tool for the job — it prevents the injection at the source rather than stripping it after the fact. Stripping post-hoc would also remove the agent's ability to see git context that an explicit Bash call can recover, and would risk false-positive matches against assistant-written text. Use the native flag.
+> **Why we don't ship a proxy extension for this:** the proxy intercepts requests after Claude Code has already composed the system prompt — by then the volatile `git status` text is already part of the prefix that the model conditioned on in the previous turn, and stripping it post-hoc would itself bust the cache. The fix has to happen at the source. `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` prevents the injection before the prompt is composed, which is why the native flag is the right tool. Stripping post-hoc would additionally remove model-visible context that an explicit Bash call can recover, and would risk false-positive matches against assistant-written text.
 
-This is the substance of why item 10 is intentionally not ported. Closing-out comment on #59 should reference this README addition.
+Closing-out comment on #59 should reference this README addition.
 
 ## Out of scope
 
@@ -92,17 +153,17 @@ This is the substance of why item 10 is intentionally not ported. Closing-out co
 
 ## Acceptance
 
-- All 11 new tests pass; full proxy test suite green
-- README has the "why we don't ship" note in the git-status section
-- `claude --continue` with `MCP_DELAY_HACK=true` (or equivalent simulation in a manual test) shows `[deferred-tools-restore] restored ...` in proxy stderr and the corresponding cache-creation drop
-- Codex review with no blockers
+- All 16 new tests pass; full proxy test suite green
+- README has the "why we don't ship" note in the git-status section, phrased as technical impossibility (not preference)
+- `claude --continue` against a project with MCP delay shows `[deferred-tools-restore] restored ...` in proxy stderr and a corresponding cache-creation drop
+- Codex re-review with no blockers
 - PR description closes #59 (`Closes #59`)
 
 ## #59 close-out comment (for the merger to post when merging)
 
-> Final piece of the port. Item 10 (git-status strip) is intentionally not ported — `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` already does the right thing at the source, and stripping post-hoc has worse trade-offs than the native flag (false-positive risk against assistant text, removes recoverable Bash-tool context). README updated in this PR to document the reasoning.
+> Final piece of the port. Item 10 (git-status strip) is intentionally not ported because the proxy can't fix it — by the time a request reaches the proxy, CC has already composed the system prompt and conditioned the prior turn on its contents. The fix has to happen at the source via `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1`. README updated in this PR to document the reasoning.
 >
-> Closing #59. All ten items have been resolved (eight ported, item 10 deferred to native CC flag with README note).
+> Closing #59. All ten items resolved (eight ported, item 10 deferred to native CC flag with README note).
 >
 > — AI Team Lead
 

--- a/docs/directives/proxy-deferred-tools-restore.md
+++ b/docs/directives/proxy-deferred-tools-restore.md
@@ -23,15 +23,38 @@ The preload version uses `process.cwd()` as the snapshot key. **This does not tr
 - In preload, `process.cwd()` is the Claude Code process's CWD — different per CC session per project.
 - In the proxy, `process.cwd()` is the long-lived proxy daemon's CWD — **shared across all CC sessions on the host**. Two unrelated projects would collide onto the same snapshot file.
 
-The proxy version derives the snapshot key from the **system prompt content**, not the proxy's CWD:
+A previous revision proposed `sha1(JSON.stringify(payload.system).slice(0, 2000))` as the key. **This is also unsafe** for two competing reasons:
 
-```
-key = sha1(JSON.stringify(payload.system).slice(0, 2000)).slice(0, 16)
-```
+- The first ~500 chars of CC's system prompt are stable across sessions but **identical across all projects** (it's the role boilerplate). Hashing only the leading region produces project-blind keys.
+- Going deeper into the slice catches project-distinguishing content (cwd line, CLAUDE.md, skills) but also catches volatile content (git status text, hook output) that drifts between sessions for the same project.
 
-Same project (same CC project root, same CLAUDE.md, same skills) → same system prompt → same key. Different projects → different system prompts → different keys. This matches the keying scheme that `prefix-diff` (PR #65) uses, with the same rationale.
+Either failure mode breaks restore reliability or causes cross-project contamination.
 
-If `payload.system` is absent or empty, the extension no-ops (no key → no snapshot work). This is correct behavior: a request with no system prompt has no project identity for the proxy to key on.
+### The proxy version parses the cwd directly from the system prompt
+
+CC injects the working directory into the system prompt content as a deterministic marker (e.g., a line like `Working directory: /path/to/project` or an `<env>` block — exact format to be confirmed empirically during implementation against current CC versions). The proxy:
+
+1. Walks `payload.system` text content looking for the cwd marker.
+2. If found → key = `sha1("cwd:" + extractedPath).slice(0, 16)`. Stable across CC restarts for same project. Unique per project.
+3. If not found → **no-op for this request** (no persist, no restore). Better to do nothing than to fall back to an unsafe heuristic.
+
+This honest no-op is a correctness property: when the proxy can't reliably identify the project, the deferred-tools-restore behavior degrades to the status quo (cache may bust on the next resume), which is identical to the user not having the extension at all. The system never silently corrupts state by restoring the wrong block.
+
+### Why this passes the previous Codex blocker
+
+- `cwd:` derivation is invariant under file edits, hook firings, and git-status changes — none of those rewrite the cwd line.
+- Cross-project collision requires two projects with the same cwd string, which is impossible by definition.
+- If CC changes its system-prompt format and the marker disappears, the no-op fallback prevents incorrect restores. The implementation should log a debug warning when the marker is missing for >N consecutive requests so we notice format drift.
+
+### Marker-format research (to do during implementation)
+
+Before locking the parser, the implementation must:
+- Capture a real CC v2.1.117+ system prompt via `proxy/extensions/request-log.mjs` (or a dedicated short-lived debug extension)
+- Identify the actual cwd marker format (line prefix, surrounding tags, position in the content)
+- Build a regex that matches the current format and document a fallback if CC introduces multiple variants
+- Add a test fixture using the real captured prompt shape (sanitized of any user paths)
+
+If the empirical inspection shows the cwd is NOT reliably present in the system prompt, escalate before shipping — at that point the choice is option (B): drop the extension and document why deferred-tools-restore is preload-only.
 
 ## Reference (preload behavior to mirror)
 
@@ -39,18 +62,19 @@ If `payload.system` is absent or empty, the extension no-ops (no key → no snap
 - `preload.mjs` lines ~2286–2322 (integration block — persist-or-restore decision)
 - Env var: `CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1` to opt out (extension defaults **ON**)
 - Snapshot dir: `~/.claude/cache-fix-state/`
-- Snapshot file: `deferred-tools-<key>.txt` where `<key>` is the system-hash described above
+- Snapshot file: `deferred-tools-<key>.txt` where `<key>` is `sha1("cwd:" + extractedCwd).slice(0, 16)`
 - Markers (unchanged from preload):
   - AVAILABLE: `"The following deferred tools are now available via ToolSearch"`
   - UNAVAILABLE: `"The following deferred tools are no longer available"`
 
 ### Algorithm
 
-1. Compute snapshot key from `payload.system`. If empty/absent → no-op.
-2. Walk `body.messages` to locate the deferred-tools block — only `role: "user"` messages, only `type: "text"` blocks containing the AVAILABLE marker. Return `{ msgIdx, blockIdx, text }` or `null`. (Skip assistant messages so the agent quoting the marker doesn't trigger a false match.)
-3. If no block found → no-op.
-4. If block exists and does **not** contain the UNAVAILABLE marker → it's a clean baseline. Persist it (best-effort, atomic write — see below).
-5. If block exists and **does** contain the UNAVAILABLE marker → attempt restore:
+1. Parse cwd from `payload.system`. If `payload.system` is absent, empty, or no cwd marker is found → **no-op for this request** (skip both persist and restore).
+2. Compute snapshot key: `sha1("cwd:" + extractedCwd).slice(0, 16)`.
+3. Walk `body.messages` to locate the deferred-tools block — only `role: "user"` messages, only `type: "text"` blocks containing the AVAILABLE marker. Return `{ msgIdx, blockIdx, text }` or `null`. (Skip assistant messages so the agent quoting the marker doesn't trigger a false match.)
+4. If no block found → no-op.
+5. If block exists and does **not** contain the UNAVAILABLE marker → it's a clean baseline. Persist it (best-effort, atomic write — see below).
+6. If block exists and **does** contain the UNAVAILABLE marker → attempt restore:
    - Read snapshot file. If unreadable, malformed, or shorter than a sane minimum (e.g., < length of `AVAILABLE` marker) → skip restore (treat as no snapshot).
    - **Only substitute if the snapshot is strictly longer than the current block.** Never downgrade.
    - Substitute by replacing `messages[msgIdx].content[blockIdx].text` with the snapshotted bytes.
@@ -91,7 +115,8 @@ The restored block may reference MCP tools that haven't actually reconnected yet
 
 Match the prefix-diff revision: **do not** introduce `CACHE_FIX_DEFERRED_TOOLS_DIR` as a runtime env var. Instead, export the underlying pure functions alongside `default`:
 
-- `deriveSnapshotKey(systemPrompt)` — returns the sha1 hash key, exposed for tests
+- `extractCwdFromSystem(systemPrompt)` — returns the cwd string or `null` if no marker found, exposed for tests
+- `deriveSnapshotKey(cwd)` — returns `sha1("cwd:" + cwd).slice(0, 16)`, exposed for tests
 - `findDeferredToolsBlockInBody(body)` — returns `{ msgIdx, blockIdx, text } | null`
 - `persistDeferredTools(text, options)` — atomic write to `options.dir`
 - `restoreDeferredTools(options)` — read + validate; returns `string | null`
@@ -118,24 +143,28 @@ Set `ctx.meta.deferredToolsRestoreStats = { action: "persisted"|"restored"|"skip
 
 1. No-op when `CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1`
 2. No-op when no deferred-tools block exists in `body.messages`
-3. No-op when `payload.system` is absent (no key)
-4. Persists snapshot when block is clean (no UNAVAILABLE marker)
-5. `deriveSnapshotKey` is deterministic for identical system prompts and differs for distinct system prompts
-6. Restores from snapshot when current block has UNAVAILABLE marker AND snapshot is longer
-7. **Downgrade guard — exhaustive boundary tests:**
-   - Snapshot exactly 1 byte shorter than current → skip restore
-   - Snapshot many bytes shorter than current → skip restore
-   - Snapshot exactly equal length to current → skip restore (must be **strictly** longer)
-   - Snapshot 1 byte longer → restore
-8. Skips restore when no snapshot file exists
-9. Skips assistant messages (block in assistant content does not trigger detection)
-10. Locates block at `messages[N].content[M]` for arbitrary N, M (not just `[0][0]`)
-11. **Atomic write under failure:** simulate `rename` throwing after `.tmp` write succeeds; assert the prior snapshot file is intact and unchanged
-12. **Truncated snapshot rejection:** write a snapshot file shorter than `AVAILABLE_MARKER.length`; next call must skip restore (never substitute a truncated value)
-13. **Missing-marker rejection:** write a same-length snapshot that doesn't contain the AVAILABLE marker; next call must skip restore
-14. **Concurrent invocations:** fire two `default.onRequest` calls in parallel against the same key; assert no throw, snapshot file is one of the two valid versions (not partial), and at least one call's stats reflect the persistence
-15. Snapshot read failure (point dir at unreadable path) does not throw; debug-logs when `CACHE_FIX_DEBUG=1`
-16. Snapshot write failure (point dir at `/dev/null/nope`) does not throw; debug-logs when `CACHE_FIX_DEBUG=1`
+3. No-op when `payload.system` is absent
+4. **No-op when cwd marker is not present in `payload.system`** (assert that no file is written and no restore is attempted; assert that `ctx.body` is unchanged)
+5. `extractCwdFromSystem` returns the path when the marker is present in any block of the system array; returns `null` otherwise
+6. `extractCwdFromSystem` is robust against the marker appearing inside a code-fenced or quoted region of an unrelated block (the implementation should look in expected positions, not just any text containing the marker substring)
+7. `deriveSnapshotKey("/foo")` is deterministic across calls; `deriveSnapshotKey("/foo")` ≠ `deriveSnapshotKey("/bar")`
+8. Persists snapshot when block is clean (no UNAVAILABLE marker) AND cwd is parseable
+9. Restores from snapshot when current block has UNAVAILABLE marker AND snapshot is longer AND cwd is parseable
+10. **Downgrade guard — exhaustive boundary tests:**
+    - Snapshot exactly 1 byte shorter than current → skip restore
+    - Snapshot many bytes shorter than current → skip restore
+    - Snapshot exactly equal length to current → skip restore (must be **strictly** longer)
+    - Snapshot 1 byte longer → restore
+11. Skips restore when no snapshot file exists
+12. Skips assistant messages (block in assistant content does not trigger detection)
+13. Locates block at `messages[N].content[M]` for arbitrary N, M (not just `[0][0]`)
+14. **Atomic write under failure:** simulate `rename` throwing after `.tmp` write succeeds; assert the prior snapshot file is intact and unchanged
+15. **Atomic write — temp-write failure:** simulate `writeFile` throwing on the `.tmp` path; assert no `.tmp` orphan, no rename attempted, prior snapshot intact
+16. **Truncated snapshot rejection:** write a snapshot file shorter than `AVAILABLE_MARKER.length`; next call must skip restore (never substitute a truncated value)
+17. **Missing-marker rejection:** write a same-length snapshot that doesn't contain the AVAILABLE marker; next call must skip restore
+18. **Concurrent invocations:** fire two `default.onRequest` calls in parallel against the same key; assert no throw, snapshot file is one of the two valid versions (not partial), and at least one call's stats reflect the persistence
+19. Snapshot read failure (point dir at unreadable path) does not throw; debug-logs when `CACHE_FIX_DEBUG=1`
+20. Snapshot write failure (point dir at `/dev/null/nope`) does not throw; debug-logs when `CACHE_FIX_DEBUG=1`
 
 ## README update (handles #59 item 10)
 
@@ -153,10 +182,11 @@ Closing-out comment on #59 should reference this README addition.
 
 ## Acceptance
 
-- All 16 new tests pass; full proxy test suite green
+- All 20 new tests pass; full proxy test suite green
+- The cwd-marker format is verified empirically against current CC v2.1.117+ system prompts (capture via request-log; document the actual marker shape in a code comment)
 - README has the "why we don't ship" note in the git-status section, phrased as technical impossibility (not preference)
 - `claude --continue` against a project with MCP delay shows `[deferred-tools-restore] restored ...` in proxy stderr and a corresponding cache-creation drop
-- Codex re-review with no blockers
+- Codex implementation-stage review with no blockers
 - PR description closes #59 (`Closes #59`)
 
 ## #59 close-out comment (for the merger to post when merging)

--- a/docs/directives/proxy-deferred-tools-restore.md
+++ b/docs/directives/proxy-deferred-tools-restore.md
@@ -1,0 +1,109 @@
+# Directive: Port `deferred-tools-restore` to proxy extension + close out #59
+
+**Issues:** #59 item 6 (deferred-tools-restore), #59 item 10 (git-status strip — closed via README, not ported)
+**Branch:** `feature/proxy-deferred-tools-restore`
+**Stage:** directive
+
+This is the **final PR for #59**. It ports the last behavior-bearing item, documents why item 10 is intentionally not ported, and closes #59.
+
+## Goal
+
+Port the `deferred_tools_restore` fix from `preload.mjs` to a proxy extension. This **modifies outgoing requests** by substituting a stale, shrunken deferred-tools attachment block with a previously-snapshotted full-form copy when MCP servers haven't reconnected yet at resume time.
+
+## Why
+
+Observed empirically: on `claude --continue`, if MCP servers haven't finished reconnecting before CC fires the first post-resume request, the `<system-reminder>The following deferred tools are now available via ToolSearch…` block at `msg[0]` (or wherever the attachment lands post-compaction) shrinks dramatically. A full list of ~40 tools collapses to a handful of CC built-ins, and CC injects a trailing `The following deferred tools are no longer available (their MCP server disconnected). Do not search for them — ToolSearch will return no match:` notice.
+
+That block change at the root of the message array busts the cache at the very top — the entire ~940K prompt re-caches. By the time the second post-resume request fires, MCPs are usually reconnected and the block is full again, but the cache is already committed to the shrunk version for this session.
+
+## Reference (preload behavior to mirror)
+
+- `preload.mjs` lines ~429–518 (helpers + constants)
+- `preload.mjs` lines ~2286–2322 (integration block)
+- Env var: `CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1` to opt out (extension defaults **ON**)
+- Snapshot dir: `~/.claude/cache-fix-state/`
+- Snapshot file: `deferred-tools-<sha1(key).slice(0,16)>.txt`
+- Snapshot key: `process.cwd()` (one snapshot per project)
+- Markers:
+  - AVAILABLE: `"The following deferred tools are now available via ToolSearch"`
+  - UNAVAILABLE: `"The following deferred tools are no longer available"`
+
+### Algorithm
+
+1. Walk `body.messages` to locate the deferred-tools block — only `role: "user"` messages, only `type: "text"` blocks containing the AVAILABLE marker. Return `{ msgIdx, blockIdx, text }` or `null`. (Skip assistant messages so the agent quoting the marker doesn't trigger a false match.)
+2. If no block found → no-op, return.
+3. If block exists and does **not** contain the UNAVAILABLE marker → it's a clean baseline. Persist it to the snapshot file (best-effort; swallow I/O errors). Done.
+4. If block exists and **does** contain the UNAVAILABLE marker → attempt restore:
+   - Read snapshot file.
+   - **Only substitute if the snapshot is strictly longer than the current block.** Never downgrade to a stale shorter snapshot. (This is the safety guard from the preload version — keep it.)
+   - Substitute by replacing `messages[msgIdx].content[blockIdx].text` with the snapshotted bytes.
+
+### Trade-off (document in extension header comment, mirroring preload)
+
+The restored block may reference MCP tools that haven't actually reconnected yet. If the agent calls ToolSearch on one of them → no match → one retry. Tiny cost versus a full-prompt cache miss on every resume.
+
+## Extension contract
+
+- File: `proxy/extensions/deferred-tools-restore.mjs`
+- `name`: `"deferred-tools-restore"`
+- `description`: `"Persist and restore the deferred-tools attachment block across sessions to prevent MCP-reconnect-race cache busts at resume time"`
+- `enabled`: `true` (defaults ON, mirroring preload — opt out via `CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1`)
+- `order`: `350` (after `identity-normalization` at 300, before `cache-control-normalize` at 400 — block content must be stable before cache_control marker placement)
+- Hook: `onRequest(ctx)` — locates block, persists or restores
+- Snapshot dir override (for tests): `CACHE_FIX_DEFERRED_TOOLS_DIR` env var; default `~/.claude/cache-fix-state/`
+
+**Error handling:** mirror preload — wrap all I/O in try/catch and silently swallow. Snapshot write failure must not block the request. Snapshot read failure is treated as "no snapshot" (skip restore).
+
+**Telemetry:** emit a `process.stderr.write` line on `applied` and `persisted` events, matching the existing extension style:
+- `[deferred-tools-restore] persisted N bytes to <path>`
+- `[deferred-tools-restore] restored N→M bytes at msg[X].content[Y]`
+
+Set `ctx.meta.deferredToolsRestoreStats = { action: "persisted"|"restored"|"skipped", bytes: <N> }` for observability.
+
+## Tests (in `test/proxy-deferred-tools-restore.test.mjs`)
+
+1. No-op when `CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1`
+2. No-op when no deferred-tools block exists in `body.messages`
+3. Persists snapshot when block is clean (no UNAVAILABLE marker)
+4. Snapshot path derives correctly from `CACHE_FIX_DEFERRED_TOOLS_DIR` + sha1(cwd) hash
+5. Restores from snapshot when current block has UNAVAILABLE marker AND snapshot is longer
+6. **Does not** restore when snapshot exists but is shorter than current block (downgrade guard)
+7. **Does not** restore when no snapshot file exists
+8. Skips assistant messages (block in assistant content does not trigger detection)
+9. Locates block at `messages[N].content[M]` for arbitrary N, M (not just `[0][0]`)
+10. Snapshot read failure does not throw; results in skipped restore
+11. Snapshot write failure (point dir at `/dev/null/nope`) does not throw
+
+Use `CACHE_FIX_DEFERRED_TOOLS_DIR=<tmpdir>` for test isolation.
+
+## README update (handles #59 item 10)
+
+Edit `README.md`'s "Recommended: disable git-status injection" section (line ~274) to add an explicit note:
+
+> **Why we don't ship a proxy extension for this:** `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` is the right tool for the job — it prevents the injection at the source rather than stripping it after the fact. Stripping post-hoc would also remove the agent's ability to see git context that an explicit Bash call can recover, and would risk false-positive matches against assistant-written text. Use the native flag.
+
+This is the substance of why item 10 is intentionally not ported. Closing-out comment on #59 should reference this README addition.
+
+## Out of scope
+
+- No `extensions.json` registration (auto-loaded from `proxy/extensions/`)
+- No image-stripping section update (separate cleanup; that section is mislabeled "preload mode" but the proxy now supports it — track separately)
+- No CHANGELOG bump (release work)
+
+## Acceptance
+
+- All 11 new tests pass; full proxy test suite green
+- README has the "why we don't ship" note in the git-status section
+- `claude --continue` with `MCP_DELAY_HACK=true` (or equivalent simulation in a manual test) shows `[deferred-tools-restore] restored ...` in proxy stderr and the corresponding cache-creation drop
+- Codex review with no blockers
+- PR description closes #59 (`Closes #59`)
+
+## #59 close-out comment (for the merger to post when merging)
+
+> Final piece of the port. Item 10 (git-status strip) is intentionally not ported — `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` already does the right thing at the source, and stripping post-hoc has worse trade-offs than the native flag (false-positive risk against assistant text, removes recoverable Bash-tool context). README updated in this PR to document the reasoning.
+>
+> Closing #59. All ten items have been resolved (eight ported, item 10 deferred to native CC flag with README note).
+>
+> — AI Team Lead
+
+— AI Team Lead

--- a/proxy/extensions/deferred-tools-restore.mjs
+++ b/proxy/extensions/deferred-tools-restore.mjs
@@ -1,0 +1,300 @@
+// deferred-tools-restore — preserve cache prefix across MCP reconnect race.
+//
+// PROBLEM (mirrored from preload.mjs ~429-518):
+// On `claude --continue`, if MCP servers haven't finished reconnecting before
+// CC fires the first post-resume request, the
+//   <system-reminder>The following deferred tools are now available via ToolSearch…</system-reminder>
+// block at msg[0] (or wherever the attachment lands post-compaction) shrinks
+// dramatically. ~40 tools collapse to a handful of CC built-ins, and CC
+// injects a trailing
+//   "The following deferred tools are no longer available (their MCP server
+//    disconnected). Do not search for them — ToolSearch will return no match:"
+// notice. That block change at the root of the message array busts the cache
+// at the very top — the entire ~940K prompt re-caches.
+//
+// FIX: Persist the clean (no-UNAVAILABLE-marker) form of the block. On a
+// subsequent request where the block has shrunk and contains the UNAVAILABLE
+// marker, substitute the persisted full bytes. Restore only if the snapshot
+// is STRICTLY LONGER than the current block — never downgrade to a stale
+// shorter snapshot.
+//
+// SNAPSHOT KEY (proxy-specific adaptation):
+// Preload uses process.cwd() because each preload runs in the CC process,
+// where cwd identifies the project. The proxy is a long-lived daemon; its
+// cwd is shared across all CC sessions on the host. To key per-project, the
+// proxy parses the cwd OUT of the system prompt content (CC injects
+// " - Primary working directory: <path>" in the # Environment section) and
+// keys on sha1("cwd:" + that path). Verified empirically against CC v2.1.117.
+//
+// FAIL-OPEN: If the cwd marker is absent (CC format drift, missing system
+// prompt), the extension no-ops the request entirely. Result: status quo
+// cache-bust, never silently restores the wrong block.
+
+import {
+  mkdir as _mkdir,
+  readFile as _readFile,
+  writeFile as _writeFile,
+  rename as _rename,
+} from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createHash } from "node:crypto";
+
+const SKIP = process.env.CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE === "1";
+const DEBUG = process.env.CACHE_FIX_DEBUG === "1";
+
+const AVAILABLE_MARKER =
+  "The following deferred tools are now available via ToolSearch";
+const UNAVAILABLE_MARKER =
+  "The following deferred tools are no longer available";
+
+// Empirically verified against CC v2.1.117+. The marker line lives in the
+// stable # Environment section, before the volatile gitStatus content.
+const CWD_MARKER_RE =
+  /^\s*-\s+Primary working directory:\s*(.+?)\s*$/m;
+
+const DEFAULT_FS = {
+  mkdir: _mkdir,
+  readFile: _readFile,
+  writeFile: _writeFile,
+  rename: _rename,
+};
+
+function getSnapshotDir() {
+  return join(homedir(), ".claude", "cache-fix-state");
+}
+
+function debug(msg) {
+  if (DEBUG) process.stderr.write(`[deferred-tools-restore] ${msg}\n`);
+}
+
+/**
+ * Extract the working-directory path from CC's system prompt.
+ * Returns the parsed path string, or null if the marker is not found.
+ *
+ * Accepts:
+ *   - array of content blocks (CC's normal shape): walks .text fields
+ *   - a single string (rare; older clients): scans directly
+ *   - anything else: returns null
+ */
+function extractCwdFromSystem(system) {
+  if (!system) return null;
+  const texts = [];
+  if (typeof system === "string") {
+    texts.push(system);
+  } else if (Array.isArray(system)) {
+    for (const block of system) {
+      if (block && typeof block === "object" && typeof block.text === "string") {
+        texts.push(block.text);
+      }
+    }
+  } else {
+    return null;
+  }
+  for (const t of texts) {
+    const m = t.match(CWD_MARKER_RE);
+    if (m && m[1]) return m[1];
+  }
+  return null;
+}
+
+function deriveSnapshotKey(cwd) {
+  return createHash("sha1").update(`cwd:${cwd}`).digest("hex").slice(0, 16);
+}
+
+/**
+ * Locate the deferred-tools attachment block in body.messages.
+ * Only inspects user messages (skips assistant so the agent quoting the
+ * AVAILABLE marker verbatim doesn't trigger a false match).
+ * Returns { msgIdx, blockIdx, text } or null.
+ */
+function findDeferredToolsBlockInBody(body) {
+  if (!body || !Array.isArray(body.messages)) return null;
+  for (let m = 0; m < body.messages.length; m++) {
+    const msg = body.messages[m];
+    if (!msg || msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    for (let i = 0; i < msg.content.length; i++) {
+      const b = msg.content[i];
+      if (
+        b &&
+        b.type === "text" &&
+        typeof b.text === "string" &&
+        b.text.includes(AVAILABLE_MARKER)
+      ) {
+        return { msgIdx: m, blockIdx: i, text: b.text };
+      }
+    }
+  }
+  return null;
+}
+
+// Atomic write (same lesson as prefix-diff): unique tmp per invocation so
+// concurrent calls don't collide on a shared .tmp path.
+async function atomicWriteText(finalPath, data, fs) {
+  const tmpPath = `${finalPath}.${process.pid}.${Date.now()}.${Math.random()
+    .toString(36)
+    .slice(2, 10)}.tmp`;
+  await fs.writeFile(tmpPath, data);
+  await fs.rename(tmpPath, finalPath);
+}
+
+/**
+ * Persist a snapshot of the clean deferred-tools block.
+ *
+ * @param {string} text  The full block text to persist.
+ * @param {object} options
+ * @param {string} options.dir  Snapshot directory.
+ * @param {string} options.key  Snapshot key (from deriveSnapshotKey).
+ * @param {object} [options.fs] fs/promises overrides for tests.
+ * @returns {Promise<{persisted: boolean, bytes: number, path: string}>}
+ */
+async function persistDeferredTools(text, options) {
+  const dir = options.dir;
+  const key = options.key;
+  const fs = { ...DEFAULT_FS, ...(options.fs || {}) };
+  const path = join(dir, `deferred-tools-${key}.txt`);
+  try {
+    await fs.mkdir(dir, { recursive: true });
+    await atomicWriteText(path, text, fs);
+    return { persisted: true, bytes: Buffer.byteLength(text, "utf-8"), path };
+  } catch (err) {
+    debug(`persist failed at ${path}: ${err?.message ?? err}`);
+    return { persisted: false, bytes: 0, path };
+  }
+}
+
+/**
+ * Read and validate a snapshot. Returns the snapshot text on success, null
+ * otherwise. Validation:
+ *  - file exists and is readable
+ *  - byte length >= AVAILABLE_MARKER length (sanity floor)
+ *  - content contains the AVAILABLE marker (defense in depth against a
+ *    truncated-but-readable file passing only the length check)
+ */
+async function restoreDeferredTools(options) {
+  const dir = options.dir;
+  const key = options.key;
+  const fs = { ...DEFAULT_FS, ...(options.fs || {}) };
+  const path = join(dir, `deferred-tools-${key}.txt`);
+  let snapshot;
+  try {
+    snapshot = await fs.readFile(path, "utf-8");
+  } catch (err) {
+    if (err && err.code !== "ENOENT") {
+      debug(`snapshot read failed at ${path}: ${err?.message ?? err}`);
+    }
+    return null;
+  }
+  if (typeof snapshot !== "string") return null;
+  if (snapshot.length < AVAILABLE_MARKER.length) {
+    debug(`snapshot rejected (too short: ${snapshot.length} bytes) at ${path}`);
+    return null;
+  }
+  if (!snapshot.includes(AVAILABLE_MARKER)) {
+    debug(`snapshot rejected (missing AVAILABLE marker) at ${path}`);
+    return null;
+  }
+  return snapshot;
+}
+
+export {
+  extractCwdFromSystem,
+  deriveSnapshotKey,
+  findDeferredToolsBlockInBody,
+  persistDeferredTools,
+  restoreDeferredTools,
+  AVAILABLE_MARKER,
+  UNAVAILABLE_MARKER,
+  CWD_MARKER_RE,
+};
+
+export default {
+  name: "deferred-tools-restore",
+  description:
+    "Persist and restore the deferred-tools attachment block across sessions to prevent MCP-reconnect-race cache busts at resume time",
+  enabled: true,
+  order: 350,
+
+  async onRequest(ctx) {
+    if (SKIP) return;
+    if (!ctx || !ctx.body) return;
+    const body = ctx.body;
+
+    // 1. Parse cwd from system. No marker → no-op (honest degradation).
+    const cwd = extractCwdFromSystem(body.system);
+    if (!cwd) {
+      ctx.meta = ctx.meta || {};
+      ctx.meta.deferredToolsRestoreStats = { action: "skipped", reason: "no-cwd" };
+      return;
+    }
+    const key = deriveSnapshotKey(cwd);
+
+    // 2-4. Locate the deferred-tools block.
+    const found = findDeferredToolsBlockInBody(body);
+    if (!found) {
+      ctx.meta = ctx.meta || {};
+      ctx.meta.deferredToolsRestoreStats = { action: "skipped", reason: "no-block", key };
+      return;
+    }
+
+    const dir = getSnapshotDir();
+    const hasUnavail = found.text.includes(UNAVAILABLE_MARKER);
+
+    if (!hasUnavail) {
+      // 5. Clean baseline → persist.
+      const result = await persistDeferredTools(found.text, { dir, key });
+      ctx.meta = ctx.meta || {};
+      ctx.meta.deferredToolsRestoreStats = {
+        action: result.persisted ? "persisted" : "skipped",
+        bytes: result.bytes,
+        key,
+      };
+      if (result.persisted) {
+        process.stderr.write(
+          `[deferred-tools-restore] persisted ${result.bytes} bytes (key=${key})\n`,
+        );
+      }
+      return;
+    }
+
+    // 6. Block has UNAVAILABLE marker → attempt restore.
+    const snapshot = await restoreDeferredTools({ dir, key });
+    if (!snapshot) {
+      ctx.meta = ctx.meta || {};
+      ctx.meta.deferredToolsRestoreStats = { action: "skipped", reason: "no-snapshot", key };
+      return;
+    }
+
+    // Strictly-longer guard. Equal-length snapshots are not restored.
+    if (snapshot.length <= found.text.length) {
+      ctx.meta = ctx.meta || {};
+      ctx.meta.deferredToolsRestoreStats = {
+        action: "skipped",
+        reason: "snapshot-not-longer",
+        key,
+        snapshotBytes: snapshot.length,
+        currentBytes: found.text.length,
+      };
+      return;
+    }
+
+    // Substitute. Build new content array and new message; do not mutate
+    // the original arrays / objects.
+    const targetMsg = body.messages[found.msgIdx];
+    const newContent = targetMsg.content.slice();
+    newContent[found.blockIdx] = { ...newContent[found.blockIdx], text: snapshot };
+    body.messages[found.msgIdx] = { ...targetMsg, content: newContent };
+
+    ctx.meta = ctx.meta || {};
+    ctx.meta.deferredToolsRestoreStats = {
+      action: "restored",
+      bytes: snapshot.length,
+      previousBytes: found.text.length,
+      key,
+    };
+    process.stderr.write(
+      `[deferred-tools-restore] restored ${found.text.length}→${snapshot.length} bytes ` +
+        `at msg[${found.msgIdx}].content[${found.blockIdx}] (key=${key})\n`,
+    );
+  },
+};

--- a/proxy/extensions/deferred-tools-restore.mjs
+++ b/proxy/extensions/deferred-tools-restore.mjs
@@ -72,11 +72,24 @@ function debug(msg) {
  * Extract the working-directory path from CC's system prompt.
  * Returns the parsed path string, or null if the marker is not found.
  *
+ * SECTION-AWARE: Only matches the marker within CC's actual # Environment
+ * section. A bare regex over all text blocks would accept a code-fenced
+ * fake marker (e.g. an example in another block) ahead of the real one
+ * and derive the wrong key — exactly the false-positive Codex flagged on
+ * the first implementation review.
+ *
+ * Algorithm: find the `# Environment` header in any text block, then look
+ * for the marker line within a small window after it (the env section is
+ * <1KB in practice; window cap is generous defense). If no `# Environment`
+ * header → null (fail-open: extension no-ops the request).
+ *
  * Accepts:
- *   - array of content blocks (CC's normal shape): walks .text fields
+ *   - array of content blocks (CC's normal shape): walks .text fields in order
  *   - a single string (rare; older clients): scans directly
  *   - anything else: returns null
  */
+const ENV_SECTION_WINDOW = 1500;
+
 function extractCwdFromSystem(system) {
   if (!system) return null;
   const texts = [];
@@ -92,7 +105,10 @@ function extractCwdFromSystem(system) {
     return null;
   }
   for (const t of texts) {
-    const m = t.match(CWD_MARKER_RE);
+    const envIdx = t.indexOf("# Environment");
+    if (envIdx === -1) continue;
+    const window = t.slice(envIdx, envIdx + ENV_SECTION_WINDOW);
+    const m = window.match(CWD_MARKER_RE);
     if (m && m[1]) return m[1];
   }
   return null;
@@ -192,6 +208,14 @@ async function restoreDeferredTools(options) {
   }
   if (!snapshot.includes(AVAILABLE_MARKER)) {
     debug(`snapshot rejected (missing AVAILABLE marker) at ${path}`);
+    return null;
+  }
+  // Defense in depth: persisted snapshots should be clean by construction
+  // (we only persist when !hasUnavail), but if a snapshot ever contains the
+  // UNAVAILABLE marker we refuse to restore it — restoring a "no longer
+  // available" block would be worse than no restore.
+  if (snapshot.includes(UNAVAILABLE_MARKER)) {
+    debug(`snapshot rejected (contains UNAVAILABLE marker, not a clean baseline) at ${path}`);
     return null;
   }
   return snapshot;

--- a/proxy/extensions/deferred-tools-restore.mjs
+++ b/proxy/extensions/deferred-tools-restore.mjs
@@ -48,11 +48,6 @@ const AVAILABLE_MARKER =
 const UNAVAILABLE_MARKER =
   "The following deferred tools are no longer available";
 
-// Empirically verified against CC v2.1.117+. The marker line lives in the
-// stable # Environment section, before the volatile gitStatus content.
-const CWD_MARKER_RE =
-  /^\s*-\s+Primary working directory:\s*(.+?)\s*$/m;
-
 const DEFAULT_FS = {
   mkdir: _mkdir,
   readFile: _readFile,
@@ -70,25 +65,66 @@ function debug(msg) {
 
 /**
  * Extract the working-directory path from CC's system prompt.
- * Returns the parsed path string, or null if the marker is not found.
+ * Returns the parsed path string, or null if the marker is not found OR
+ * the prompt structure is ambiguous (multiple valid env sections).
  *
- * SECTION-AWARE: Only matches the marker within CC's actual # Environment
- * section. A bare regex over all text blocks would accept a code-fenced
- * fake marker (e.g. an example in another block) ahead of the real one
- * and derive the wrong key — exactly the false-positive Codex flagged on
- * the first implementation review.
+ * STRICT STRUCTURAL PARSER (line-based, not regex-window):
  *
- * Algorithm: find the `# Environment` header in any text block, then look
- * for the marker line within a small window after it (the env section is
- * <1KB in practice; window cap is generous defense). If no `# Environment`
- * header → null (fail-open: extension no-ops the request).
+ * Recognizes a valid # Environment section ONLY when ALL of these hold:
+ *   1. A line that is exactly `# Environment` (whitespace-trimmed)
+ *   2. The next non-blank line is exactly the CC intro line:
+ *      `You have been invoked in the following environment:`
+ *   3. The marker appears in a bullet line (`- Primary working directory: ...`)
+ *      within the bullet list immediately following the intro line — bounded
+ *      by the first blank line or first non-bullet line.
+ *
+ * Only the conjunction of all three rejects the false positives Codex flagged:
+ *   - bare `# Environment` mention in narrative/code (fails rule 2)
+ *   - code-fenced `Primary working directory:` example without the env header
+ *     (fails rule 1)
+ *   - a fake marker line elsewhere in the same block but not in a bullet
+ *     list immediately following the intro (fails rule 3)
+ *
+ * AMBIGUITY GUARD: if MULTIPLE distinct valid env sections produce different
+ * cwd values (across blocks or within one block), refuse to pick — return
+ * null. The fail-open path (extension no-ops the request) is strictly safer
+ * than restoring with the wrong snapshot key.
  *
  * Accepts:
  *   - array of content blocks (CC's normal shape): walks .text fields in order
  *   - a single string (rare; older clients): scans directly
  *   - anything else: returns null
  */
-const ENV_SECTION_WINDOW = 1500;
+const ENV_HEADER_LINE = "# Environment";
+const ENV_INTRO_LINE = "You have been invoked in the following environment:";
+const CWD_BULLET_RE = /^-\s+Primary working directory:\s*(.+?)\s*$/;
+
+function parseAllCwdsFromBlock(text) {
+  const found = [];
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() !== ENV_HEADER_LINE) continue;
+    // Skip blank lines after the header (CC emits exactly one intro line
+    // immediately following, but be tolerant of whitespace).
+    let j = i + 1;
+    while (j < lines.length && lines[j].trim() === "") j++;
+    if (j >= lines.length) continue;
+    if (lines[j].trim() !== ENV_INTRO_LINE) continue;
+    // Walk the bullet list following the intro line; first cwd bullet wins
+    // for this section. A blank line or non-bullet line ends the section.
+    for (let k = j + 1; k < lines.length; k++) {
+      const trimmed = lines[k].trimStart();
+      if (lines[k].trim() === "") break;
+      if (!trimmed.startsWith("-")) break;
+      const m = trimmed.match(CWD_BULLET_RE);
+      if (m && m[1]) {
+        found.push(m[1]);
+        break;
+      }
+    }
+  }
+  return found;
+}
 
 function extractCwdFromSystem(system) {
   if (!system) return null;
@@ -104,13 +140,15 @@ function extractCwdFromSystem(system) {
   } else {
     return null;
   }
+  const seen = new Set();
   for (const t of texts) {
-    const envIdx = t.indexOf("# Environment");
-    if (envIdx === -1) continue;
-    const window = t.slice(envIdx, envIdx + ENV_SECTION_WINDOW);
-    const m = window.match(CWD_MARKER_RE);
-    if (m && m[1]) return m[1];
+    const matches = parseAllCwdsFromBlock(t);
+    for (const m of matches) {
+      seen.add(m);
+      if (seen.size > 1) return null; // ambiguous → no-op
+    }
   }
+  if (seen.size === 1) return [...seen][0];
   return null;
 }
 
@@ -229,7 +267,6 @@ export {
   restoreDeferredTools,
   AVAILABLE_MARKER,
   UNAVAILABLE_MARKER,
-  CWD_MARKER_RE,
 };
 
 export default {

--- a/test/proxy-deferred-tools-restore.test.mjs
+++ b/test/proxy-deferred-tools-restore.test.mjs
@@ -1,0 +1,659 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile, rm, readdir, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import ext, {
+  extractCwdFromSystem,
+  deriveSnapshotKey,
+  findDeferredToolsBlockInBody,
+  persistDeferredTools,
+  restoreDeferredTools,
+  AVAILABLE_MARKER,
+  UNAVAILABLE_MARKER,
+} from "../proxy/extensions/deferred-tools-restore.mjs";
+
+// `import.meta.dirname` requires Node 20.11+; CI matrix includes Node 18.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// --- Helpers ---
+
+async function newTmp() {
+  return mkdtemp(join(tmpdir(), "deferred-tools-test-"));
+}
+
+// Build a system block array shaped like real CC v2.1.117+ system prompts:
+// [0] = role boilerplate (identical across projects)
+// [1] = giant block containing # Environment with the cwd marker.
+function makeSystem(cwd, { extra = "" } = {}) {
+  return [
+    { type: "text", text: "You are Claude Code, Anthropic's official CLI for Claude." },
+    {
+      type: "text",
+      text:
+        "boilerplate intro line\n" +
+        "another line\n" +
+        "\n" +
+        "# Environment\n" +
+        "You have been invoked in the following environment: \n" +
+        ` - Primary working directory: ${cwd}\n` +
+        "  - Is a git repository: true\n" +
+        " - Platform: linux\n" +
+        extra,
+    },
+  ];
+}
+
+function makeBaselineBlock(toolCount = 5) {
+  const tools = Array.from({ length: toolCount }, (_, i) => `tool_${i}: a tool`).join("\n");
+  return (
+    `<system-reminder>\n${AVAILABLE_MARKER}:\n${tools}\n</system-reminder>`
+  );
+}
+
+function makeShrunkBlock() {
+  // Shorter; contains both AVAILABLE and UNAVAILABLE markers
+  return (
+    `<system-reminder>\n${AVAILABLE_MARKER}:\nbuiltin_only_1\nbuiltin_only_2\n` +
+    `${UNAVAILABLE_MARKER} (their MCP server disconnected). ` +
+    `Do not search for them — ToolSearch will return no match:\n</system-reminder>`
+  );
+}
+
+function makeBody({ system, deferredText, msgIdx = 0, blockIdx = 0 } = {}) {
+  // Build N user messages so deferredText can sit at arbitrary indices
+  const messages = [];
+  for (let i = 0; i <= msgIdx; i++) {
+    if (i === msgIdx) {
+      const content = [];
+      for (let j = 0; j <= blockIdx; j++) {
+        if (j === blockIdx) {
+          content.push({ type: "text", text: deferredText });
+        } else {
+          content.push({ type: "text", text: `padding_block_${j}` });
+        }
+      }
+      messages.push({ role: "user", content });
+    } else {
+      messages.push({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content: [{ type: "text", text: `padding_msg_${i}` }],
+      });
+    }
+  }
+  return { system, messages };
+}
+
+async function captureStderr(fn) {
+  const chunks = [];
+  const orig = process.stderr.write;
+  process.stderr.write = (chunk) => {
+    chunks.push(chunk.toString());
+    return true;
+  };
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = orig;
+  }
+  return chunks.join("");
+}
+
+// --- extractCwdFromSystem ---
+
+test("extractCwdFromSystem: returns null on missing/empty inputs", () => {
+  assert.equal(extractCwdFromSystem(null), null);
+  assert.equal(extractCwdFromSystem(undefined), null);
+  assert.equal(extractCwdFromSystem(""), null);
+  assert.equal(extractCwdFromSystem([]), null);
+  assert.equal(extractCwdFromSystem(42), null);
+});
+
+test("extractCwdFromSystem: parses cwd from CC's # Environment block", () => {
+  const sys = makeSystem("/home/manager/git_repos/myproject");
+  assert.equal(extractCwdFromSystem(sys), "/home/manager/git_repos/myproject");
+});
+
+test("extractCwdFromSystem: also accepts string system prompt", () => {
+  const text =
+    "# Environment\n" +
+    " - Primary working directory: /var/projects/foo\n" +
+    " - Platform: linux\n";
+  assert.equal(extractCwdFromSystem(text), "/var/projects/foo");
+});
+
+test("extractCwdFromSystem: returns null when marker is absent", () => {
+  const sys = [
+    { type: "text", text: "boilerplate" },
+    { type: "text", text: "no environment section here" },
+  ];
+  assert.equal(extractCwdFromSystem(sys), null);
+});
+
+test("extractCwdFromSystem: narrative mention of working directory does NOT match", () => {
+  // The marker requires line-start "- Primary working directory:"; narrative
+  // text mentioning the phrase does not have that structure.
+  const sys = [
+    {
+      type: "text",
+      text:
+        "When you change the current working directory you should reconsider context. " +
+        "Primary working directory should be respected.",
+    },
+  ];
+  assert.equal(extractCwdFromSystem(sys), null);
+});
+
+test("extractCwdFromSystem: scans across blocks; first match wins", () => {
+  const sys = [
+    { type: "text", text: "no marker here" },
+    {
+      type: "text",
+      text:
+        "# Environment\n" +
+        " - Primary working directory: /first/match\n" +
+        "more content",
+    },
+    {
+      type: "text",
+      text: " - Primary working directory: /should/not/win\n",
+    },
+  ];
+  assert.equal(extractCwdFromSystem(sys), "/first/match");
+});
+
+// --- deriveSnapshotKey ---
+
+test("deriveSnapshotKey: deterministic per cwd, distinct across cwds", () => {
+  const a1 = deriveSnapshotKey("/foo");
+  const a2 = deriveSnapshotKey("/foo");
+  const b = deriveSnapshotKey("/bar");
+  assert.equal(a1, a2);
+  assert.notEqual(a1, b);
+  assert.equal(a1.length, 16);
+});
+
+// --- findDeferredToolsBlockInBody ---
+
+test("findDeferredToolsBlockInBody: finds block at [0][0]", () => {
+  const body = makeBody({ deferredText: makeBaselineBlock() });
+  const found = findDeferredToolsBlockInBody(body);
+  assert.ok(found);
+  assert.equal(found.msgIdx, 0);
+  assert.equal(found.blockIdx, 0);
+});
+
+test("findDeferredToolsBlockInBody: finds block at arbitrary [N][M]", () => {
+  const body = makeBody({ deferredText: makeBaselineBlock(), msgIdx: 4, blockIdx: 3 });
+  const found = findDeferredToolsBlockInBody(body);
+  assert.ok(found);
+  assert.equal(found.msgIdx, 4);
+  assert.equal(found.blockIdx, 3);
+});
+
+test("findDeferredToolsBlockInBody: skips assistant messages", () => {
+  // Place AVAILABLE marker in an assistant message — must NOT match
+  const body = {
+    messages: [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: makeBaselineBlock() }],
+      },
+    ],
+  };
+  assert.equal(findDeferredToolsBlockInBody(body), null);
+});
+
+test("findDeferredToolsBlockInBody: returns null when block missing", () => {
+  const body = {
+    messages: [{ role: "user", content: [{ type: "text", text: "no marker" }] }],
+  };
+  assert.equal(findDeferredToolsBlockInBody(body), null);
+});
+
+// --- persist + restore happy paths ---
+
+test("persistDeferredTools: writes snapshot atomically", async () => {
+  const dir = await newTmp();
+  try {
+    const text = makeBaselineBlock();
+    const key = "abc1234567890def";
+    const result = await persistDeferredTools(text, { dir, key });
+    assert.ok(result.persisted);
+    assert.equal(result.bytes, Buffer.byteLength(text, "utf-8"));
+    const path = join(dir, `deferred-tools-${key}.txt`);
+    const onDisk = await readFile(path, "utf-8");
+    assert.equal(onDisk, text);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("restoreDeferredTools: returns the snapshot when valid", async () => {
+  const dir = await newTmp();
+  try {
+    const text = makeBaselineBlock(20);
+    const key = "abc1234567890def";
+    await persistDeferredTools(text, { dir, key });
+    const restored = await restoreDeferredTools({ dir, key });
+    assert.equal(restored, text);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("restoreDeferredTools: returns null when snapshot missing", async () => {
+  const dir = await newTmp();
+  try {
+    const restored = await restoreDeferredTools({ dir, key: "nonexistentkey00" });
+    assert.equal(restored, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- snapshot integrity validation ---
+
+test("restoreDeferredTools: rejects truncated snapshot (shorter than AVAILABLE_MARKER)", async () => {
+  const dir = await newTmp();
+  try {
+    const key = "trunc1234567890a";
+    const path = join(dir, `deferred-tools-${key}.txt`);
+    await writeFile(path, "tiny");
+    const restored = await restoreDeferredTools({ dir, key });
+    assert.equal(restored, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("restoreDeferredTools: rejects same-length snapshot missing AVAILABLE marker", async () => {
+  const dir = await newTmp();
+  try {
+    const key = "missingmark12345";
+    const path = join(dir, `deferred-tools-${key}.txt`);
+    // Make a snapshot LONGER than AVAILABLE_MARKER but missing the marker text
+    await writeFile(path, "x".repeat(AVAILABLE_MARKER.length + 100));
+    const restored = await restoreDeferredTools({ dir, key });
+    assert.equal(restored, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- atomic write under failure ---
+
+test("persistDeferredTools: rename failure leaves prior snapshot intact", async () => {
+  const dir = await newTmp();
+  try {
+    const key = "renamefail123456";
+    const path = join(dir, `deferred-tools-${key}.txt`);
+    const original = makeBaselineBlock(50);
+    await persistDeferredTools(original, { dir, key });
+    const before = await readFile(path, "utf-8");
+
+    const failingFs = {
+      rename: async () => {
+        throw new Error("simulated rename failure");
+      },
+    };
+    let result;
+    await captureStderr(async () => {
+      result = await persistDeferredTools(makeBaselineBlock(80), {
+        dir,
+        key,
+        fs: failingFs,
+      });
+    });
+    assert.equal(result.persisted, false);
+    const after = await readFile(path, "utf-8");
+    assert.equal(after, before, "original snapshot must be unchanged");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("persistDeferredTools: writeFile failure produces no orphan tmp and no rename", async () => {
+  const dir = await newTmp();
+  try {
+    const key = "writefail1234567";
+
+    let renameCalled = false;
+    const failingFs = {
+      writeFile: async () => {
+        throw new Error("simulated writeFile failure");
+      },
+      rename: async () => {
+        renameCalled = true;
+      },
+    };
+    let result;
+    await captureStderr(async () => {
+      result = await persistDeferredTools(makeBaselineBlock(), {
+        dir,
+        key,
+        fs: failingFs,
+      });
+    });
+    assert.equal(result.persisted, false);
+    assert.equal(renameCalled, false, "rename must not be attempted on writeFile failure");
+    // No .tmp orphan should exist
+    const files = await readdir(dir);
+    assert.equal(files.filter((f) => f.includes(".tmp")).length, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- onRequest end-to-end (extension default export) ---
+
+const CWD = "/home/test/project-X";
+
+function fullBody({ deferredText, system = makeSystem(CWD), msgIdx = 0, blockIdx = 0 } = {}) {
+  const partial = makeBody({ deferredText, msgIdx, blockIdx });
+  return { system, messages: partial.messages };
+}
+
+test("onRequest: no-op when CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1 (verified via re-import)", async () => {
+  const prevSkip = process.env.CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE;
+  try {
+    process.env.CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE = "1";
+    const url =
+      pathToFileURL(
+        join(__dirname, "..", "proxy", "extensions", "deferred-tools-restore.mjs"),
+      ).href + "?skipReload=" + Date.now();
+    const reloaded = await import(url);
+    const ctx = { body: fullBody({ deferredText: makeBaselineBlock() }), meta: {} };
+    const before = JSON.stringify(ctx.body);
+    await reloaded.default.onRequest(ctx);
+    assert.equal(JSON.stringify(ctx.body), before);
+    // No stats set when skip kicks in early
+    assert.equal(ctx.meta.deferredToolsRestoreStats, undefined);
+  } finally {
+    if (prevSkip === undefined) delete process.env.CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE;
+    else process.env.CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE = prevSkip;
+  }
+});
+
+test("onRequest: no-op when system absent", async () => {
+  const ctx = { body: { messages: [] }, meta: {} };
+  await ext.onRequest(ctx);
+  assert.equal(ctx.meta.deferredToolsRestoreStats?.action, "skipped");
+  assert.equal(ctx.meta.deferredToolsRestoreStats?.reason, "no-cwd");
+});
+
+test("onRequest: no-op when cwd marker not in system", async () => {
+  const ctx = {
+    body: { system: [{ type: "text", text: "no environment section" }], messages: [] },
+    meta: {},
+  };
+  await ext.onRequest(ctx);
+  assert.equal(ctx.meta.deferredToolsRestoreStats?.reason, "no-cwd");
+});
+
+test("onRequest: no-op when no deferred-tools block in messages", async () => {
+  const ctx = {
+    body: {
+      system: makeSystem(CWD),
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    },
+    meta: {},
+  };
+  const before = JSON.stringify(ctx.body);
+  await ext.onRequest(ctx);
+  assert.equal(JSON.stringify(ctx.body), before);
+  assert.equal(ctx.meta.deferredToolsRestoreStats?.reason, "no-block");
+});
+
+test("onRequest: persists baseline (no UNAVAILABLE marker)", async () => {
+  const dir = await newTmp();
+  // Persist via the extension end-to-end
+  const baseline = makeBaselineBlock(40);
+  const ctx = { body: fullBody({ deferredText: baseline }), meta: {} };
+
+  // Patch the snapshot dir by temporarily setting HOME
+  const realHome = process.env.HOME;
+  process.env.HOME = dir;
+  try {
+    await captureStderr(async () => {
+      await ext.onRequest(ctx);
+    });
+    assert.equal(ctx.meta.deferredToolsRestoreStats?.action, "persisted");
+    const key = deriveSnapshotKey(CWD);
+    const snapPath = join(dir, ".claude", "cache-fix-state", `deferred-tools-${key}.txt`);
+    const onDisk = await readFile(snapPath, "utf-8");
+    assert.equal(onDisk, baseline);
+  } finally {
+    process.env.HOME = realHome;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("onRequest: restores from snapshot when block has UNAVAILABLE marker AND snapshot longer", async () => {
+  const dir = await newTmp();
+  const baseline = makeBaselineBlock(40);
+  const shrunk = makeShrunkBlock();
+  assert.ok(baseline.length > shrunk.length, "test fixture sanity");
+
+  const realHome = process.env.HOME;
+  process.env.HOME = dir;
+  try {
+    // First call: persist the baseline
+    const ctx1 = { body: fullBody({ deferredText: baseline }), meta: {} };
+    await captureStderr(async () => {
+      await ext.onRequest(ctx1);
+    });
+
+    // Second call: shrunk block, should be restored
+    const ctx2 = { body: fullBody({ deferredText: shrunk }), meta: {} };
+    await captureStderr(async () => {
+      await ext.onRequest(ctx2);
+    });
+    assert.equal(ctx2.meta.deferredToolsRestoreStats?.action, "restored");
+    assert.equal(ctx2.body.messages[0].content[0].text, baseline);
+  } finally {
+    process.env.HOME = realHome;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("onRequest: skips restore when no snapshot exists for key", async () => {
+  const dir = await newTmp();
+  const realHome = process.env.HOME;
+  process.env.HOME = dir;
+  try {
+    // No prior persist; only a shrunk block this time
+    const ctx = { body: fullBody({ deferredText: makeShrunkBlock() }), meta: {} };
+    const before = JSON.stringify(ctx.body);
+    await captureStderr(async () => {
+      await ext.onRequest(ctx);
+    });
+    assert.equal(ctx.meta.deferredToolsRestoreStats?.reason, "no-snapshot");
+    assert.equal(JSON.stringify(ctx.body), before);
+  } finally {
+    process.env.HOME = realHome;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- Downgrade guard exhaustive boundary cases ---
+
+async function downgradeTest(snapshotLen, currentLen, expectAction) {
+  const dir = await newTmp();
+  const realHome = process.env.HOME;
+  process.env.HOME = dir;
+  try {
+    // Build snapshot of exact byte length, ensuring AVAILABLE marker present
+    const padding = (n) =>
+      "x".repeat(Math.max(0, n - AVAILABLE_MARKER.length));
+    const snap = AVAILABLE_MARKER + padding(snapshotLen);
+    const cur =
+      AVAILABLE_MARKER + padding(currentLen - UNAVAILABLE_MARKER.length) + UNAVAILABLE_MARKER;
+    // Sanity: actual lengths
+    assert.equal(snap.length, snapshotLen, "snap length sanity");
+    assert.equal(cur.length, currentLen, "cur length sanity");
+
+    const key = deriveSnapshotKey(CWD);
+    await persistDeferredTools(snap, {
+      dir: join(dir, ".claude", "cache-fix-state"),
+      key,
+    });
+
+    const ctx = { body: fullBody({ deferredText: cur }), meta: {} };
+    await captureStderr(async () => {
+      await ext.onRequest(ctx);
+    });
+    assert.equal(
+      ctx.meta.deferredToolsRestoreStats?.action,
+      expectAction,
+      `snapshot=${snapshotLen}, current=${currentLen}, expected ${expectAction}`,
+    );
+  } finally {
+    process.env.HOME = realHome;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("downgrade guard: snapshot 1 byte shorter than current → skipped", async () => {
+  await downgradeTest(199, 200, "skipped");
+});
+
+test("downgrade guard: snapshot many bytes shorter than current → skipped", async () => {
+  await downgradeTest(150, 250, "skipped");
+});
+
+test("downgrade guard: snapshot exactly equal length to current → skipped", async () => {
+  await downgradeTest(200, 200, "skipped");
+});
+
+test("downgrade guard: snapshot 1 byte longer than current → restored", async () => {
+  await downgradeTest(201, 200, "restored");
+});
+
+// --- Concurrency ---
+
+test("onRequest: concurrent persist calls do not corrupt the snapshot", async () => {
+  const dir = await newTmp();
+  const realHome = process.env.HOME;
+  process.env.HOME = dir;
+  try {
+    const blockA = makeBaselineBlock(30);
+    const blockB = makeBaselineBlock(31);
+    const results = await Promise.all([
+      captureStderr(async () => {
+        await ext.onRequest({ body: fullBody({ deferredText: blockA }), meta: {} });
+      }),
+      captureStderr(async () => {
+        await ext.onRequest({ body: fullBody({ deferredText: blockB }), meta: {} });
+      }),
+    ]);
+    // No stderr should contain a thrown-stack trace
+    for (const out of results) {
+      assert.ok(!out.includes("UnhandledRejection"));
+    }
+    // Final snapshot must be exactly one of the two candidates
+    const key = deriveSnapshotKey(CWD);
+    const snapPath = join(dir, ".claude", "cache-fix-state", `deferred-tools-${key}.txt`);
+    const onDisk = await readFile(snapPath, "utf-8");
+    assert.ok(
+      onDisk === blockA || onDisk === blockB,
+      "final snapshot must equal exactly one of the two candidate blocks",
+    );
+  } finally {
+    process.env.HOME = realHome;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- Debug-log paths (deterministic via re-import with DEBUG=1) ---
+
+test("snapshotPrefix-style: snapshot read failure with debug=1 logs", async () => {
+  const dir = await newTmp();
+  const prevDebug = process.env.CACHE_FIX_DEBUG;
+  try {
+    process.env.CACHE_FIX_DEBUG = "1";
+    const url =
+      pathToFileURL(
+        join(__dirname, "..", "proxy", "extensions", "deferred-tools-restore.mjs"),
+      ).href + "?debugRead=" + Date.now();
+    const reloaded = await import(url);
+
+    const failingFs = {
+      readFile: async () => {
+        const err = new Error("EACCES simulated");
+        err.code = "EACCES";
+        throw err;
+      },
+    };
+    const stderr = await captureStderr(async () => {
+      const out = await reloaded.restoreDeferredTools({
+        dir,
+        key: "abcdef0123456789",
+        fs: failingFs,
+      });
+      assert.equal(out, null);
+    });
+    assert.ok(
+      stderr.includes("snapshot read failed"),
+      `expected debug log, got: ${JSON.stringify(stderr)}`,
+    );
+  } finally {
+    if (prevDebug === undefined) delete process.env.CACHE_FIX_DEBUG;
+    else process.env.CACHE_FIX_DEBUG = prevDebug;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("persistDeferredTools: write failure with debug=1 logs", async () => {
+  const dir = await newTmp();
+  const prevDebug = process.env.CACHE_FIX_DEBUG;
+  try {
+    process.env.CACHE_FIX_DEBUG = "1";
+    const url =
+      pathToFileURL(
+        join(__dirname, "..", "proxy", "extensions", "deferred-tools-restore.mjs"),
+      ).href + "?debugWrite=" + Date.now();
+    const reloaded = await import(url);
+
+    const failingFs = {
+      writeFile: async () => {
+        throw new Error("ENOSPC simulated");
+      },
+    };
+    const stderr = await captureStderr(async () => {
+      const out = await reloaded.persistDeferredTools(makeBaselineBlock(), {
+        dir,
+        key: "abcdef0123456789",
+        fs: failingFs,
+      });
+      assert.equal(out.persisted, false);
+    });
+    assert.ok(
+      stderr.includes("persist failed"),
+      `expected debug log, got: ${JSON.stringify(stderr)}`,
+    );
+  } finally {
+    if (prevDebug === undefined) delete process.env.CACHE_FIX_DEBUG;
+    else process.env.CACHE_FIX_DEBUG = prevDebug;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- Extension contract metadata ---
+
+test("default has correct extension contract metadata", () => {
+  assert.equal(ext.name, "deferred-tools-restore");
+  assert.equal(ext.order, 350);
+  assert.equal(ext.enabled, true);
+  assert.equal(typeof ext.onRequest, "function");
+});
+
+test("onRequest: tolerates missing ctx and missing body", async () => {
+  await ext.onRequest({});
+  await ext.onRequest({ body: null });
+  await ext.onRequest(null);
+  // No throw = pass
+  assert.ok(true);
+});

--- a/test/proxy-deferred-tools-restore.test.mjs
+++ b/test/proxy-deferred-tools-restore.test.mjs
@@ -37,7 +37,7 @@ function makeSystem(cwd, { extra = "" } = {}) {
         "another line\n" +
         "\n" +
         "# Environment\n" +
-        "You have been invoked in the following environment: \n" +
+        "You have been invoked in the following environment:\n" +
         ` - Primary working directory: ${cwd}\n` +
         "  - Is a git repository: true\n" +
         " - Platform: linux\n" +
@@ -119,6 +119,7 @@ test("extractCwdFromSystem: parses cwd from CC's # Environment block", () => {
 test("extractCwdFromSystem: also accepts string system prompt", () => {
   const text =
     "# Environment\n" +
+    "You have been invoked in the following environment:\n" +
     " - Primary working directory: /var/projects/foo\n" +
     " - Platform: linux\n";
   assert.equal(extractCwdFromSystem(text), "/var/projects/foo");
@@ -146,19 +147,20 @@ test("extractCwdFromSystem: narrative mention of working directory does NOT matc
   assert.equal(extractCwdFromSystem(sys), null);
 });
 
-test("extractCwdFromSystem: scans across blocks; only the # Environment-anchored match wins", () => {
+test("extractCwdFromSystem: only the structurally-valid section yields a match", () => {
   const sys = [
     { type: "text", text: "no marker here" },
     {
       type: "text",
       text:
         "# Environment\n" +
+        "You have been invoked in the following environment:\n" +
         " - Primary working directory: /first/match\n" +
         "more content",
     },
     {
-      // No # Environment header in this block, so the marker is ignored
-      // even though it's syntactically valid.
+      // No # Environment header + intro line in this block, so the marker
+      // line is ignored even though it's syntactically valid in isolation.
       type: "text",
       text: " - Primary working directory: /should/not/win\n",
     },
@@ -167,8 +169,6 @@ test("extractCwdFromSystem: scans across blocks; only the # Environment-anchored
 });
 
 test("extractCwdFromSystem: rejects code-fenced fake marker without # Environment header", () => {
-  // A block that LOOKS like it has the marker but lacks the # Environment
-  // header — typical of an example or quoted region elsewhere in the prompt.
   const sys = [
     {
       type: "text",
@@ -182,10 +182,22 @@ test("extractCwdFromSystem: rejects code-fenced fake marker without # Environmen
   assert.equal(extractCwdFromSystem(sys), null);
 });
 
+test("extractCwdFromSystem: rejects bare # Environment header without the intro line", () => {
+  // A user note or other section that happens to be titled # Environment
+  // but doesn't carry the CC intro line is NOT an env section.
+  const sys = [
+    {
+      type: "text",
+      text:
+        "# Environment\n" +
+        "(this is a user note about environment variables)\n" +
+        " - Primary working directory: /not/the/real/marker\n",
+    },
+  ];
+  assert.equal(extractCwdFromSystem(sys), null);
+});
+
 test("extractCwdFromSystem: prefers real # Environment marker over earlier fake in fence", () => {
-  // Block A has a code-fenced fake marker (no env header).
-  // Block B has the real # Environment section.
-  // Real value must win regardless of block order.
   const fakeBlock = {
     type: "text",
     text:
@@ -198,17 +210,15 @@ test("extractCwdFromSystem: prefers real # Environment marker over earlier fake 
     type: "text",
     text:
       "# Environment\n" +
+      "You have been invoked in the following environment:\n" +
       " - Primary working directory: /actual/cwd\n" +
       " - Platform: linux\n",
   };
   assert.equal(extractCwdFromSystem([fakeBlock, realBlock]), "/actual/cwd");
-  // And in the reverse order — the loop finds the real one in block 0.
   assert.equal(extractCwdFromSystem([realBlock, fakeBlock]), "/actual/cwd");
 });
 
 test("extractCwdFromSystem: ignores marker that appears BEFORE the # Environment header in same block", () => {
-  // Pathological case: same block contains a fake marker before the env
-  // header. Our window starts at the env header, so the fake is ignored.
   const sys = [
     {
       type: "text",
@@ -216,10 +226,75 @@ test("extractCwdFromSystem: ignores marker that appears BEFORE the # Environment
         " - Primary working directory: /pre-env/fake\n" +
         "...much later in the block...\n" +
         "# Environment\n" +
+        "You have been invoked in the following environment:\n" +
         " - Primary working directory: /actual/cwd\n",
     },
   ];
   assert.equal(extractCwdFromSystem(sys), "/actual/cwd");
+});
+
+test("extractCwdFromSystem: returns null when MULTIPLE structurally-valid env sections disagree", () => {
+  // Two valid env sections in the same block (e.g. one inside a code fence
+  // showing a full example, one real). Refusing to pick is the safe move.
+  const sys = [
+    {
+      type: "text",
+      text:
+        "# Environment\n" +
+        "You have been invoked in the following environment:\n" +
+        " - Primary working directory: /first\n" +
+        " - Platform: linux\n" +
+        "\n" +
+        "Some narrative...\n" +
+        "\n" +
+        "# Environment\n" +
+        "You have been invoked in the following environment:\n" +
+        " - Primary working directory: /second\n" +
+        " - Platform: linux\n",
+    },
+  ];
+  assert.equal(extractCwdFromSystem(sys), null);
+});
+
+test("extractCwdFromSystem: returns null when valid env sections in different blocks disagree", () => {
+  const sys = [
+    {
+      type: "text",
+      text:
+        "# Environment\n" +
+        "You have been invoked in the following environment:\n" +
+        " - Primary working directory: /block-A\n",
+    },
+    {
+      type: "text",
+      text:
+        "# Environment\n" +
+        "You have been invoked in the following environment:\n" +
+        " - Primary working directory: /block-B\n",
+    },
+  ];
+  assert.equal(extractCwdFromSystem(sys), null);
+});
+
+test("extractCwdFromSystem: identical cwds across multiple valid sections still resolve", () => {
+  // If multiple env sections exist but all agree, that's not ambiguous.
+  const sys = [
+    {
+      type: "text",
+      text:
+        "# Environment\n" +
+        "You have been invoked in the following environment:\n" +
+        " - Primary working directory: /same\n",
+    },
+    {
+      type: "text",
+      text:
+        "# Environment\n" +
+        "You have been invoked in the following environment:\n" +
+        " - Primary working directory: /same\n",
+    },
+  ];
+  assert.equal(extractCwdFromSystem(sys), "/same");
 });
 
 // --- deriveSnapshotKey ---

--- a/test/proxy-deferred-tools-restore.test.mjs
+++ b/test/proxy-deferred-tools-restore.test.mjs
@@ -146,7 +146,7 @@ test("extractCwdFromSystem: narrative mention of working directory does NOT matc
   assert.equal(extractCwdFromSystem(sys), null);
 });
 
-test("extractCwdFromSystem: scans across blocks; first match wins", () => {
+test("extractCwdFromSystem: scans across blocks; only the # Environment-anchored match wins", () => {
   const sys = [
     { type: "text", text: "no marker here" },
     {
@@ -157,11 +157,69 @@ test("extractCwdFromSystem: scans across blocks; first match wins", () => {
         "more content",
     },
     {
+      // No # Environment header in this block, so the marker is ignored
+      // even though it's syntactically valid.
       type: "text",
       text: " - Primary working directory: /should/not/win\n",
     },
   ];
   assert.equal(extractCwdFromSystem(sys), "/first/match");
+});
+
+test("extractCwdFromSystem: rejects code-fenced fake marker without # Environment header", () => {
+  // A block that LOOKS like it has the marker but lacks the # Environment
+  // header — typical of an example or quoted region elsewhere in the prompt.
+  const sys = [
+    {
+      type: "text",
+      text:
+        "Example output:\n" +
+        "```\n" +
+        " - Primary working directory: /WRONG/path/from/example\n" +
+        "```\n",
+    },
+  ];
+  assert.equal(extractCwdFromSystem(sys), null);
+});
+
+test("extractCwdFromSystem: prefers real # Environment marker over earlier fake in fence", () => {
+  // Block A has a code-fenced fake marker (no env header).
+  // Block B has the real # Environment section.
+  // Real value must win regardless of block order.
+  const fakeBlock = {
+    type: "text",
+    text:
+      "Tutorial section:\n" +
+      "```\n" +
+      " - Primary working directory: /tutorial/example\n" +
+      "```\n",
+  };
+  const realBlock = {
+    type: "text",
+    text:
+      "# Environment\n" +
+      " - Primary working directory: /actual/cwd\n" +
+      " - Platform: linux\n",
+  };
+  assert.equal(extractCwdFromSystem([fakeBlock, realBlock]), "/actual/cwd");
+  // And in the reverse order — the loop finds the real one in block 0.
+  assert.equal(extractCwdFromSystem([realBlock, fakeBlock]), "/actual/cwd");
+});
+
+test("extractCwdFromSystem: ignores marker that appears BEFORE the # Environment header in same block", () => {
+  // Pathological case: same block contains a fake marker before the env
+  // header. Our window starts at the env header, so the fake is ignored.
+  const sys = [
+    {
+      type: "text",
+      text:
+        " - Primary working directory: /pre-env/fake\n" +
+        "...much later in the block...\n" +
+        "# Environment\n" +
+        " - Primary working directory: /actual/cwd\n",
+    },
+  ];
+  assert.equal(extractCwdFromSystem(sys), "/actual/cwd");
 });
 
 // --- deriveSnapshotKey ---
@@ -276,6 +334,26 @@ test("restoreDeferredTools: rejects same-length snapshot missing AVAILABLE marke
     const path = join(dir, `deferred-tools-${key}.txt`);
     // Make a snapshot LONGER than AVAILABLE_MARKER but missing the marker text
     await writeFile(path, "x".repeat(AVAILABLE_MARKER.length + 100));
+    const restored = await restoreDeferredTools({ dir, key });
+    assert.equal(restored, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("restoreDeferredTools: rejects snapshot containing UNAVAILABLE marker (defense-in-depth)", async () => {
+  // Persisted snapshots should never contain UNAVAILABLE by construction
+  // (we only persist when !hasUnavail), but if one ever does, refuse to
+  // restore. Restoring a "no longer available" block would be worse than
+  // not restoring at all.
+  const dir = await newTmp();
+  try {
+    const key = "hasunavail123456";
+    const path = join(dir, `deferred-tools-${key}.txt`);
+    await writeFile(
+      path,
+      `${AVAILABLE_MARKER}: tool1, tool2\n${UNAVAILABLE_MARKER} (their MCP server disconnected)`,
+    );
     const restored = await restoreDeferredTools({ dir, key });
     assert.equal(restored, null);
   } finally {


### PR DESCRIPTION
**Final PR for #59.** Ports the last behavior-bearing item, documents why item 10 is not ported, and closes the issue on merge.

**Stage:** directive — see `docs/directives/proxy-deferred-tools-restore.md` for the full spec.

## TL;DR

- New extension `proxy/extensions/deferred-tools-restore.mjs`, order 350, defaults **ON** (opt out via `CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE=1`)
- Snapshots the deferred-tools attachment block when clean; on a resume request where the block has shrunk and contains the UNAVAILABLE marker, substitutes the snapshot to keep the cache prefix intact
- Strict downgrade guard: only substitutes when snapshot is **strictly longer** than current block
- New env override `CACHE_FIX_DEFERRED_TOOLS_DIR` for test isolation
- 11 tests covering opt-out, no-op paths, persist, restore, downgrade guard, missing snapshot, assistant skip, arbitrary block position, I/O error swallowing
- README updated to explain why #59 item 10 (git-status strip) uses the native `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` flag instead of a proxy extension
- `Closes #59`

After merge, post the close-out comment included in the directive (see "#59 close-out comment" section).

— AI Team Lead