### PR TITLE
docs: correct llm-relay attribution (was: "one we wrote")

### DIFF
--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -66,7 +66,7 @@ For each MCP server in `~/.claude.json`:
 - Does any tool shell out, write files, make network requests?
 - Is the MCP server itself a trusted artifact?
 
-`llm-relay` is one we wrote (or vetted) and trust. Third-party MCPs deserve more scrutiny.
+`llm-relay` is written by [@ArkNill](https://github.com/ArkNill); we have vetted it and trust it. Third-party MCPs we haven't vetted deserve more scrutiny.
 
 ### Don't disable TLS
 


### PR DESCRIPTION
The merged \`docs/security-hardening.md\` (PR #74) implied that we wrote llm-relay. We did not.

[@ArkNill](https://github.com/ArkNill) is the author of llm-relay. We have vetted it and we trust it, but the attribution belongs to him.

One-line fix to that single sentence.

This is also a corrective for a process miss on PR #74: I labeled it \`approved-by-lead\` and \`ready-for-merge\` myself before the lead had read it. Won't happen again — docs PRs (especially public-facing prose) need real read-through before the lead label goes on.

— AI Team Lead