### PR TITLE
docs: Apr 23 tracking update + preserve deferred serializer design

### DIFF
--- a/TRACKED_ISSUES.md
+++ b/TRACKED_ISSUES.md
@@ -2,7 +2,7 @@
 
 Issues we are actively monitoring, have commented on, or are directly relevant to our interceptor work.
 
-Last updated: 2026-04-22 (v3.0.1 proxy shipped, v2.1.117 upgrade, Q7d binding constraint confirmed)
+Last updated: 2026-04-23 (v3.0.5 shipped, Max 20x upgrade, three new CC issues filed, llm-relay deployed)
 
 ## Legend
 
@@ -136,6 +136,9 @@ Last updated: 2026-04-22 (v3.0.1 proxy shipped, v2.1.117 upgrade, Q7d binding co
 | @nikhilsitaram | Called out Anthropic's 1h→5m TTL contradiction (#45756, Apr 21) — Boris references 1h cache windows while server enforces 5m. |
 | @AlfredGuquan | Documented skill listing duplication on resume (#45188, Apr 19) — 8+ injections per session, ~3-4K tokens each. |
 | @YuriyKrasilnikov | Maintaining evidence map and appendix on #50513. Engaged ArkNill for cross-validation. |
+| @ThatDragonOverThere | 5 detailed posts on #41930 (Apr 23): 54% Q7d in 34.5h on v2.1.118, confirmed default effort silently upgraded to high for all models, identified three compounding factors on 4.7 launch. Best independent analysis of the effort+pricing+context triple hit. |
+| @ANogin | Bedrock/LiteLLM cache_read double-counting (#45756, Apr 22-23). 19.3M input / 19.2M cache_read suggests input includes cache_read on Bedrock path. We disambiguated: direct Anthropic auth shows 0.1x weight, not double-counted. |
+| @TheAuditorTool | Max20 depleted in 32 minutes, one Q5h = 18% weekly (#38335, Apr 23). Previously assessed our tool as "LEGITIMATE." Now documenting the cost crisis himself. |
 
 ## Media Coverage
 
@@ -168,6 +171,20 @@ Users who have confirmed the interceptor resolved their issue:
 |---|-------|-------|---------------|
 | [#47098](https://github.com/anthropics/claude-code/issues/47098) | New sessions will NEVER hit a full cache | Open | Skills + CLAUDE.md blocks in `messages[0]` are not prefix-cacheable. Regenerated non-deterministically on fresh session / `/clear`. 6,505+ tokens of cache_creation even seconds after prior session. Separate from TTL issue — prefix placement problem. **Our issue #12.** |
 | [#47107](https://github.com/anthropics/claude-code/issues/47107) | Uncachable system prompt caused by git status | Open | `includeGitInstructions` (default: true) injects live `git status` into `system[]`. Every file edit busts the entire system-prompt cache prefix. **Our issue #11.** |
+
+### Completed (2026-04-23 — v3.0.3/v3.0.4/v3.0.5 shipped, three CC issues filed)
+- **v3.0.3** — corp proxy support (PR #54, @X-15), Korean README (PR #56, @ArkNill), Chinese README restructured
+- **v3.0.4** — cache-telemetry extension now persists quota state to disk (was broken since v3.0.0 for all proxy users)
+- **v3.0.5** — status bar reads from quota-status.json instead of dead claude-meter.jsonl
+- **Filed CC #52376** — thinking.display for subscription sessions (thinking content server-gated, signature = encoded billing token)
+- **Filed CC #52470** — MCP hot-reload without session restart
+- **Filed CC #52534** — Opus 4.7 ignores CLAUDE_CODE_EFFORT_LEVEL env var and settings.json (pins to xhigh)
+- **Binary analysis findings:** CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING only matches 4.6 model strings, silently ignored on 4.7. Opus 4.7 defaults to xhigh effort (not high as ThatDragonOverThere reported — it's worse). Thinking block "signature" field = encoded content used for billing via tl8() function (length * 0.75 = tokens).
+- **#45756** — Posted cache_read double-counting disambiguation. Direct Anthropic auth = 0.1x weight (not double-counted). ANogin's finding is Bedrock/LiteLLM-specific.
+- **#41930** — ThatDragonOverThere posted 5 detailed comments: 54% Q7d in 34.5h, default effort silently upgraded, three compounding factors on 4.7 launch.
+- **#38335** — TheAuditorTool: Max20 depleted in 32 minutes, one Q5h window = 18% weekly (was 8.5% before Mar 23). mhbosch: Codex gained 1M users in two weeks (German press).
+- **All three filed issues got bot "duplicate" responses** — no actual dups linked (known bot behavior).
+- **No Anthropic engineer responses** on any tracked issue today.
 
 ### Completed (2026-04-22 — v3.0.1 shipped, issue sweep)
 - **v3.0.1 proxy shipped to npm**, v3.0.0 proxy architecture issue #40 closed.

--- a/docs/deferred/proxy-session-serializer.md
+++ b/docs/deferred/proxy-session-serializer.md
@@ -1,0 +1,156 @@
+# Deferred design: Per-session request serializer (Phase 3b)
+
+**Original date:** 2026-04-21
+**Status:** Deferred — preserved as a design reference, not scheduled
+**Tracking issue:** [#67](https://github.com/cnighswonger/claude-code-cache-fix/issues/67)
+
+This document was written before the proxy v3.0 multi-extension
+architecture landed. Some assumptions (e.g., the `onResponseComplete`
+hook described below does not exist yet, and the original branch path
+referenced a pre-v3 layout) need to be re-evaluated before this is
+picked up. See #67 for the gating questions.
+
+---
+
+## Problem
+
+Claude Code sends parallel HTTP requests to the Anthropic API during
+concurrent tool calls (subagents, simultaneous tool use). When multiple
+requests for the same conversation hit the API simultaneously, failure
+modes include request rejection, cache invalidation, and degraded
+model selection. Community research has identified this pattern and
+confirmed that serializing requests per session eliminates it.
+
+---
+
+## Goal
+
+Implement a per-session request serializer as a proxy extension. Only
+one request per conversation is in-flight to Anthropic at a time.
+Additional requests queue until the previous response completes.
+
+---
+
+## 1. Design
+
+### 1.1 Scope
+
+Single-user localhost proxy. The serializer needs:
+
+- Per-conversation FIFO queue
+- Configurable depth limit
+- Timeout for queued requests
+- Clean release on response completion or error
+
+### 1.2 Session Identity
+
+The serializer keys on whatever session/conversation identifier CC
+includes in requests. Investigate the request to determine the key:
+- Request headers (session-related)
+- Request body fields
+- Anthropic-specific headers
+
+If no session identifier is present, requests pass through without
+serialization (backwards compatible).
+
+### 1.3 Queue Behavior
+
+```
+Request arrives → extract session key
+  → Is there an in-flight request for this session?
+    → No: mark as in-flight, forward immediately
+    → Yes: add to FIFO queue
+      → Queue depth exceeded? → reject with 429 + retry-after
+      → Queue accepted → wait for current in-flight to complete
+        → Timeout exceeded? → reject with 504
+        → Released → forward this request
+```
+
+### 1.4 Release Trigger
+
+The in-flight lock is released when:
+- The upstream response is fully streamed (SSE stream ends)
+- The upstream returns a non-streaming response (body complete)
+- The upstream returns an error
+- The request is aborted by the client
+- The configured timeout expires
+
+### 1.5 Extension Interface
+
+The serializer is a proxy extension following the Phase 3a pipeline.
+It should run early (low order number) so requests are serialized
+before other extensions process them.
+
+**Design question:** The current extension interface does not have an
+`onResponseComplete` hook. The serializer needs to know when the full
+response has been sent to release the lock. Options:
+
+1. Add `onResponseComplete(ctx)` hook to the pipeline
+2. Use the server's response `finish` event to trigger release
+3. Have the serializer wrap the response stream and detect end
+
+Recommend option 1 — it benefits other extensions too.
+
+---
+
+## 2. Configuration
+
+Add to `proxy/extensions.json`:
+
+```json
+{
+  "session-serializer": {
+    "enabled": true,
+    "order": 50,
+    "maxQueueDepth": 10,
+    "timeoutMs": 120000,
+    "idleCleanupMs": 300000
+  }
+}
+```
+
+---
+
+## 3. Observability
+
+- Debug logging (`CACHE_FIX_DEBUG`): queue, release, reject, timeout, cleanup events
+- Health endpoint: expose active session count, queue depth, total processed
+
+---
+
+## 4. Testing
+
+- Queue/release mechanics
+- Timeout and depth limit enforcement
+- Client abort while queued releases correctly
+- Upstream error releases lock
+- No session key = passthrough
+- Mixed sessions don't block each other
+- Integration: two concurrent requests to same session, second waits
+
+---
+
+## 5. Acknowledgment
+
+The concurrent-request failure pattern and its impact on cache stability
+were identified by [@fgrosswig](https://github.com/fgrosswig) through
+his proxy-based API observability work. Our implementation is independent,
+designed for the single-user localhost proxy use case.
+
+---
+
+## 6. Deliverables
+
+1. `proxy/extensions/session-serializer.mjs`
+2. `onResponseComplete` hook in `proxy/pipeline.mjs` (if option 1)
+3. Updated `proxy/extensions.json`
+4. Updated health endpoint in `proxy/server.mjs`
+5. Tests
+
+---
+
+## 7. Non-Goals
+
+- Multi-client session registry
+- Dashboard visualization
+- Remote deployment support


### PR DESCRIPTION
Two unrelated docs cleanups bundled to keep merge overhead low.

## TRACKED_ISSUES.md

Apr 23 backfill: v3.0.3/4/5 ship notes, three filed CC issues (#52376, #52470, #52534), three new contributor entries (ThatDragonOverThere, ANogin, TheAuditorTool).

## docs/deferred/proxy-session-serializer.md

A Phase 3b session-serializer draft was sitting in the working tree as an untracked file with a "DO NOT PUSH" header. Moved into `docs/deferred/` so the design isn't lost, header updated to reflect deferred status, tracking issue opened (#67) for future re-evaluation.

— AI Team Lead