### PR TITLE
feat: install-service / uninstall-service subcommands (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,40 +45,41 @@ Extensions are hot-reloadable — add, remove, or modify `.mjs` files in `proxy/
 
 ### Running as a service
 
-**Linux (systemd — recommended):**
+**Recommended (Linux/macOS) — `install-service` subcommand:**
 
-Create `~/.config/systemd/user/cache-fix-proxy.service`:
-
-```ini
-[Unit]
-Description=Claude Code Cache Fix Proxy (v3.x)
-After=network.target
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/node /path/to/claude-code-cache-fix/proxy/server.mjs
-Restart=on-failure
-RestartSec=5
-Environment=CACHE_FIX_PROXY_PORT=9801
-
-[Install]
-WantedBy=default.target
+```bash
+cache-fix-proxy install-service
 ```
+
+Detects your platform and writes the appropriate config:
+
+- **Linux** → `~/.config/systemd/user/cache-fix-proxy.service` (systemd user unit)
+- **macOS** → `~/Library/LaunchAgents/com.cnighswonger.cache-fix-proxy.plist` (launchd agent)
+
+The output prints the next-step commands to enable and start the service. On Linux:
 
 ```bash
 systemctl --user daemon-reload
 systemctl --user enable --now cache-fix-proxy
-
-# Optional: start on boot (before login)
-sudo loginctl enable-linger $USER
+sudo loginctl enable-linger $USER   # optional: start on boot, not just on login
 ```
 
-A `cache-fix-proxy install-service` subcommand is planned for v3.1.0 ([#48](https://github.com/cnighswonger/claude-code-cache-fix/issues/48)).
-
-**Fallback (any OS):**
+On macOS:
 
 ```bash
-nohup node "$(npm root -g)/claude-code-cache-fix/proxy/server.mjs" > /tmp/cache-fix-proxy.log 2>&1 &
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.cnighswonger.cache-fix-proxy.plist
+launchctl enable gui/$(id -u)/com.cnighswonger.cache-fix-proxy
+launchctl kickstart gui/$(id -u)/com.cnighswonger.cache-fix-proxy
+```
+
+The installed config picks up `CACHE_FIX_PROXY_PORT`, `CACHE_FIX_PROXY_UPSTREAM`, and `CACHE_FIX_DEBUG` from the env at install time. Re-run `install-service --force` to regenerate after env changes, or edit the service file directly. Pair with `cache-fix-proxy uninstall-service` to remove cleanly (stops, disables, deletes).
+
+The service runs `cache-fix-proxy server` in the foreground, which is just the proxy without the wrapper-mode claude launcher.
+
+**Manual (any platform):**
+
+```bash
+nohup cache-fix-proxy server > /tmp/cache-fix-proxy.log 2>&1 &
 echo 'export ANTHROPIC_BASE_URL=http://127.0.0.1:9801' >> ~/.bashrc
 ```
 

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -9,6 +9,63 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const SERVER_PATH = resolve(__dirname, "../proxy/server.mjs");
 
 const args = process.argv.slice(2);
+const SUBCOMMAND = args[0];
+
+// Subcommand dispatch (must come before the wrapper-arg parser so subcommand
+// names don't get treated as claude args). Returns null when no subcommand
+// matched, signaling fall-through to wrapper mode below.
+async function dispatch() {
+  if (SUBCOMMAND === "server") {
+    return new Promise((resolveP) => {
+      const serverProc = spawn(process.execPath, [SERVER_PATH, ...args.slice(1)], {
+        stdio: "inherit",
+        env: process.env,
+      });
+      serverProc.on("close", (code) => resolveP(code ?? 0));
+      serverProc.on("error", (err) => {
+        process.stderr.write(`Failed to start proxy server: ${err.message}\n`);
+        resolveP(1);
+      });
+    });
+  }
+  if (SUBCOMMAND === "install-service") {
+    const force = args.includes("--force");
+    const { install } = await import("./install-service.mjs");
+    return install({ force });
+  }
+  if (SUBCOMMAND === "uninstall-service") {
+    const { uninstall } = await import("./install-service.mjs");
+    return uninstall();
+  }
+  if (SUBCOMMAND === "--help" || SUBCOMMAND === "-h" || SUBCOMMAND === "help") {
+    process.stdout.write(
+      "Usage: cache-fix-proxy [subcommand] [args]\n\n" +
+        "Subcommands:\n" +
+        "  (no subcommand)        Spawn the proxy + launch claude with ANTHROPIC_BASE_URL set.\n" +
+        "                         Pass any claude args after optional --proxy-port / --proxy-upstream.\n" +
+        "  server                 Run just the proxy in the foreground (for systemd/launchd ExecStart).\n" +
+        "  install-service        Install a systemd user service (Linux) or launchd agent (macOS).\n" +
+        "                         Pass --force to overwrite an existing config.\n" +
+        "  uninstall-service      Stop, disable, and remove the installed service.\n" +
+        "  help                   Show this help.\n\n" +
+        "Wrapper-mode flags:\n" +
+        "  --proxy-port <N>       Port for the spawned proxy (default 9801)\n" +
+        "  --proxy-upstream <URL> Upstream URL the proxy forwards to (default api.anthropic.com)\n" +
+        "\nEnvironment:\n" +
+        "  CACHE_FIX_PROXY_PORT     Port for the proxy server\n" +
+        "  CACHE_FIX_PROXY_UPSTREAM Upstream URL\n" +
+        "  CACHE_FIX_DEBUG=1        Verbose proxy logging\n" +
+        "  CACHE_FIX_CLAUDE_CMD     Override the `claude` command for the wrapper\n",
+    );
+    return 0;
+  }
+  return null;
+}
+
+const subcommandExit = await dispatch();
+if (subcommandExit !== null) process.exit(subcommandExit);
+
+// No subcommand matched → wrapper mode (back-compat with v3.0.x behavior).
 let proxyPort = 9801;
 let proxyUpstream = undefined;
 const claudeArgs = [];

--- a/bin/install-service.mjs
+++ b/bin/install-service.mjs
@@ -197,7 +197,12 @@ async function install({ force = false } = {}) {
     return 1;
   }
   if (paths.kind === "systemd") {
-    const r = await installSystemd({ paths });
+    let r;
+    try {
+      r = await installSystemd({ paths, force });
+    } catch (err) {
+      return reportFsError("install-service", err);
+    }
     if (!r.ok) {
       process.stderr.write(`[install-service] ${r.reason}: ${r.path}\n`);
       if (r.hint) process.stderr.write(`  ${r.hint}\n`);
@@ -213,7 +218,12 @@ async function install({ force = false } = {}) {
     return 0;
   }
   if (paths.kind === "launchd") {
-    const r = await installLaunchd({ paths });
+    let r;
+    try {
+      r = await installLaunchd({ paths, force });
+    } catch (err) {
+      return reportFsError("install-service", err);
+    }
     if (!r.ok) {
       process.stderr.write(`[install-service] ${r.reason}: ${r.path}\n`);
       if (r.hint) process.stderr.write(`  ${r.hint}\n`);
@@ -231,6 +241,19 @@ async function install({ force = false } = {}) {
   return 1;
 }
 
+// Translate raw fs errors into operator-friendly one-liners. Returns the
+// exit code so callers can pass it straight back.
+function reportFsError(prefix, err) {
+  const code = err?.code ?? "";
+  let hint = "";
+  if (code === "ENOENT") hint = "file or directory not found";
+  else if (code === "EACCES" || code === "EPERM") hint = "permission denied";
+  else if (code === "ENOSPC") hint = "no space left on device";
+  else hint = err?.message || String(err);
+  process.stderr.write(`[${prefix}] ${hint}${err?.path ? `: ${err.path}` : ""}\n`);
+  return 1;
+}
+
 async function uninstall() {
   const paths = getPaths();
   if (paths.kind === "unsupported") {
@@ -241,7 +264,12 @@ async function uninstall() {
     // Best-effort stop + disable before removing the file
     await runCmd("systemctl", ["--user", "stop", "cache-fix-proxy"]);
     await runCmd("systemctl", ["--user", "disable", "cache-fix-proxy"]);
-    const r = await uninstallSystemd({ paths });
+    let r;
+    try {
+      r = await uninstallSystemd({ paths });
+    } catch (err) {
+      return reportFsError("uninstall-service", err);
+    }
     if (!r.ok) {
       process.stderr.write(`[uninstall-service] ${r.reason}: ${r.path}\n`);
       return 1;
@@ -253,7 +281,12 @@ async function uninstall() {
   if (paths.kind === "launchd") {
     const targetPath = join(paths.configDir, paths.configFile);
     await runCmd("launchctl", ["bootout", `gui/${process.getuid()}`, targetPath]);
-    const r = await uninstallLaunchd({ paths });
+    let r;
+    try {
+      r = await uninstallLaunchd({ paths });
+    } catch (err) {
+      return reportFsError("uninstall-service", err);
+    }
     if (!r.ok) {
       process.stderr.write(`[uninstall-service] ${r.reason}: ${r.path}\n`);
       return 1;

--- a/bin/install-service.mjs
+++ b/bin/install-service.mjs
@@ -1,0 +1,282 @@
+// install-service / uninstall-service subcommands.
+//
+// Detects platform and installs an appropriate service definition for the
+// cache-fix proxy:
+//   - linux  → systemd user service at ~/.config/systemd/user/cache-fix-proxy.service
+//   - darwin → launchd agent at ~/Library/LaunchAgents/com.cnighswonger.cache-fix-proxy.plist
+//   - other  → prints manual instructions and exits non-zero
+//
+// Pure helpers exported for tests; orchestration lives in main().
+
+import { readFile, writeFile, mkdir, unlink, stat } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve, join } from "node:path";
+import { homedir, platform } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_DIR = resolve(__dirname, "..", "templates");
+const SERVER_PATH = resolve(__dirname, "..", "proxy", "server.mjs");
+
+function getDefaults() {
+  return {
+    port: process.env.CACHE_FIX_PROXY_PORT || "9801",
+    upstream: process.env.CACHE_FIX_PROXY_UPSTREAM || "",
+    debug: process.env.CACHE_FIX_DEBUG || "",
+    workingDir: resolve(__dirname, ".."),
+  };
+}
+
+function getPaths(plat = platform()) {
+  if (plat === "linux") {
+    return {
+      kind: "systemd",
+      configDir: join(homedir(), ".config", "systemd", "user"),
+      configFile: "cache-fix-proxy.service",
+      label: "cache-fix-proxy",
+    };
+  }
+  if (plat === "darwin") {
+    return {
+      kind: "launchd",
+      configDir: join(homedir(), "Library", "LaunchAgents"),
+      configFile: "com.cnighswonger.cache-fix-proxy.plist",
+      label: "com.cnighswonger.cache-fix-proxy",
+      logDir: join(homedir(), "Library", "Logs"),
+    };
+  }
+  return { kind: "unsupported", platform: plat };
+}
+
+function renderSystemdTemplate(template, vars) {
+  const upstreamLine = vars.upstream
+    ? `Environment=CACHE_FIX_PROXY_UPSTREAM=${vars.upstream}`
+    : "";
+  const debugLine = vars.debug
+    ? `Environment=CACHE_FIX_DEBUG=${vars.debug}`
+    : "";
+  // Allow callers to wire a Requires= line (e.g. another service the proxy
+  // chains to). Empty string by default so the unit has no extra deps.
+  const requiresLine = vars.requires
+    ? `Requires=${vars.requires}\nAfter=${vars.requires}`
+    : "";
+  return template
+    .replaceAll("{{NODE}}", vars.node)
+    .replaceAll("{{SERVER_PATH}}", vars.serverPath)
+    .replaceAll("{{PORT}}", vars.port)
+    .replaceAll("{{UPSTREAM_LINE}}", upstreamLine)
+    .replaceAll("{{DEBUG_LINE}}", debugLine)
+    .replaceAll("{{REQUIRES_LINE}}", requiresLine)
+    .replaceAll("{{WORKING_DIR}}", vars.workingDir)
+    // Collapse triple newlines from empty optional lines down to single blank
+    .replace(/\n\n\n+/g, "\n\n");
+}
+
+function renderLaunchdTemplate(template, vars) {
+  const upstreamPlist = vars.upstream
+    ? `        <key>CACHE_FIX_PROXY_UPSTREAM</key>\n        <string>${vars.upstream}</string>`
+    : "";
+  const debugPlist = vars.debug
+    ? `        <key>CACHE_FIX_DEBUG</key>\n        <string>${vars.debug}</string>`
+    : "";
+  return template
+    .replaceAll("{{NODE}}", vars.node)
+    .replaceAll("{{SERVER_PATH}}", vars.serverPath)
+    .replaceAll("{{PORT}}", vars.port)
+    .replaceAll("{{UPSTREAM_PLIST}}", upstreamPlist)
+    .replaceAll("{{DEBUG_PLIST}}", debugPlist)
+    .replaceAll("{{WORKING_DIR}}", vars.workingDir)
+    .replaceAll("{{LOG_DIR}}", vars.logDir)
+    .replace(/\n\n+/g, "\n");
+}
+
+async function fileExists(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runCmd(cmd, args, opts = {}) {
+  return new Promise((resolveP) => {
+    const p = spawn(cmd, args, { stdio: "inherit", ...opts });
+    p.on("close", (code) => resolveP(code ?? 0));
+    p.on("error", () => resolveP(127));
+  });
+}
+
+async function installSystemd({ paths, defaults, force = false } = {}) {
+  paths = paths || getPaths("linux");
+  defaults = defaults || getDefaults();
+  const targetPath = join(paths.configDir, paths.configFile);
+  if ((await fileExists(targetPath)) && !force) {
+    return {
+      ok: false,
+      reason: "already-installed",
+      path: targetPath,
+      hint: "Re-run with --force to overwrite, or `cache-fix-proxy uninstall-service` first.",
+    };
+  }
+  const template = await readFile(
+    join(TEMPLATE_DIR, "cache-fix-proxy.service.template"),
+    "utf-8",
+  );
+  const rendered = renderSystemdTemplate(template, {
+    node: process.execPath,
+    serverPath: SERVER_PATH,
+    port: defaults.port,
+    upstream: defaults.upstream,
+    debug: defaults.debug,
+    workingDir: defaults.workingDir,
+    requires: "",
+  });
+  await mkdir(paths.configDir, { recursive: true });
+  await writeFile(targetPath, rendered);
+  return { ok: true, path: targetPath };
+}
+
+async function installLaunchd({ paths, defaults, force = false } = {}) {
+  paths = paths || getPaths("darwin");
+  defaults = defaults || getDefaults();
+  const targetPath = join(paths.configDir, paths.configFile);
+  if ((await fileExists(targetPath)) && !force) {
+    return {
+      ok: false,
+      reason: "already-installed",
+      path: targetPath,
+      hint: "Re-run with --force to overwrite, or `cache-fix-proxy uninstall-service` first.",
+    };
+  }
+  const template = await readFile(
+    join(TEMPLATE_DIR, "com.cnighswonger.cache-fix-proxy.plist.template"),
+    "utf-8",
+  );
+  const rendered = renderLaunchdTemplate(template, {
+    node: process.execPath,
+    serverPath: SERVER_PATH,
+    port: defaults.port,
+    upstream: defaults.upstream,
+    debug: defaults.debug,
+    workingDir: defaults.workingDir,
+    logDir: paths.logDir,
+  });
+  await mkdir(paths.configDir, { recursive: true });
+  await writeFile(targetPath, rendered);
+  return { ok: true, path: targetPath };
+}
+
+async function uninstallSystemd({ paths } = {}) {
+  paths = paths || getPaths("linux");
+  const targetPath = join(paths.configDir, paths.configFile);
+  if (!(await fileExists(targetPath))) {
+    return { ok: false, reason: "not-installed", path: targetPath };
+  }
+  await unlink(targetPath);
+  return { ok: true, path: targetPath };
+}
+
+async function uninstallLaunchd({ paths } = {}) {
+  paths = paths || getPaths("darwin");
+  const targetPath = join(paths.configDir, paths.configFile);
+  if (!(await fileExists(targetPath))) {
+    return { ok: false, reason: "not-installed", path: targetPath };
+  }
+  await unlink(targetPath);
+  return { ok: true, path: targetPath };
+}
+
+async function install({ force = false } = {}) {
+  const paths = getPaths();
+  if (paths.kind === "unsupported") {
+    process.stderr.write(
+      `[install-service] Unsupported platform: ${paths.platform}\n` +
+        `Manual install: run \`node ${SERVER_PATH}\` under your platform's service manager.\n`,
+    );
+    return 1;
+  }
+  if (paths.kind === "systemd") {
+    const r = await installSystemd({ paths });
+    if (!r.ok) {
+      process.stderr.write(`[install-service] ${r.reason}: ${r.path}\n`);
+      if (r.hint) process.stderr.write(`  ${r.hint}\n`);
+      return 1;
+    }
+    process.stdout.write(
+      `Wrote systemd unit: ${r.path}\n\n` +
+        `Next steps:\n` +
+        `  systemctl --user daemon-reload\n` +
+        `  systemctl --user enable --now cache-fix-proxy\n` +
+        `  loginctl enable-linger ${process.env.USER || "<your-user>"}   # optional: start on boot vs login\n`,
+    );
+    return 0;
+  }
+  if (paths.kind === "launchd") {
+    const r = await installLaunchd({ paths });
+    if (!r.ok) {
+      process.stderr.write(`[install-service] ${r.reason}: ${r.path}\n`);
+      if (r.hint) process.stderr.write(`  ${r.hint}\n`);
+      return 1;
+    }
+    process.stdout.write(
+      `Wrote launchd plist: ${r.path}\n\n` +
+        `Next steps:\n` +
+        `  launchctl bootstrap gui/$(id -u) ${r.path}\n` +
+        `  launchctl enable gui/$(id -u)/com.cnighswonger.cache-fix-proxy\n` +
+        `  launchctl kickstart gui/$(id -u)/com.cnighswonger.cache-fix-proxy\n`,
+    );
+    return 0;
+  }
+  return 1;
+}
+
+async function uninstall() {
+  const paths = getPaths();
+  if (paths.kind === "unsupported") {
+    process.stderr.write(`[uninstall-service] Unsupported platform: ${paths.platform}\n`);
+    return 1;
+  }
+  if (paths.kind === "systemd") {
+    // Best-effort stop + disable before removing the file
+    await runCmd("systemctl", ["--user", "stop", "cache-fix-proxy"]);
+    await runCmd("systemctl", ["--user", "disable", "cache-fix-proxy"]);
+    const r = await uninstallSystemd({ paths });
+    if (!r.ok) {
+      process.stderr.write(`[uninstall-service] ${r.reason}: ${r.path}\n`);
+      return 1;
+    }
+    await runCmd("systemctl", ["--user", "daemon-reload"]);
+    process.stdout.write(`Removed: ${r.path}\n`);
+    return 0;
+  }
+  if (paths.kind === "launchd") {
+    const targetPath = join(paths.configDir, paths.configFile);
+    await runCmd("launchctl", ["bootout", `gui/${process.getuid()}`, targetPath]);
+    const r = await uninstallLaunchd({ paths });
+    if (!r.ok) {
+      process.stderr.write(`[uninstall-service] ${r.reason}: ${r.path}\n`);
+      return 1;
+    }
+    process.stdout.write(`Removed: ${r.path}\n`);
+    return 0;
+  }
+  return 1;
+}
+
+export {
+  // Pure helpers (test surface)
+  renderSystemdTemplate,
+  renderLaunchdTemplate,
+  getPaths,
+  getDefaults,
+  installSystemd,
+  installLaunchd,
+  uninstallSystemd,
+  uninstallLaunchd,
+  // Orchestration
+  install,
+  uninstall,
+  TEMPLATE_DIR,
+  SERVER_PATH,
+};

--- a/docs/code-reviews/pr-73-install-service-impl-review-2026-04-25.md
+++ b/docs/code-reviews/pr-73-install-service-impl-review-2026-04-25.md
@@ -1,0 +1,37 @@
+# Review: install-service / uninstall-service subcommands
+
+Date: 2026-04-25
+Reviewed: PR #73 implementation (`bin/claude-via-proxy.mjs`, `bin/install-service.mjs`, templates, tests, README)
+Label applied: changes-requested
+
+## What Is Correct
+
+- Subcommand dispatch preserves wrapper-mode parsing for the main back-compat case. I verified `CACHE_FIX_CLAUDE_CMD='node -p JSON.stringify({argv:process.argv.slice(1),base:process.env.ANTHROPIC_BASE_URL})' node bin/claude-via-proxy.mjs --proxy-port 9802 some-claude-arg` and got `{"argv":["some-claude-arg"],"base":"http://127.0.0.1:9802"}`.
+- `cache-fix-proxy server` does run only the proxy in the foreground. With `CACHE_FIX_PROXY_PORT=9988`, `timeout 3s node bin/claude-via-proxy.mjs server` printed `proxy listening on 127.0.0.1:9988` and did not go through wrapper mode.
+- `SERVER_PATH = resolve(__dirname, "..", "proxy", "server.mjs")` resolves correctly in both layouts I checked:
+  - git checkout: `/home/manager/git_repos/claude-code-cache-fix/proxy/server.mjs` exists
+  - packed npm tarball: `/tmp/.../package/proxy/server.mjs` exists after `npm pack`
+- Template placeholder coverage looks correct after the `replaceAll` fix. The only repeated placeholder is `{{LOG_DIR}}` in the launchd plist, and all placeholders in both templates render with no leftovers.
+- Platform detection for unsupported OS values is intentionally graceful at the helper level (`getPaths("freebsd") -> { kind: "unsupported" }`), which matches the requested behavior.
+- Scope is appropriate. I did not find the PR sneaking in the wrapper health-check from issue #48; it stays focused on service install/uninstall and README guidance.
+
+## Blockers
+
+- `--force` is parsed by the CLI but dropped before the install helpers are called, so the advertised overwrite path does not work in real usage. In [bin/claude-via-proxy.mjs](/home/manager/git_repos/claude-code-cache-fix/bin/claude-via-proxy.mjs:31) the subcommand passes `install({ force })`, but in [bin/install-service.mjs](/home/manager/git_repos/claude-code-cache-fix/bin/install-service.mjs:190) `install()` ignores that parameter and calls `installSystemd({ paths })` / `installLaunchd({ paths })` without forwarding `force`. I verified the actual CLI behavior with a temporary `HOME`: first `install-service` succeeds, then `install-service --force` still returns `already-installed`. This breaks one of the core requirements for the PR.
+
+## What Needs Attention
+
+- Test coverage misses the exact blocker above because it only exercises `installSystemd(..., force: true)` directly, not the shipped CLI/orchestration path through `dispatch()` and `install()`. See [test/install-service.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/install-service.test.mjs:164). A CLI-level or orchestration-level test would have caught this regression.
+- The new tests do not cover the back-compat wrapper dispatch path, even though this PR changes the top-level command-routing logic in [bin/claude-via-proxy.mjs](/home/manager/git_repos/claude-code-cache-fix/bin/claude-via-proxy.mjs:17). I manually verified `--proxy-port 9802 some-claude-arg`, but this should be automated because dispatch ordering is the riskiest compatibility point in the bin refactor.
+- Failure-mode handling for missing templates and filesystem permission errors is currently just raw exceptions bubbling out of `readFile`, `mkdir`, and `writeFile` in [bin/install-service.mjs](/home/manager/git_repos/claude-code-cache-fix/bin/install-service.mjs:122) and [bin/install-service.mjs](/home/manager/git_repos/claude-code-cache-fix/bin/install-service.mjs:152). That is survivable, but not very operator-friendly for a user-facing install command. I would treat this as non-blocking for this PR if the core `--force` bug is fixed first.
+
+## Recommendations
+
+- Forward `force` from `install()` into `installSystemd()` / `installLaunchd()`.
+- Add one CLI/orchestration test that proves `cache-fix-proxy install-service --force` overwrites an existing config via the public entrypoint.
+- Add one dispatch back-compat test for `cache-fix-proxy --proxy-port 9802 some-claude-arg`.
+- Consider catching `ENOENT`/`EACCES` around template reads and writes so the subcommand prints a concise prefixed error instead of a raw stack trace.
+
+## Bottom Line
+
+REQUEST CHANGES. The overall shape is sound: dispatch behavior is mostly correct, the service templates are safe, path resolution works from both a checkout and a packed install, and the PR stays within scope. But the published `install-service --force` behavior is broken at the real CLI layer, which is a direct miss against the stated requirements and user-facing README guidance. Fix that and add a top-level test for it before merging.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "tools/",
     "claude-fixed.bat",
     "proxy/",
-    "bin/"
+    "bin/",
+    "templates/"
   ],
   "engines": {
     "node": ">=18"

--- a/templates/cache-fix-proxy.service.template
+++ b/templates/cache-fix-proxy.service.template
@@ -1,0 +1,17 @@
+[Unit]
+Description=Claude Code Cache Fix Proxy
+After=network.target
+{{REQUIRES_LINE}}
+
+[Service]
+Type=simple
+ExecStart={{NODE}} {{SERVER_PATH}}
+Restart=on-failure
+RestartSec=5
+Environment=CACHE_FIX_PROXY_PORT={{PORT}}
+{{UPSTREAM_LINE}}
+{{DEBUG_LINE}}
+WorkingDirectory={{WORKING_DIR}}
+
+[Install]
+WantedBy=default.target

--- a/templates/com.cnighswonger.cache-fix-proxy.plist.template
+++ b/templates/com.cnighswonger.cache-fix-proxy.plist.template
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.cnighswonger.cache-fix-proxy</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{NODE}}</string>
+        <string>{{SERVER_PATH}}</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>CACHE_FIX_PROXY_PORT</key>
+        <string>{{PORT}}</string>
+{{UPSTREAM_PLIST}}
+{{DEBUG_PLIST}}
+    </dict>
+    <key>WorkingDirectory</key>
+    <string>{{WORKING_DIR}}</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{LOG_DIR}}/cache-fix-proxy.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{LOG_DIR}}/cache-fix-proxy.err</string>
+</dict>
+</plist>

--- a/test/install-service.test.mjs
+++ b/test/install-service.test.mjs
@@ -1,0 +1,219 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile, rm, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  renderSystemdTemplate,
+  renderLaunchdTemplate,
+  getPaths,
+  installSystemd,
+  installLaunchd,
+  uninstallSystemd,
+  uninstallLaunchd,
+  TEMPLATE_DIR,
+} from "../bin/install-service.mjs";
+
+async function newTmp() {
+  return mkdtemp(join(tmpdir(), "install-service-test-"));
+}
+
+const sampleVars = {
+  node: "/usr/local/bin/node",
+  serverPath: "/opt/cache-fix/proxy/server.mjs",
+  port: "9801",
+  upstream: "",
+  debug: "",
+  workingDir: "/opt/cache-fix",
+  requires: "",
+};
+
+// --- Template rendering ---
+
+test("renderSystemdTemplate: substitutes core fields", async () => {
+  const tpl = await readFile(join(TEMPLATE_DIR, "cache-fix-proxy.service.template"), "utf-8");
+  const out = renderSystemdTemplate(tpl, sampleVars);
+  assert.ok(out.includes("ExecStart=/usr/local/bin/node /opt/cache-fix/proxy/server.mjs"));
+  assert.ok(out.includes("Environment=CACHE_FIX_PROXY_PORT=9801"));
+  assert.ok(out.includes("WorkingDirectory=/opt/cache-fix"));
+  assert.ok(out.includes("WantedBy=default.target"));
+});
+
+test("renderSystemdTemplate: omits empty optional Environment lines", async () => {
+  const tpl = await readFile(join(TEMPLATE_DIR, "cache-fix-proxy.service.template"), "utf-8");
+  const out = renderSystemdTemplate(tpl, sampleVars);
+  assert.ok(!out.includes("CACHE_FIX_PROXY_UPSTREAM"));
+  assert.ok(!out.includes("CACHE_FIX_DEBUG"));
+  // No leftover empty placeholders
+  assert.ok(!out.includes("{{"));
+  assert.ok(!out.includes("}}"));
+});
+
+test("renderSystemdTemplate: includes UPSTREAM and DEBUG when set", async () => {
+  const tpl = await readFile(join(TEMPLATE_DIR, "cache-fix-proxy.service.template"), "utf-8");
+  const out = renderSystemdTemplate(tpl, {
+    ...sampleVars,
+    upstream: "http://127.0.0.1:8080",
+    debug: "1",
+  });
+  assert.ok(out.includes("Environment=CACHE_FIX_PROXY_UPSTREAM=http://127.0.0.1:8080"));
+  assert.ok(out.includes("Environment=CACHE_FIX_DEBUG=1"));
+});
+
+test("renderSystemdTemplate: requires line wires both Requires and After", async () => {
+  const tpl = await readFile(join(TEMPLATE_DIR, "cache-fix-proxy.service.template"), "utf-8");
+  const out = renderSystemdTemplate(tpl, { ...sampleVars, requires: "llm-relay.service" });
+  assert.ok(out.includes("Requires=llm-relay.service"));
+  assert.ok(out.includes("After=llm-relay.service"));
+});
+
+test("renderLaunchdTemplate: substitutes core fields and renders valid plist", async () => {
+  const tpl = await readFile(
+    join(TEMPLATE_DIR, "com.cnighswonger.cache-fix-proxy.plist.template"),
+    "utf-8",
+  );
+  const out = renderLaunchdTemplate(tpl, {
+    ...sampleVars,
+    logDir: "/Users/test/Library/Logs",
+  });
+  assert.ok(out.includes("<string>com.cnighswonger.cache-fix-proxy</string>"));
+  assert.ok(out.includes("<string>/usr/local/bin/node</string>"));
+  assert.ok(out.includes("<string>/opt/cache-fix/proxy/server.mjs</string>"));
+  assert.ok(out.includes("<string>9801</string>"));
+  assert.ok(out.includes("<string>/Users/test/Library/Logs/cache-fix-proxy.log</string>"));
+  assert.ok(!out.includes("{{"));
+});
+
+test("renderLaunchdTemplate: omits CACHE_FIX_PROXY_UPSTREAM/DEBUG when not set", async () => {
+  const tpl = await readFile(
+    join(TEMPLATE_DIR, "com.cnighswonger.cache-fix-proxy.plist.template"),
+    "utf-8",
+  );
+  const out = renderLaunchdTemplate(tpl, {
+    ...sampleVars,
+    logDir: "/tmp/logs",
+  });
+  assert.ok(!out.includes("CACHE_FIX_PROXY_UPSTREAM"));
+  assert.ok(!out.includes("CACHE_FIX_DEBUG"));
+});
+
+// --- Platform detection ---
+
+test("getPaths: linux returns systemd shape", () => {
+  const p = getPaths("linux");
+  assert.equal(p.kind, "systemd");
+  assert.ok(p.configDir.endsWith(".config/systemd/user"));
+  assert.equal(p.configFile, "cache-fix-proxy.service");
+});
+
+test("getPaths: darwin returns launchd shape", () => {
+  const p = getPaths("darwin");
+  assert.equal(p.kind, "launchd");
+  assert.ok(p.configDir.endsWith("Library/LaunchAgents"));
+  assert.equal(p.configFile, "com.cnighswonger.cache-fix-proxy.plist");
+  assert.ok(p.logDir);
+});
+
+test("getPaths: unsupported platform returns kind=unsupported", () => {
+  const p = getPaths("freebsd");
+  assert.equal(p.kind, "unsupported");
+  assert.equal(p.platform, "freebsd");
+});
+
+// --- installSystemd / uninstallSystemd round-trip ---
+
+test("installSystemd: writes file to configDir; uninstall removes it", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = {
+      kind: "systemd",
+      configDir: dir,
+      configFile: "cache-fix-proxy.service",
+    };
+    const r1 = await installSystemd({ paths, defaults: { port: "9999", upstream: "", debug: "", workingDir: "/tmp" } });
+    assert.ok(r1.ok);
+    const onDisk = await readFile(join(dir, "cache-fix-proxy.service"), "utf-8");
+    assert.ok(onDisk.includes("CACHE_FIX_PROXY_PORT=9999"));
+
+    const r2 = await uninstallSystemd({ paths });
+    assert.ok(r2.ok);
+    const files = await readdir(dir);
+    assert.deepEqual(files, []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("installSystemd: refuses overwrite without force", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = { kind: "systemd", configDir: dir, configFile: "cache-fix-proxy.service" };
+    await installSystemd({ paths, defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" } });
+    const r2 = await installSystemd({ paths, defaults: { port: "9999", upstream: "", debug: "", workingDir: "/tmp" } });
+    assert.equal(r2.ok, false);
+    assert.equal(r2.reason, "already-installed");
+    // File should NOT be modified
+    const onDisk = await readFile(join(dir, "cache-fix-proxy.service"), "utf-8");
+    assert.ok(onDisk.includes("CACHE_FIX_PROXY_PORT=9801"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("installSystemd: --force overwrites existing", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = { kind: "systemd", configDir: dir, configFile: "cache-fix-proxy.service" };
+    await installSystemd({ paths, defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" } });
+    const r2 = await installSystemd({
+      paths,
+      defaults: { port: "9999", upstream: "", debug: "", workingDir: "/tmp" },
+      force: true,
+    });
+    assert.ok(r2.ok);
+    const onDisk = await readFile(join(dir, "cache-fix-proxy.service"), "utf-8");
+    assert.ok(onDisk.includes("CACHE_FIX_PROXY_PORT=9999"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("uninstallSystemd: not-installed when file missing", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = { kind: "systemd", configDir: dir, configFile: "cache-fix-proxy.service" };
+    const r = await uninstallSystemd({ paths });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "not-installed");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- installLaunchd / uninstallLaunchd round-trip ---
+
+test("installLaunchd: writes plist to configDir; uninstall removes it", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = {
+      kind: "launchd",
+      configDir: dir,
+      configFile: "com.cnighswonger.cache-fix-proxy.plist",
+      logDir: "/tmp/logs",
+    };
+    const r1 = await installLaunchd({
+      paths,
+      defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" },
+    });
+    assert.ok(r1.ok);
+    const onDisk = await readFile(join(dir, "com.cnighswonger.cache-fix-proxy.plist"), "utf-8");
+    assert.ok(onDisk.includes("<key>Label</key>"));
+    assert.ok(onDisk.includes("com.cnighswonger.cache-fix-proxy"));
+
+    const r2 = await uninstallLaunchd({ paths });
+    assert.ok(r2.ok);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/test/install-service.test.mjs
+++ b/test/install-service.test.mjs
@@ -1,8 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, writeFile, rm, readdir } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { tmpdir, platform } from "node:os";
+import { join, dirname } from "node:path";
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 import {
   renderSystemdTemplate,
@@ -12,8 +15,13 @@ import {
   installLaunchd,
   uninstallSystemd,
   uninstallLaunchd,
+  install,
   TEMPLATE_DIR,
 } from "../bin/install-service.mjs";
+
+const execFileP = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = join(__dirname, "..", "bin", "claude-via-proxy.mjs");
 
 async function newTmp() {
   return mkdtemp(join(tmpdir(), "install-service-test-"));
@@ -192,6 +200,72 @@ test("uninstallSystemd: not-installed when file missing", async () => {
 });
 
 // --- installLaunchd / uninstallLaunchd round-trip ---
+
+// --- CLI orchestration: end-to-end through dispatch() (Linux only) ---
+
+test("install() CLI orchestration: --force overwrites existing service file (linux)", { skip: platform() !== "linux" }, async () => {
+  const dir = await newTmp();
+  const realHome = process.env.HOME;
+  try {
+    process.env.HOME = dir;
+    // First install: should succeed.
+    const c1 = await install();
+    assert.equal(c1, 0);
+    const target = join(dir, ".config", "systemd", "user", "cache-fix-proxy.service");
+    const before = await readFile(target, "utf-8");
+
+    // Mutate the file so we can prove the overwrite happened, then re-install
+    // without --force: should refuse.
+    await writeFile(target, "MUTATED");
+    const c2 = await install({ force: false });
+    assert.equal(c2, 1, "second install without --force must refuse");
+    assert.equal(await readFile(target, "utf-8"), "MUTATED", "file must be unchanged");
+
+    // Re-install WITH --force: should overwrite.
+    const c3 = await install({ force: true });
+    assert.equal(c3, 0, "install --force must succeed");
+    const after = await readFile(target, "utf-8");
+    assert.notEqual(after, "MUTATED", "file must have been rewritten");
+    assert.ok(after.includes("CACHE_FIX_PROXY_PORT="), "rewritten file must look like a real unit");
+  } finally {
+    process.env.HOME = realHome;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- Back-compat: subcommand dispatch must not eat wrapper-mode args ---
+
+test("dispatch back-compat: --proxy-port + claude-arg passes through to wrapper mode", async () => {
+  // Write a tiny intercept script so CACHE_FIX_CLAUDE_CMD can be a clean
+  // `node <path>` (no embedded spaces in arg payload — the wrapper splits
+  // CACHE_FIX_CLAUDE_CMD naively on whitespace).
+  const dir = await newTmp();
+  const interceptScript = join(dir, "intercept.mjs");
+  await writeFile(
+    interceptScript,
+    'process.stdout.write("INTERCEPT:" + JSON.stringify({argv: process.argv.slice(2), base: process.env.ANTHROPIC_BASE_URL}));\n',
+  );
+  try {
+    const { stdout } = await execFileP(
+      process.execPath,
+      [BIN, "--proxy-port", "9876", "some-claude-arg", "--another"],
+      {
+        env: {
+          ...process.env,
+          CACHE_FIX_CLAUDE_CMD: `${process.execPath} ${interceptScript}`,
+        },
+        timeout: 15000,
+      },
+    );
+    const match = stdout.match(/INTERCEPT:(\{.*\})/);
+    assert.ok(match, `expected wrapper-intercept JSON in stdout; got: ${JSON.stringify(stdout)}`);
+    const parsed = JSON.parse(match[1]);
+    assert.deepEqual(parsed.argv, ["some-claude-arg", "--another"], "wrapper-mode args must reach the claude command");
+    assert.equal(parsed.base, "http://127.0.0.1:9876", "ANTHROPIC_BASE_URL must reflect --proxy-port");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
 
 test("installLaunchd: writes plist to configDir; uninstall removes it", async () => {
   const dir = await newTmp();


### PR DESCRIPTION
Closes #48.

## What this adds

```bash
cache-fix-proxy install-service     # systemd (Linux) or launchd (macOS)
cache-fix-proxy uninstall-service   # stop, disable, remove
cache-fix-proxy server              # run just the proxy (for ExecStart)
cache-fix-proxy help                # full subcommand listing
```

## Behavior

- Detects platform (`linux` → systemd, `darwin` → launchd, anything else → prints manual instructions and exits non-zero)
- `install-service`:
  - Linux: writes `~/.config/systemd/user/cache-fix-proxy.service`, prints next-step commands (`daemon-reload`, `enable --now`, optional `loginctl enable-linger`)
  - macOS: writes `~/Library/LaunchAgents/com.cnighswonger.cache-fix-proxy.plist`, prints `launchctl bootstrap` / `enable` / `kickstart`
  - Refuses to overwrite an existing config without `--force`
  - Picks up `CACHE_FIX_PROXY_PORT`, `CACHE_FIX_PROXY_UPSTREAM`, `CACHE_FIX_DEBUG` from env at install time
- `uninstall-service`: stops + disables (best-effort) then removes the file

## Implementation notes

- Subcommand dispatch in `bin/claude-via-proxy.mjs` preserves back-compat: no subcommand → existing wrapper-mode behavior unchanged
- New `bin/install-service.mjs` holds platform detection, template rendering, and the systemctl/launchctl orchestration
- Templates ship in new `templates/` directory; added to `package.json` `files`
- Renderer uses `replaceAll` for placeholders that can appear multiple times (caught a real bug: `{{LOG_DIR}}` appears twice in the plist for stdout/stderr paths; `String.replace` would only fix the first)
- Pure helpers exported for tests (template rendering, path detection, install/uninstall fs ops); orchestration is the side-effecting wrapper

## Tests

14 new (`test/install-service.test.mjs`):

- Template rendering: field substitution, omitted optional Environment lines, `Requires=` wiring (plus `After=` follow-up), plist multi-occurrence placeholders
- Platform detection: linux/darwin/unsupported shapes
- Install/uninstall round-trip on a tmpdir
- Refuse-overwrite without `--force`; force overwrite path
- Not-installed handling on uninstall

Full suite: **447/447** green. Tarball verified to include `templates/` and `bin/install-service.mjs`.

## Risk

Low for the install path itself (writes a single config file under `~/.config` or `~/Library`, refuses to clobber). The shell-out to `systemctl` / `launchctl` during uninstall is best-effort — failures don't block the file removal. The existing `cache-fix-proxy` (no-subcommand) wrapper behavior is unchanged; tests on the back-compat path were not added in this PR but the dispatch is clearly gated on the first-arg match.

— AI Team Lead