### PR TITLE
release: v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 3.1.1 (2026-04-25)
+
+**`cache-fix-proxy install-service` subcommand** (#73, closes #48):
+
+- New CLI dispatch supports `install-service` (systemd on Linux, launchd on macOS), `uninstall-service`, `server` (run just the proxy in foreground for ExecStart), and `help`.
+- Existing `cache-fix-proxy` no-subcommand wrapper behavior is unchanged (back-compat).
+- Refuses to overwrite existing config without `--force`. Picks up `CACHE_FIX_PROXY_PORT`, `CACHE_FIX_PROXY_UPSTREAM`, `CACHE_FIX_DEBUG` from the env at install time.
+- Templates ship in new `templates/` directory.
+
+**Healthcheck companion for proxy auto-recovery** (#75):
+
+After the 2026-04-25 incident where the proxy was stopped by an unidentified caller during the Anthropic outage and stayed down for ~10 hours (`Restart=on-failure` doesn't fire on clean stops), `install-service` now also drops a healthcheck companion on Linux:
+
+- `cache-fix-proxy-healthcheck.service` — oneshot that does `curl -fs http://127.0.0.1:<port>/health` and `systemctl --user start cache-fix-proxy.service` if the probe fails
+- `cache-fix-proxy-healthcheck.timer` — fires the oneshot 30s after boot then every 2 minutes (AccuracySec=15s)
+- `uninstall-service` stops the timer FIRST, then the proxy, then removes all three files
+
+Recovery within 2 minutes from any stop cause: clean stop, crash, OOM, an external `systemctl stop`. macOS doesn't need it — launchd's `KeepAlive` already auto-restarts on any exit.
+
+**Hardening + security**:
+
+- Port string is now validated before being interpolated into the healthcheck shell command. A hostile `CACHE_FIX_PROXY_PORT` value (with shell metacharacters) would have allowed command injection; rejected with a clear error message now.
+- Symmetric existence check on the healthcheck pair: refuses overwrite if either the service file OR the timer file exists (caught case where one was a half-installed stale artifact).
+- Half-install rollback: if the healthcheck install throws after the main unit is written, the main unit is removed so users aren't left in a partial state.
+
+**New doc: `docs/security-hardening.md`** (#74):
+
+Honest assessment of the trust model around running CC + cache-fix proxy. Ranked threat surface, practical mitigations, what we explicitly DON'T defend against. Includes the proposed dangerous-command filter as a future v3.2.0 candidate, and audit-trail enablement docs (systemd user manager debug logging) for forensic recovery.
+
+**Tests**: 433 → 465 (32 new). No breaking changes. No migration required.
+
+---
+
 ## 3.1.0 (2026-04-25)
 
 **New proxy extensions** (drop-in, behavior described inline):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-cache-fix",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Cache optimization proxy and interceptor for Claude Code. Fixes prompt cache bugs, stabilizes prefix, reduces quota burn.",
   "type": "module",
   "exports": "./preload.mjs",


### PR DESCRIPTION
## v3.1.1 release commit

Bumps to 3.1.1, adds the v3.1.1 CHANGELOG entry.

## What's in v3.1.1

- **#73 (closes #48)**: \`cache-fix-proxy install-service / uninstall-service\` subcommands (systemd Linux, launchd macOS)
- **#75**: healthcheck companion for proxy auto-recovery (systemd timer + oneshot service that curls /health and restarts the proxy if down)
- **#74**: \`docs/security-hardening.md\` — honest threat model + practical mitigations
- Hardening: port validation against shell injection, symmetric overwrite guard on healthcheck pair, half-install rollback if healthcheck install throws

## Verification

- \`npm test\`: **465/465** green on the release commit
- \`npm pack --dry-run\`: tarball includes \`install-service.mjs\` + all 4 templates + \`security-hardening.md\`. 48 files total.

## Post-merge sequence

1. Tag v3.1.1, push tag
2. \`npm publish\`
3. GitHub Release with notes mirroring the CHANGELOG entry
4. Restart local cache-fix-proxy systemd service to verify deployed code matches released

— AI Team Lead