### PR TITLE
directive: claude-meter compat with proxy mode (#70)

### DIFF
--- a/docs/code-reviews/pr-81-claude-meter-compat-directive-review-2026-04-25.md
+++ b/docs/code-reviews/pr-81-claude-meter-compat-directive-review-2026-04-25.md
@@ -1,0 +1,37 @@
+# Review: claude-meter compat directive
+
+Date: 2026-04-25
+Reviewed: `docs/directives/proxy-claude-meter-compat.md`
+Label applied: `changes-requested`
+
+## What Is Correct
+- The high-level direction is sound: moving claude-meter off the broken `NODE_OPTIONS` preload and onto proxy-produced telemetry is the right fix for CC v2.1.113+.
+- Reusing the existing `usage-log` extension pattern is the right activation model for this feature. Keeping the extension opt-in via extension config, rather than introducing a second env-var gate inside the extension, is consistent with the repo’s extension loader and with the current `usage-log` design in `proxy/extensions/usage-log.mjs`.
+- Most of the raw data needed by claude-meter is available on the proxy side. The request model is already captured in `proxy/server.mjs`, rate-limit headers are available in `responseHeaders`, and the SSE stream includes the usage payloads that carry `speed`, `service_tier`, `cache_creation.ephemeral_*`, and `server_tool_use.web_search_requests`.
+- Splitting the work across the two repos is directionally correct: this repo should produce the canonical per-call log row, and claude-meter should switch ingestion sources without changing its upload/share protocol.
+
+## Blockers
+- The directive’s “canonical superset” schema is not actually compatible with claude-meter’s current strict validator. `MeterRowSchema` is a `z.strictObject` with `v: 1` and does not allow extra keys such as `total_input` or `peak_hour`, while the directive says the proxy will emit `v: 2` plus those extra fields and that claude-meter will “reuse existing `src/log/schema.mjs` validation.” Those statements cannot all be true at once. The directive needs one coherent contract: either the shared wire schema is updated in claude-meter to accept the new fields/version, or the proxy output must stay within the strict row shape that claude-meter validates today.
+- The activation/config story is wrong in two places. The directive tells users to enable the integration with `CACHE_FIX_USAGE_LOG=1`, but in this repo `CACHE_FIX_USAGE_LOG` is the path override, not an enable flag, and `usage-log` is supposed to remain a config-toggle opt-in. It also says to add a comment to `extensions.json`, but this repo parses that file with `JSON.parse`, so comments are not valid there. The directive needs to describe the real activation path: extension config enables the module; `CACHE_FIX_USAGE_LOG` only overrides the destination path.
+- The org ID privacy requirement is not specified precisely enough for a cross-repo contract. The directive says “hashed sha256 prefix” and has a test that asserts “not the original,” but it never states the exact encoding and truncation rule. claude-meter’s existing writer uses `sha256(...).digest("hex").slice(0, 16)`. If the proxy side is supposed to preserve compatibility and privacy guarantees, the directive needs to pin that exact algorithm and output length.
+- The proxy-side test seam is underspecified for several required fields. The proposed `buildRecord(meta, telemetry, responseHeaders, ...)` signature assumes all needed inputs are already present in `meta`/`telemetry`, but the current proxy telemetry object only carries `model`, `requestedModel`, token counters, and `stopReason`, and `cache-telemetry` currently does not populate `speed`, `service_tier`, `cache_creation.ephemeral_*`, or `web_search_requests`. Those values are available from the SSE stream, but the directive does not specify where that state will be captured before the final `message_delta` write. As written, the pure-function contract does not line up with the actual data flow.
+- The migration/versioning story is incomplete. The directive says claude-meter will handle “old `v: 1` (preload-era) rows” during a transition window, but the old preload data lives in `~/.claude/claude-meter.jsonl`, while the existing proxy `usage-log` file uses a different 9-field shape with no `v` field at all. The directive needs to say exactly which historical formats the new claude-meter ingest path must tolerate, whether existing `usage.jsonl` content is supported or intentionally ignored, and what the release ordering is between the proxy change and the claude-meter release.
+- The file/test path list is incorrect for this repo. The directive names `tests/usage-log.test.mjs`, but this repo uses `test/`, and there is already a `test/proxy-usage-log.test.mjs`. That should be corrected before implementation starts so the PR target is unambiguous.
+
+## What Needs Attention
+- The schema reconciliation section says `MeterRowSchema` has “derived: `total_input`,” but the actual schema does not include `total_input`; only `cache_hit_rate`, `q5h_delta`, and `q7d_delta` are derived fields today. That mismatch is another sign that the shared row contract needs to be restated from the real schema, not from a paraphrase.
+- The directive does not spell out release sequencing across repos. Practically, claude-meter cannot rely on this ingestion path until the proxy side is released with the expanded row shape. That ordering is manageable, but it should be stated explicitly so the two PRs do not appear independently shippable.
+- The cache-fix test plan should explicitly cover the message-start state capture needed for `speed`, `service_tier`, ephemeral split, and `web_search_requests`, not just the final record object. Otherwise the hardest part of the refactor can regress while the pure `buildRecord()` tests still pass.
+
+## Recommendations
+- Rewrite the shared-schema section around the exact claude-meter validator contract. List the authoritative field set, mark which fields remain optional, and say plainly whether `peak_hour` is part of the shared wire row or a separate proxy-only artifact.
+- Replace the activation text with the actual `usage-log` pattern: `enabled: false` by default, opt-in through `proxy/extensions.json` (or whatever documented extension-config flow the repo standardizes on), optional `CACHE_FIX_USAGE_LOG=<path>` override for destination path only.
+- Pin the org ID rule to the existing claude-meter implementation: SHA-256, hex digest, first 16 characters, never raw.
+- Add an explicit state-capture plan on the proxy side for fields only available on `message_start`, and ensure the test seam reflects that state model instead of pretending everything already exists in `meta` and `telemetry`.
+- Clarify migration scope and ordering: whether old `usage.jsonl` rows are supported, whether old preload rows are out of scope for the new ingest path, and that the proxy release must land before claude-meter can ship the new default ingestion mode.
+- Correct the file references to `test/` and point the work at `test/proxy-usage-log.test.mjs` unless there is a strong reason to create a second test file.
+
+## Bottom Line
+Revise before implementation. The architectural direction is right, and the `usage-log` opt-in pattern is the correct one to build on, but the directive still has blocking contract errors around schema compatibility, activation semantics, org ID hashing, and migration/versioning. Those need to be fixed in the directive first so the two repos do not implement different interpretations of the same wire format.
+
+Verdict: REQUEST CHANGES

--- a/docs/code-reviews/pr-81-claude-meter-compat-impl-review-2026-04-25.md
+++ b/docs/code-reviews/pr-81-claude-meter-compat-impl-review-2026-04-25.md
@@ -1,0 +1,31 @@
+# Review: PR 81 claude-meter compat implementation
+
+Date: 2026-04-25
+Reviewed: `proxy/extensions/usage-log.mjs`, `test/proxy-usage-log.test.mjs`
+Label applied: `approved-by-codex-agent`
+
+## What Is Correct
+
+- `assembleRecord` emits the strict `MeterRowSchema` v:1 wire shape, with required fields always present and optional fields conditionally omitted instead of emitted as `undefined` ([proxy/extensions/usage-log.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/usage-log.mjs:137)).
+- The extension follows the approved `message_start` → `message_delta` lifecycle: start-state is captured in `ctx.meta._usageLog.start`, and `message_delta` emits only when that state exists ([proxy/extensions/usage-log.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/usage-log.mjs:230)).
+- The implementation matches the directive’s privacy and activation requirements: `org_id` is hashed with `sha256(...).slice(0, 16)`, `enabled: false` remains on the default export, and `CACHE_FIX_USAGE_LOG` is used as a path override rather than an activation switch ([proxy/extensions/usage-log.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/usage-log.mjs:63), [proxy/extensions/usage-log.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/usage-log.mjs:224)).
+- Delta tracking and append semantics align with the directive: first-call deltas are zero because previous values are applied during assembly and updated only afterward, and writes are a single `appendFile()` call per row ([proxy/extensions/usage-log.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/usage-log.mjs:131), [proxy/extensions/usage-log.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/usage-log.mjs:202), [proxy/extensions/usage-log.mjs](/home/manager/git_repos/claude-code-cache-fix/proxy/extensions/usage-log.mjs:265)).
+- The new test file covers the directive checklist well, including `v: 1`, `peak_hour` absence, `org_id` bit-exact hashing, first-call delta behavior, no-output-without-start-state, and concurrent append behavior ([test/proxy-usage-log.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/proxy-usage-log.test.mjs:66), [test/proxy-usage-log.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/proxy-usage-log.test.mjs:289), [test/proxy-usage-log.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/proxy-usage-log.test.mjs:329), [test/proxy-usage-log.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/proxy-usage-log.test.mjs:341), [test/proxy-usage-log.test.mjs](/home/manager/git_repos/claude-code-cache-fix/test/proxy-usage-log.test.mjs:366)).
+- I also validated a synthesized emitted row against `claude-meter`’s external `MeterRowSchema.parse()` from `/home/manager/git_repos/claude-meter/src/log/schema.mjs`; the record parsed successfully.
+
+## Blockers
+
+None
+
+## What Needs Attention
+
+- No blocking findings in `e1a89f4`.
+
+## Recommendations
+
+- Keep the cross-repo release ordering called out in the directive intact: proxy release first, then claude-meter ingest release.
+- When follow-up changes touch this wire format, continue validating against the external `MeterRowSchema` directly; this implementation is now tightly coupled to that contract by design.
+
+## Bottom Line
+
+APPROVE. The implementation in `e1a89f4` matches the approved directive at `efb9789`, satisfies the strict `MeterRowSchema` v:1 contract from `claude-meter`, preserves the intended `usage-log` activation model, and is backed by both targeted and full-suite passing tests.

--- a/docs/directives/proxy-claude-meter-compat.md
+++ b/docs/directives/proxy-claude-meter-compat.md
@@ -145,7 +145,7 @@ Stay inside `proxy/extensions/usage-log.mjs`. Don't split across files.
   - `parseQuotaHeaders(responseHeaders)` → quota object
   - `assembleRecord({ start, delta, quota, headers, sid, prevQ5h, prevQ7d, now })` → full v:1 record
   - `computeDelta(current, previous)` → numeric delta
-- Atomic-append per write — single-syscall `fs.promises.appendFile(path, JSON.stringify(record) + "\n")`. Records are well under 4 KB, so `O_APPEND` + `PIPE_BUF` (4096 bytes on Linux) gives record-level atomicity.
+- Atomic-append per write — single-syscall `fs.promises.appendFile(path, JSON.stringify(record) + "\n")`. POSIX guarantees `O_APPEND` atomically combines offset adjustment with the write (no torn offsets between concurrent appenders). POSIX does NOT guarantee non-interleaved writes to regular files (`PIPE_BUF` atomicity, often cited here, applies to pipes/FIFOs only). In practice on Linux with ext4/xfs/btrfs and a single `write(2)` of a buffer well under one page (4096 bytes), record-level interleaving does not occur — empirical kernel behavior, not POSIX. Each record is well under 4 KB. Test #15 (50 parallel writes, no interleaving) validates this empirically. Escalation path if it fails: per-record `tmp+rename`, `flock(2)`, or single-writer queue.
 
 ## Test plan (cache-fix side)
 

--- a/docs/directives/proxy-claude-meter-compat.md
+++ b/docs/directives/proxy-claude-meter-compat.md
@@ -1,0 +1,195 @@
+# Directive: claude-meter compatibility with proxy mode
+
+**Issue:** #70
+**Branch:** `feature/claude-meter-compat`
+**Stage:** directive
+**Milestone:** v3.2.0
+
+## Goal
+
+Restore `claude-code-meter` functionality for users on CC v2.1.113+ (Bun binary) by repointing it from the broken NODE_OPTIONS preload at the existing `usage-log` JSONL stream the proxy already writes. Keep claude-meter's privacy and validation guarantees intact; eliminate the duplicate collection logic that no longer fires.
+
+## Why
+
+`claude-code-meter` was wired into the legacy CC wrapper via `NODE_OPTIONS="--import .../claude-meter/preload.mjs"`. CC v2.1.113+ ships as a Bun binary that ignores NODE_OPTIONS. Result: every modern CC install silently drops claude-meter rows. We've already pulled the broken README references in v3.1.0 (PR #71) so we stop promising a path that doesn't work; this directive does the actual fix.
+
+The proxy already produces `~/.claude/usage.jsonl` via the `usage-log` extension (currently `enabled: false`). It captures most of what claude-meter needs from the same response stream. Refactoring claude-meter to consume from this file:
+
+- Works for both Bun and Node CC installs
+- Decouples claude-meter from CC's binary lifecycle entirely
+- Eliminates duplicate fetch-patching logic
+- Keeps the proxy as the single point of telemetry collection
+
+## Scope (v3.2.0)
+
+This directive spans **two repositories**:
+
+### Repo 1: `claude-code-cache-fix` (this repo)
+
+In scope:
+- Extend `proxy/extensions/usage-log.mjs` to emit a superset record that includes every field claude-meter currently captures (model, requested_model, speed, service_tier, ephemeral_1h/5m split, qstatus, qoverage, qclaim, qfallback_pct, qoverage_util, qrepresentative_claim, hashed org_id, overage_disabled_reason, derived totals, q5h/q7d deltas, sid for session grouping).
+- Update `usage-log` schema to match the same shape claude-meter validates with `MeterRowSchema` — the file becomes a canonical wire format both projects agree on.
+- Document the new schema explicitly in `usage-log.mjs` as a comment block with the field list.
+- Add an opt-in env var `CACHE_FIX_USAGE_LOG_PATH` to override the file path (already partly there as `CACHE_FIX_USAGE_LOG`; rename for clarity OR keep existing name with alias). Decision: **keep existing name**, no churn.
+- Keep `enabled: false` default for v3.2.0. Document that enabling it is the gate for claude-meter ingestion.
+- Update README to point claude-meter users at `CACHE_FIX_USAGE_LOG=1` as the integration path (or via `extensions.json` toggle).
+
+Out of scope (this repo, this milestone):
+- Making `usage-log` default-on. That's a v3.3.0 decision after we see real adoption and any disk-usage concerns surface.
+- Removing the existing simpler 9-field record format. We change the record shape in-place; downstream consumers either upgrade to the new schema or pin an older version.
+
+### Repo 2: `claude-code-meter` (separate repo)
+
+In scope:
+- New ingestion mode: read from `~/.claude/usage.jsonl` (path configurable) instead of via fetch-patch.
+- Refactor `bin/claude-meter.mjs` to add a subcommand (e.g., `claude-meter ingest` or default behavior) that tails the proxy's JSONL.
+- Validate every row through `MeterRowSchema` (existing) — proxy-emitted rows must pass the same validation. Fields the proxy doesn't yet emit (e.g., `web_search_requests`) become optional in `MeterRowSchema` or are emitted by the proxy as `0`.
+- Track ingestion offset (e.g., `~/.claude/.claude-meter-ingest-offset`) so we don't re-process already-uploaded rows on restart.
+- Deprecate `src/interceptor/preload.mjs` — keep the file with a notice for now (people may have it pinned in NODE_OPTIONS and deserve a friendly error), remove in next major.
+- Update `package.json` exports — drop `./preload`.
+- Update README — describe the new flow: install cache-fix proxy → enable usage-log → run `claude-meter` to ingest/share.
+
+Out of scope (claude-meter, this milestone):
+- Changes to the share/upload protocol. Same wire format, same validation, same endpoints. Only the ingestion source changes.
+- New analytics features. Keep the change purely structural.
+
+### Repo 3: wrapper script (`~/bin/claude` on each user host)
+
+In scope (documented in cache-fix README, not committed code):
+- Remove the legacy `NODE_OPTIONS="--import .../claude-meter/preload.mjs"` line for v2.1.113+ users.
+- The cache-fix proxy is the only production wiring needed for usage capture going forward.
+
+Not in this PR (this is local-host setup, not a versioned artifact).
+
+## Schema reconciliation
+
+Current proxy `usage-log` record (9 fields):
+```
+timestamp, model, input_tokens, output_tokens, cache_read_input_tokens,
+cache_creation_input_tokens, q5h_pct, q7d_pct, peak_hour
+```
+
+claude-meter `MeterRowSchema` (24+ fields, see `src/log/schema.mjs`):
+```
+v, ts, sid, model, requested_model, model_mismatch, speed, service_tier,
+input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens,
+ephemeral_1h_input_tokens, ephemeral_5m_input_tokens, web_search_requests,
+q5h, q7d, q5h_reset, q7d_reset, qstatus, qoverage, qclaim, qfallback_pct,
+qoverage_util, qrepresentative_claim, org_id, overage_disabled_reason,
++ derived: q5h_delta, q7d_delta, total_input, cache_hit_rate
+```
+
+Target proxy `usage-log` record (canonical superset, schema-version 2):
+```
+v: 2,
+ts: <ISO>,
+sid: <8-char-hex>,                       // proxy session, regenerated on restart
+model, requested_model, model_mismatch, speed, service_tier,
+input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens,
+ephemeral_1h_input_tokens, ephemeral_5m_input_tokens, web_search_requests,
+q5h, q7d, q5h_reset, q7d_reset, qstatus, qoverage, qclaim, qfallback_pct,
+qoverage_util?, qrepresentative_claim?, org_id?, overage_disabled_reason?,
+q5h_delta, q7d_delta, total_input, cache_hit_rate,
+peak_hour                                 // keep — useful proxy-side derived field
+```
+
+Optional fields (`?`) are present only when the source headers/data are present. Schema-validated by zod on the claude-meter side; proxy emits without validation but follows the contract documented in the source comment block.
+
+**Schema versioning:** `v: 2` distinguishes the new superset record from anyone still reading old `v: 1` (preload-era) rows. claude-meter's reader handles both during a transition window.
+
+## Implementation choice
+
+For `usage-log.mjs`:
+- Keep the existing extension contract (`order: 650`, `onStreamEvent`).
+- Move record building to a pure exported function `buildRecord(meta, telemetry, responseHeaders)` that produces the v: 2 schema. Already half-extracted; finish the job.
+- Add session ID generation at module scope (PID + load-time hash), sticky across the proxy run.
+- Track previous q5h/q7d in module-scope vars to compute deltas. (Reset on proxy restart — same tradeoff as claude-meter's preload.)
+- Atomic-append per write (existing `appendFile` is fine — small records, single-line, kernel guarantees atomicity for small writes).
+
+For claude-meter:
+- New module `src/ingest/jsonl-tailer.mjs` — reads usage.jsonl forward from a saved offset.
+- Reuses existing `src/log/schema.mjs` validation.
+- Reuses existing `src/share/` upload logic unchanged — feeds it validated rows.
+- Bin entry adds `claude-meter ingest [--source <path>] [--once] [--watch]`.
+
+## Test seam (cache-fix side)
+
+Pure exports from `usage-log.mjs`:
+- `buildRecord(meta, telemetry, responseHeaders, sessionId, prevQ5h, prevQ7d)` → record object
+- `generateSessionId()` → string
+- `parseAllHeaders(headers)` → all the qstatus/qoverage/etc. fields
+
+Tests pass synthetic ctx/telemetry/headers. `CACHE_FIX_USAGE_LOG` env var is for runtime override only; tests pass `path` directly to a write helper.
+
+## Test plan (cache-fix side)
+
+1. **Schema correctness**: synthesized stream-event → record matches v:2 shape exactly
+2. **Optional fields omitted when absent**: missing `org_id` header → `org_id` not in record
+3. **Required fields zero when absent**: missing `web_search_requests` → field present as `0`
+4. **Delta computation**: two consecutive calls → `q5h_delta` / `q7d_delta` reflect difference
+5. **First-call deltas**: first call after restart → deltas are `0` (no prior)
+6. **Session ID stability**: multiple calls → same `sid` within a process
+7. **Session ID format**: matches `/^[0-9a-f]{8}$/` (claude-meter's regex)
+8. **Cache hit rate**: `cache_read / total_input` computed correctly; `0` when total is `0`
+9. **org_id hashing**: input `acct-abc123` → output is sha256 prefix, not the original
+10. **Schema version**: every record has `v: 2`
+11. **Backwards-compat note**: tests verify old consumers reading new records get extra fields they can ignore (forward-compat smoke test)
+12. **Disabled**: env var off, extension config off → no file writes
+13. **Concurrency**: parallel calls don't corrupt JSONL
+
+## Test plan (claude-meter side — for the separate PR)
+
+Will be detailed in the claude-meter repo's own directive. Outline:
+1. Tailer reads valid usage.jsonl rows
+2. Tailer rejects (and logs) invalid rows without crashing
+3. Offset persists across restarts; no double-ingestion
+4. Backward-compat with v:1 records (transition window)
+5. Watch mode picks up appended rows in <1s
+6. Once mode reads to current EOF and exits
+
+## Files modified / created
+
+### `claude-code-cache-fix` (this PR)
+
+| File | Change |
+|---|---|
+| `proxy/extensions/usage-log.mjs` | EXPAND record to v:2 superset schema; extract pure functions; add sessionId + delta tracking |
+| `tests/usage-log.test.mjs` | NEW (or expand existing) — 13 cases per test plan |
+| `extensions.json` | Confirm `enabled: false` default; add comment pointing at claude-meter integration |
+| `README.md` | Document v:2 schema; add claude-meter integration instructions |
+| `docs/directives/proxy-claude-meter-compat.md` | THIS file |
+
+### `claude-code-meter` (separate PR in that repo)
+
+| File | Change |
+|---|---|
+| `src/ingest/jsonl-tailer.mjs` | NEW |
+| `src/log/schema.mjs` | Mark `web_search_requests` and other proxy-not-yet-emitting fields optional; add v:2 acceptance |
+| `bin/claude-meter.mjs` | Add `ingest` subcommand |
+| `src/interceptor/preload.mjs` | Add deprecation notice |
+| `package.json` | Drop `./preload` export |
+| `README.md` | Rewrite integration section |
+
+## Reviewer checklist (cache-fix side)
+
+- [ ] v:2 schema documented as a source-comment block in `usage-log.mjs`
+- [ ] All claude-meter fields covered by the proxy where data is available
+- [ ] Optional vs required fields match `MeterRowSchema` constraints
+- [ ] Pure functions exported for testing; default export remains the extension contract
+- [ ] No request mutation
+- [ ] sessionId regex matches `/^[0-9a-f]{8}$/`
+- [ ] org_id is hashed (sha256 prefix), never raw
+- [ ] Tests pass on Node 18, 20, 22 (CI matrix)
+- [ ] `extensions.json` default remains `enabled: false`
+- [ ] README documents the schema change AND the claude-meter integration path
+- [ ] Existing 9-field consumers handled with a CHANGELOG note (v:1 → v:2 is a breaking change for anyone parsing the old shape)
+
+## Out of scope (explicit)
+
+- **Default-enabling `usage-log`** — defer to v3.3.0 once adoption pattern is clear.
+- **claude-meter share-protocol changes** — wire format and endpoints unchanged.
+- **Real-time ingestion** beyond watch-mode polling. JSONL append is the boundary; if we need true streaming later, that's a different design.
+- **Backfill of historical preload-written `~/.claude/claude-meter.jsonl` data** — already collected data is what it is; this directive doesn't migrate it.
+- **The dangerous-command filter** from the security doc — separate proposal.
+
+— AI Team Lead

--- a/docs/directives/proxy-claude-meter-compat.md
+++ b/docs/directives/proxy-claude-meter-compat.md
@@ -2,7 +2,7 @@
 
 **Issue:** #70
 **Branch:** `feature/claude-meter-compat`
-**Stage:** directive
+**Stage:** directive (revised after Codex review — see `docs/code-reviews/pr-81-claude-meter-compat-directive-review-2026-04-25.md`)
 **Milestone:** v3.2.0
 
 ## Goal
@@ -11,141 +11,172 @@ Restore `claude-code-meter` functionality for users on CC v2.1.113+ (Bun binary)
 
 ## Why
 
-`claude-code-meter` was wired into the legacy CC wrapper via `NODE_OPTIONS="--import .../claude-meter/preload.mjs"`. CC v2.1.113+ ships as a Bun binary that ignores NODE_OPTIONS. Result: every modern CC install silently drops claude-meter rows. We've already pulled the broken README references in v3.1.0 (PR #71) so we stop promising a path that doesn't work; this directive does the actual fix.
+`claude-code-meter` was wired into the legacy CC wrapper via `NODE_OPTIONS="--import .../claude-meter/preload.mjs"`. CC v2.1.113+ ships as a Bun binary that ignores NODE_OPTIONS. Result: every modern CC install silently drops claude-meter rows. We've already pulled the broken README references in v3.1.0 (PR #71); this directive does the actual fix.
 
-The proxy already produces `~/.claude/usage.jsonl` via the `usage-log` extension (currently `enabled: false`). It captures most of what claude-meter needs from the same response stream. Refactoring claude-meter to consume from this file:
+The proxy already produces `~/.claude/usage.jsonl` via the `usage-log` extension (`enabled: false` by default). It can capture every field claude-meter needs from the same response stream. Refactoring claude-meter to consume from this file:
 
 - Works for both Bun and Node CC installs
 - Decouples claude-meter from CC's binary lifecycle entirely
 - Eliminates duplicate fetch-patching logic
 - Keeps the proxy as the single point of telemetry collection
 
+## Schema decision
+
+After Codex review, the directive is anchored on a single coherent contract: **the proxy emits EXACTLY the `MeterRowSchema` v:1 shape that claude-meter's strict validator already enforces.** No new schema version. No proxy-only extras. The wire format becomes the single source of truth, owned by the schema file in `claude-code-meter`.
+
+Why this and not the previous "v:2 superset" approach:
+- `MeterRowSchema` is `z.strictObject({ v: z.literal(1), ... })` — it rejects extra keys AND requires `v: 1`. Emitting v:2 with extra fields like `peak_hour` would fail validation immediately. Adapting claude-meter to accept v:2 is a real cross-repo coordination cost we don't need.
+- Anything the proxy currently emits beyond `MeterRowSchema` (today: `peak_hour`) is either trivially recomputable from `ts` (peak_hour is) or not actually needed downstream.
+- Same wire format = simplest possible cross-repo contract.
+
+The current proxy `usage-log` shape (9 fields including `peak_hour`) is replaced wholesale. Existing rows from people who manually enabled `usage-log` were never schema-validated and have no production consumer — they're skipped by the new claude-meter ingest path with a debug log. Documented as a one-time "old format rows are ignored" event in CHANGELOG.
+
+The exact field set the proxy must emit (from `MeterRowSchema` in `claude-code-meter/src/log/schema.mjs`):
+
+| Field | Type | Source |
+|---|---|---|
+| `v` | literal `1` | constant |
+| `ts` | ISO-8601 datetime | `new Date().toISOString()` |
+| `sid` | 8-char lowercase hex | proxy session id (sticky for proxy lifetime) |
+| `model` | string ≤64, `[a-z0-9._-]+` | `event.message.model` from `message_start` |
+| `requested_model` | string ≤64, `[a-z0-9._-]*` (opt) | request body `model` field |
+| `model_mismatch` | bool (opt) | `requested_model && model && requested_model !== model` |
+| `speed` | enum `"standard"\|"fast"\|""` | `event.message.usage.speed` from `message_start`, fallback `""` |
+| `service_tier` | string ≤32, `[a-z0-9_-]*` | `event.message.usage.service_tier` from `message_start`, fallback `""` |
+| `input_tokens` | int ≥0 | `event.message.usage.input_tokens` |
+| `output_tokens` | int ≥0 | `event.usage.output_tokens` from `message_delta` |
+| `cache_creation_input_tokens` | int ≥0 | `event.message.usage.cache_creation_input_tokens` |
+| `cache_read_input_tokens` | int ≥0 | `event.message.usage.cache_read_input_tokens` |
+| `ephemeral_1h_input_tokens` | int ≥0 | `event.message.usage.cache_creation.ephemeral_1h_input_tokens`, fallback `0` |
+| `ephemeral_5m_input_tokens` | int ≥0 | `event.message.usage.cache_creation.ephemeral_5m_input_tokens`, fallback `0` |
+| `web_search_requests` | int ≥0 | `event.message.usage.server_tool_use.web_search_requests`, fallback `0` |
+| `q5h` | float 0-2 | `anthropic-ratelimit-unified-5h-utilization` |
+| `q7d` | float 0-2 | `anthropic-ratelimit-unified-7d-utilization` |
+| `q5h_reset` | int ≥0 (unix sec) | `anthropic-ratelimit-unified-5h-reset` |
+| `q7d_reset` | int ≥0 (unix sec) | `anthropic-ratelimit-unified-7d-reset` |
+| `qstatus` | string ≤32, `[a-z_]*` | `anthropic-ratelimit-unified-status` |
+| `qoverage` | string ≤32, `[a-z_]*` | `anthropic-ratelimit-unified-overage-status` |
+| `qclaim` | string ≤16, `[a-z_]*` | `anthropic-ratelimit-unified-claim` |
+| `qfallback_pct` | float 0-1 | `anthropic-ratelimit-unified-fallback-percentage` |
+| `qoverage_util` | float ≥0 (opt) | `anthropic-ratelimit-unified-overage-utilization`, only if header present |
+| `qrepresentative_claim` | string ≤16, `[a-z0-9_]*` (opt) | `anthropic-ratelimit-unified-representative-claim`, only if header present |
+| `org_id` | string ≤64 (opt) | `sha256(anthropic-organization-id-header).digest("hex").slice(0, 16)`, only if header present — never raw |
+| `overage_disabled_reason` | string ≤64 (opt) | header same name, only if header present |
+| `cache_hit_rate` | float 0-1 | `cache_read_input_tokens / (input + cache_creation + cache_read)`, `0` when total is `0` |
+| `q5h_delta` | float | `q5h - prev_q5h`, `0` on first call after restart |
+| `q7d_delta` | float | `q7d - prev_q7d`, `0` on first call after restart |
+
+**`peak_hour` is dropped from the proxy JSONL output.** It can be derived from `ts` if any consumer needs it.
+
 ## Scope (v3.2.0)
 
-This directive spans **two repositories**:
+This directive spans **two repositories** and has a hard ordering requirement.
 
-### Repo 1: `claude-code-cache-fix` (this repo)
+### Release ordering (mandatory)
+
+1. **First**: `claude-code-cache-fix` ships the expanded `usage-log` shape on a new tag (e.g. `v3.2.0`) with the schema-change CHANGELOG note.
+2. **Then**: `claude-code-meter` ships its new `ingest` subcommand on its own next release (e.g. `v0.4.0`), declaring `claude-code-cache-fix >= 3.2.0` as the supported producer in its README.
+
+claude-meter cannot ship the new ingestion path independently — there is no proxy-emitted v:1 row to read until the proxy release lands. The two PRs are NOT independently shippable. State this in both repos' CHANGELOGs.
+
+### Repo 1: `claude-code-cache-fix` (this PR)
 
 In scope:
-- Extend `proxy/extensions/usage-log.mjs` to emit a superset record that includes every field claude-meter currently captures (model, requested_model, speed, service_tier, ephemeral_1h/5m split, qstatus, qoverage, qclaim, qfallback_pct, qoverage_util, qrepresentative_claim, hashed org_id, overage_disabled_reason, derived totals, q5h/q7d deltas, sid for session grouping).
-- Update `usage-log` schema to match the same shape claude-meter validates with `MeterRowSchema` — the file becomes a canonical wire format both projects agree on.
-- Document the new schema explicitly in `usage-log.mjs` as a comment block with the field list.
-- Add an opt-in env var `CACHE_FIX_USAGE_LOG_PATH` to override the file path (already partly there as `CACHE_FIX_USAGE_LOG`; rename for clarity OR keep existing name with alias). Decision: **keep existing name**, no churn.
-- Keep `enabled: false` default for v3.2.0. Document that enabling it is the gate for claude-meter ingestion.
-- Update README to point claude-meter users at `CACHE_FIX_USAGE_LOG=1` as the integration path (or via `extensions.json` toggle).
+- Rewrite `proxy/extensions/usage-log.mjs` to emit the exact `MeterRowSchema` v:1 record listed above.
+- State capture across stream events: `message_start` provides `model`, `usage.speed`, `usage.service_tier`, `usage.input_tokens`, `usage.cache_creation_input_tokens`, `usage.cache_read_input_tokens`, `usage.cache_creation.ephemeral_1h_input_tokens`, `usage.cache_creation.ephemeral_5m_input_tokens`, `usage.server_tool_use.web_search_requests`. `message_delta` provides `usage.output_tokens`. The extension MUST stash `message_start` data into `ctx.meta._usageLog` and assemble the final record in the `message_delta` handler.
+- Generate session id `sid` once per proxy lifetime: `crypto.createHash("sha256").update(`${process.pid}-${Date.now()}`).digest("hex").slice(0, 8)`.
+- Hash `org_id` with the EXACT algorithm claude-meter uses: `crypto.createHash("sha256").update(headerValue).digest("hex").slice(0, 16)`.
+- Track previous q5h/q7d in module-scope variables to compute deltas. First call after restart → deltas are `0`.
+- Update the existing test file `test/proxy-usage-log.test.mjs` (don't create a new one).
+- Document the schema change in CHANGELOG and README.
 
 Out of scope (this repo, this milestone):
-- Making `usage-log` default-on. That's a v3.3.0 decision after we see real adoption and any disk-usage concerns surface.
-- Removing the existing simpler 9-field record format. We change the record shape in-place; downstream consumers either upgrade to the new schema or pin an older version.
+- Default-enabling `usage-log` — defer to v3.3.0 once adoption pattern is clear.
+- Backwards-compat with the old 9-field shape on the writer side. Old rows in users' existing `~/.claude/usage.jsonl` will fail claude-meter's validator and be skipped (with a debug log on the reader). No backfill.
+- Extending `MeterRowSchema` or adding new fields — that's a coordinated future change owned by the schema file in `claude-code-meter`.
 
-### Repo 2: `claude-code-meter` (separate repo)
+### Activation (this repo)
 
-In scope:
-- New ingestion mode: read from `~/.claude/usage.jsonl` (path configurable) instead of via fetch-patch.
-- Refactor `bin/claude-meter.mjs` to add a subcommand (e.g., `claude-meter ingest` or default behavior) that tails the proxy's JSONL.
-- Validate every row through `MeterRowSchema` (existing) — proxy-emitted rows must pass the same validation. Fields the proxy doesn't yet emit (e.g., `web_search_requests`) become optional in `MeterRowSchema` or are emitted by the proxy as `0`.
-- Track ingestion offset (e.g., `~/.claude/.claude-meter-ingest-offset`) so we don't re-process already-uploaded rows on restart.
-- Deprecate `src/interceptor/preload.mjs` — keep the file with a notice for now (people may have it pinned in NODE_OPTIONS and deserve a friendly error), remove in next major.
-- Update `package.json` exports — drop `./preload`.
-- Update README — describe the new flow: install cache-fix proxy → enable usage-log → run `claude-meter` to ingest/share.
+This is the existing `usage-log` pattern, unchanged:
+
+- Default in the extension's own export: `enabled: false`. (The module is built with this default; the loader respects it.)
+- Users opt in by adding an entry to `proxy/extensions.json` like `"usage-log": { "enabled": true, "order": 650 }`. That's the entire activation gesture.
+- `CACHE_FIX_USAGE_LOG=<path>` is **only a path override** for the destination file. It is NOT an enable flag and never has been. Setting it without enabling the extension does nothing.
+- No env var for activation.
+- `extensions.json` is parsed with `JSON.parse` — no comments allowed. Any documentation we want to give users about enabling lives in the README, not in that file.
+
+### Repo 2: `claude-code-meter` (separate PR in that repo, not this PR)
+
+In scope (documented here so this directive captures the full shape; actual code change is in the other repo's PR):
+- New module `src/ingest/jsonl-tailer.mjs` — reads `~/.claude/usage.jsonl` forward from a saved offset.
+- Reuses existing `MeterRowSchema` validation unchanged. **Strict v:1 only.** Rows that fail validation (including old-format proxy rows) are logged at debug level and skipped. No silent acceptance.
+- Reuses existing share/upload logic unchanged.
+- Bin entry adds `claude-meter ingest [--source <path>] [--once] [--watch]`.
+- Persist offset to `~/.claude/.claude-meter-ingest-offset` so restart doesn't re-process rows.
+- Deprecate `src/interceptor/preload.mjs` — keep with a console warning for users who still have it pinned in NODE_OPTIONS, schedule removal for the next major.
+- Drop `./preload` from `package.json` exports.
+- README rewrite: install cache-fix proxy ≥3.2.0 → enable `usage-log` in `proxy/extensions.json` → run `claude-meter ingest`.
 
 Out of scope (claude-meter, this milestone):
-- Changes to the share/upload protocol. Same wire format, same validation, same endpoints. Only the ingestion source changes.
-- New analytics features. Keep the change purely structural.
+- Changes to the share/upload protocol. Same wire format, same endpoints.
+- Backfill of the historical preload-written `~/.claude/claude-meter.jsonl` data.
+- New analytics features. Keep this change purely structural.
 
 ### Repo 3: wrapper script (`~/bin/claude` on each user host)
 
 In scope (documented in cache-fix README, not committed code):
 - Remove the legacy `NODE_OPTIONS="--import .../claude-meter/preload.mjs"` line for v2.1.113+ users.
-- The cache-fix proxy is the only production wiring needed for usage capture going forward.
+- The cache-fix proxy with `usage-log` enabled is the only production wiring needed for usage capture going forward.
 
-Not in this PR (this is local-host setup, not a versioned artifact).
+## Implementation choice (cache-fix side)
 
-## Schema reconciliation
+Stay inside `proxy/extensions/usage-log.mjs`. Don't split across files.
 
-Current proxy `usage-log` record (9 fields):
-```
-timestamp, model, input_tokens, output_tokens, cache_read_input_tokens,
-cache_creation_input_tokens, q5h_pct, q7d_pct, peak_hour
-```
-
-claude-meter `MeterRowSchema` (24+ fields, see `src/log/schema.mjs`):
-```
-v, ts, sid, model, requested_model, model_mismatch, speed, service_tier,
-input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens,
-ephemeral_1h_input_tokens, ephemeral_5m_input_tokens, web_search_requests,
-q5h, q7d, q5h_reset, q7d_reset, qstatus, qoverage, qclaim, qfallback_pct,
-qoverage_util, qrepresentative_claim, org_id, overage_disabled_reason,
-+ derived: q5h_delta, q7d_delta, total_input, cache_hit_rate
-```
-
-Target proxy `usage-log` record (canonical superset, schema-version 2):
-```
-v: 2,
-ts: <ISO>,
-sid: <8-char-hex>,                       // proxy session, regenerated on restart
-model, requested_model, model_mismatch, speed, service_tier,
-input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens,
-ephemeral_1h_input_tokens, ephemeral_5m_input_tokens, web_search_requests,
-q5h, q7d, q5h_reset, q7d_reset, qstatus, qoverage, qclaim, qfallback_pct,
-qoverage_util?, qrepresentative_claim?, org_id?, overage_disabled_reason?,
-q5h_delta, q7d_delta, total_input, cache_hit_rate,
-peak_hour                                 // keep — useful proxy-side derived field
-```
-
-Optional fields (`?`) are present only when the source headers/data are present. Schema-validated by zod on the claude-meter side; proxy emits without validation but follows the contract documented in the source comment block.
-
-**Schema versioning:** `v: 2` distinguishes the new superset record from anyone still reading old `v: 1` (preload-era) rows. claude-meter's reader handles both during a transition window.
-
-## Implementation choice
-
-For `usage-log.mjs`:
-- Keep the existing extension contract (`order: 650`, `onStreamEvent`).
-- Move record building to a pure exported function `buildRecord(meta, telemetry, responseHeaders)` that produces the v: 2 schema. Already half-extracted; finish the job.
-- Add session ID generation at module scope (PID + load-time hash), sticky across the proxy run.
-- Track previous q5h/q7d in module-scope vars to compute deltas. (Reset on proxy restart — same tradeoff as claude-meter's preload.)
-- Atomic-append per write (existing `appendFile` is fine — small records, single-line, kernel guarantees atomicity for small writes).
-
-For claude-meter:
-- New module `src/ingest/jsonl-tailer.mjs` — reads usage.jsonl forward from a saved offset.
-- Reuses existing `src/log/schema.mjs` validation.
-- Reuses existing `src/share/` upload logic unchanged — feeds it validated rows.
-- Bin entry adds `claude-meter ingest [--source <path>] [--once] [--watch]`.
-
-## Test seam (cache-fix side)
-
-Pure exports from `usage-log.mjs`:
-- `buildRecord(meta, telemetry, responseHeaders, sessionId, prevQ5h, prevQ7d)` → record object
-- `generateSessionId()` → string
-- `parseAllHeaders(headers)` → all the qstatus/qoverage/etc. fields
-
-Tests pass synthetic ctx/telemetry/headers. `CACHE_FIX_USAGE_LOG` env var is for runtime override only; tests pass `path` directly to a write helper.
+- Keep the existing extension contract (`order: 650`, `onStreamEvent`, `enabled: false` default in the export).
+- Module-scope state:
+  - `let _sid = generateSid()` — sticky session id for proxy lifetime.
+  - `let _lastQ5h = null; let _lastQ7d = null;` — for delta tracking.
+- Per-call state on `ctx.meta._usageLog` — accumulated from `message_start`, finalized in `message_delta`.
+- Pure exported functions (test seam):
+  - `generateSid()` → 8-char hex
+  - `hashOrgId(rawOrgId)` → 16-char hex
+  - `extractMessageStartFields(event)` → partial record
+  - `extractMessageDeltaFields(event)` → partial record (just `output_tokens`)
+  - `parseQuotaHeaders(responseHeaders)` → quota object
+  - `assembleRecord({ start, delta, quota, headers, sid, prevQ5h, prevQ7d, now })` → full v:1 record
+  - `computeDelta(current, previous)` → numeric delta
+- Atomic-append per write — single-syscall `fs.promises.appendFile(path, JSON.stringify(record) + "\n")`. Records are well under 4 KB, so `O_APPEND` + `PIPE_BUF` (4096 bytes on Linux) gives record-level atomicity.
 
 ## Test plan (cache-fix side)
 
-1. **Schema correctness**: synthesized stream-event → record matches v:2 shape exactly
-2. **Optional fields omitted when absent**: missing `org_id` header → `org_id` not in record
-3. **Required fields zero when absent**: missing `web_search_requests` → field present as `0`
-4. **Delta computation**: two consecutive calls → `q5h_delta` / `q7d_delta` reflect difference
-5. **First-call deltas**: first call after restart → deltas are `0` (no prior)
-6. **Session ID stability**: multiple calls → same `sid` within a process
-7. **Session ID format**: matches `/^[0-9a-f]{8}$/` (claude-meter's regex)
-8. **Cache hit rate**: `cache_read / total_input` computed correctly; `0` when total is `0`
-9. **org_id hashing**: input `acct-abc123` → output is sha256 prefix, not the original
-10. **Schema version**: every record has `v: 2`
-11. **Backwards-compat note**: tests verify old consumers reading new records get extra fields they can ignore (forward-compat smoke test)
-12. **Disabled**: env var off, extension config off → no file writes
-13. **Concurrency**: parallel calls don't corrupt JSONL
+Update `test/proxy-usage-log.test.mjs`. Cover:
+
+1. **Schema match**: assemble a record from synthesized stream events, validate it against an inline copy of MeterRowSchema requirements (no zod dep — manual asserts on shape and types). Every required field present, every regex satisfied.
+2. **Optional fields omitted when absent**: missing `org_id` header → `org_id` not in record (not present as `undefined`, not present at all).
+3. **Required-with-default zero when source absent**: missing `web_search_requests` → field present as `0`.
+4. **`message_start` state capture**: simulated `message_start` event populates `ctx.meta._usageLog` with model, speed, service_tier, ephemeral split, web_search_requests.
+5. **`message_delta` finalization**: simulated `message_delta` event reads from `ctx.meta._usageLog`, adds output_tokens, emits the final record.
+6. **Delta computation**: two consecutive calls with q5h=0.5 then q5h=0.6 → second record's `q5h_delta` is `0.1`.
+7. **First-call deltas zero**: first call after module load → `q5h_delta` and `q7d_delta` are `0`.
+8. **Session ID stability**: multiple calls within a process → same `sid`.
+9. **Session ID format**: matches `/^[0-9a-f]{8}$/`.
+10. **Cache hit rate**: `cache_read=80, cache_creation=10, input=10` → `cache_hit_rate = 0.8`. `total=0` → `cache_hit_rate = 0`.
+11. **org_id hashing**: input `acct-abc123` → output is `sha256("acct-abc123").digest("hex").slice(0, 16)`. Bit-exact match with claude-meter's algorithm. Never the original.
+12. **Schema version**: every record has `v: 1`. (Yes, `1`, not `2`. We're not bumping.)
+13. **`peak_hour` absent**: assert `peak_hour` is NOT in the emitted record.
+14. **Disabled extension**: extension config off → no file writes, no state mutation.
+15. **Concurrency**: spawn 50 parallel `appendFile` calls → result file has exactly 50 well-formed JSON lines.
+16. **Header absence resilience**: missing every quota header → record is still assembled with safe defaults (numeric `0`, empty string for enums).
 
 ## Test plan (claude-meter side — for the separate PR)
 
-Will be detailed in the claude-meter repo's own directive. Outline:
-1. Tailer reads valid usage.jsonl rows
-2. Tailer rejects (and logs) invalid rows without crashing
-3. Offset persists across restarts; no double-ingestion
-4. Backward-compat with v:1 records (transition window)
-5. Watch mode picks up appended rows in <1s
-6. Once mode reads to current EOF and exits
+Will be detailed in claude-meter's own PR. Summary:
+1. Tailer reads valid `usage.jsonl` rows.
+2. Tailer rejects (debug-log + skip) invalid rows without crashing.
+3. Tailer rejects old 9-field proxy rows (no `v` field).
+4. Offset persists across restarts; no double-ingestion.
+5. Watch mode picks up appended rows in <1s.
+6. Once mode reads to current EOF and exits.
 
 ## Files modified / created
 
@@ -153,43 +184,52 @@ Will be detailed in the claude-meter repo's own directive. Outline:
 
 | File | Change |
 |---|---|
-| `proxy/extensions/usage-log.mjs` | EXPAND record to v:2 superset schema; extract pure functions; add sessionId + delta tracking |
-| `tests/usage-log.test.mjs` | NEW (or expand existing) — 13 cases per test plan |
-| `extensions.json` | Confirm `enabled: false` default; add comment pointing at claude-meter integration |
-| `README.md` | Document v:2 schema; add claude-meter integration instructions |
-| `docs/directives/proxy-claude-meter-compat.md` | THIS file |
+| `proxy/extensions/usage-log.mjs` | REWRITE — emits exact MeterRowSchema v:1 record; adds sessionId, message_start state capture, q5h/q7d delta tracking; drops `peak_hour` |
+| `test/proxy-usage-log.test.mjs` | EXPAND existing file — 16 cases per test plan |
+| `extensions.json` | UNCHANGED — `usage-log` continues to default `enabled: false` (extension's own export) |
+| `README.md` | Document the new schema (link to claude-meter's MeterRowSchema as the canonical source); update claude-meter integration instructions |
+| `CHANGELOG.md` | Note breaking change: usage-log row format changes; old rows in existing files will fail claude-meter validation and be skipped |
+| `docs/directives/proxy-claude-meter-compat.md` | THIS file (revised) |
 
-### `claude-code-meter` (separate PR in that repo)
+### `claude-code-meter` (separate PR in that repo, not this PR)
 
 | File | Change |
 |---|---|
 | `src/ingest/jsonl-tailer.mjs` | NEW |
-| `src/log/schema.mjs` | Mark `web_search_requests` and other proxy-not-yet-emitting fields optional; add v:2 acceptance |
+| `src/log/schema.mjs` | UNCHANGED — strict v:1 validation continues to enforce the wire contract |
 | `bin/claude-meter.mjs` | Add `ingest` subcommand |
 | `src/interceptor/preload.mjs` | Add deprecation notice |
-| `package.json` | Drop `./preload` export |
+| `package.json` | Drop `./preload` export; bump version (e.g. v0.4.0); document `>= cache-fix 3.2.0` requirement in README |
 | `README.md` | Rewrite integration section |
 
 ## Reviewer checklist (cache-fix side)
 
-- [ ] v:2 schema documented as a source-comment block in `usage-log.mjs`
-- [ ] All claude-meter fields covered by the proxy where data is available
-- [ ] Optional vs required fields match `MeterRowSchema` constraints
-- [ ] Pure functions exported for testing; default export remains the extension contract
-- [ ] No request mutation
-- [ ] sessionId regex matches `/^[0-9a-f]{8}$/`
-- [ ] org_id is hashed (sha256 prefix), never raw
-- [ ] Tests pass on Node 18, 20, 22 (CI matrix)
-- [ ] `extensions.json` default remains `enabled: false`
-- [ ] README documents the schema change AND the claude-meter integration path
-- [ ] Existing 9-field consumers handled with a CHANGELOG note (v:1 → v:2 is a breaking change for anyone parsing the old shape)
+- [ ] Emitted record matches `MeterRowSchema` v:1 EXACTLY — every field name, every type, every regex constraint. Tests assert this in detail.
+- [ ] `peak_hour` is NOT in the emitted record.
+- [ ] `v` field is the literal number `1`.
+- [ ] `org_id` hashing matches claude-meter's algorithm bit-exactly: `sha256(raw).digest("hex").slice(0, 16)`. Never raw.
+- [ ] `sid` regex matches `/^[0-9a-f]{8}$/`.
+- [ ] `message_start` data captured into `ctx.meta._usageLog`; `message_delta` reads from it and adds `output_tokens` to assemble the final record.
+- [ ] Optional fields are OMITTED (not `undefined`) when source data is absent.
+- [ ] Required-with-default fields are present as `0` (numeric) or `""` (string enums) when source is absent.
+- [ ] q5h/q7d delta tracking uses module-scope state and resets to `0` for the first call after a proxy restart.
+- [ ] Pure functions exported for testing.
+- [ ] No request mutation.
+- [ ] JSONL writes are single-syscall `appendFile` of `record + "\n"`; records are well under 4 KB.
+- [ ] `extensions.json` is NOT modified by this PR (`usage-log` keeps its existing config).
+- [ ] CHANGELOG explicitly calls out the breaking row-shape change for anyone parsing the old 9-field format.
+- [ ] README documents the v:1 wire format AND points to `claude-code-meter/src/log/schema.mjs` as the canonical schema.
+- [ ] Tests live in `test/`, not `tests/`.
+- [ ] Tests pass on Node 18, 20, 22 (CI matrix).
 
 ## Out of scope (explicit)
 
-- **Default-enabling `usage-log`** — defer to v3.3.0 once adoption pattern is clear.
+- **Default-enabling `usage-log`** — defer to v3.3.0.
 - **claude-meter share-protocol changes** — wire format and endpoints unchanged.
-- **Real-time ingestion** beyond watch-mode polling. JSONL append is the boundary; if we need true streaming later, that's a different design.
-- **Backfill of historical preload-written `~/.claude/claude-meter.jsonl` data** — already collected data is what it is; this directive doesn't migrate it.
+- **Backfill of historical preload-written `~/.claude/claude-meter.jsonl` data** — already-collected data is what it is.
+- **Backwards-compat for the old 9-field proxy `usage.jsonl` rows** — those rows fail claude-meter's strict validator and are skipped on the reader side. Documented in CHANGELOG.
+- **`MeterRowSchema` extensions** — owned by `claude-code-meter`. Any future field additions are a coordinated cross-repo change with its own ordering and migration story.
 - **The dangerous-command filter** from the security doc — separate proposal.
+- **Real-time streaming beyond watch-mode polling** — JSONL append is the boundary.
 
 — AI Team Lead

--- a/proxy/extensions/usage-log.mjs
+++ b/proxy/extensions/usage-log.mjs
@@ -1,46 +1,275 @@
+// usage-log — append per-call usage record to ~/.claude/usage.jsonl.
+//
+// The emitted record matches `MeterRowSchema` v:1 from
+// `claude-code-meter/src/log/schema.mjs` exactly. claude-meter validates each
+// row through that schema; the wire format is the cross-repo contract.
+//
+// Schema (every row):
+//   v: 1
+//   ts: ISO datetime
+//   sid: 8-char lowercase hex (proxy session, sticky for proxy lifetime)
+//   model: string ≤64, /^[a-z0-9._-]+$/
+//   requested_model?: string ≤64, /^[a-z0-9._-]*$/  (optional)
+//   model_mismatch?: bool                            (optional)
+//   speed: "standard" | "fast" | ""
+//   service_tier: string ≤32, /^[a-z0-9_-]*$/
+//   input_tokens, output_tokens, cache_creation_input_tokens,
+//   cache_read_input_tokens, ephemeral_1h_input_tokens,
+//   ephemeral_5m_input_tokens, web_search_requests: int ≥ 0
+//   q5h, q7d: float 0–2
+//   q5h_reset, q7d_reset: int (unix sec)
+//   qstatus, qoverage, qclaim: string lowercase enums
+//   qfallback_pct: float 0–1
+//   qoverage_util?: float ≥ 0                        (optional)
+//   qrepresentative_claim?: string ≤16               (optional)
+//   org_id?: 16-char hex (sha256(raw header).digest("hex").slice(0,16))
+//   overage_disabled_reason?: string ≤64             (optional)
+//   cache_hit_rate: float 0–1
+//   q5h_delta, q7d_delta: float (0 on first call after restart)
+//
+// `peak_hour` is NOT in the wire format. It can be derived from `ts` if any
+// consumer needs it.
+//
+// Activation: enabled:false in the export default (existing usage-log
+// pattern). Users opt in by adding an entry to proxy/extensions.json:
+//   "usage-log": { "enabled": true, "order": 650 }
+// CACHE_FIX_USAGE_LOG=<path> overrides the destination path only — it is NOT
+// an enable flag and never has been.
+//
+// See `docs/directives/proxy-claude-meter-compat.md` for full design.
+
 import { appendFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { createHash } from "node:crypto";
 
 const LOG_PATH = process.env.CACHE_FIX_USAGE_LOG || join(homedir(), ".claude", "usage.jsonl");
 
-function buildRecord(meta, telemetry, responseHeaders) {
-  const now = new Date();
-  const utcHour = now.getUTCHours();
-  const utcDay = now.getUTCDay();
+// --- Module-scope state ---
 
-  const stats = meta.cacheStats || {};
-  const quota = meta._quotaData || {};
+const _sid = generateSid();
+let _lastQ5h = null;
+let _lastQ7d = null;
 
+// --- Pure helpers (test seam) ---
+
+export function generateSid() {
+  return createHash("sha256")
+    .update(`${process.pid}-${Date.now()}-${Math.random()}`)
+    .digest("hex")
+    .slice(0, 8);
+}
+
+export function hashOrgId(rawOrgId) {
+  if (!rawOrgId || typeof rawOrgId !== "string") return undefined;
+  return createHash("sha256").update(rawOrgId).digest("hex").slice(0, 16);
+}
+
+export function extractMessageStartFields(event) {
+  if (!event || event.type !== "message_start") return null;
+  const msg = event.message;
+  if (!msg || !msg.usage) return null;
+  const usage = msg.usage;
+  const cc = usage.cache_creation || {};
+  const sti = usage.server_tool_use || {};
   return {
-    timestamp: now.toISOString(),
-    model: telemetry.model || "unknown",
-    input_tokens: stats.inputTokens || 0,
-    output_tokens: stats.outputTokens || 0,
-    cache_read_input_tokens: stats.cacheRead || 0,
-    cache_creation_input_tokens: stats.cacheCreation || 0,
-    q5h_pct: quota.five_hour ? quota.five_hour.pct : null,
-    q7d_pct: quota.seven_day ? quota.seven_day.pct : null,
-    peak_hour: utcDay >= 1 && utcDay <= 5 && utcHour >= 13 && utcHour < 19,
+    model: typeof msg.model === "string" ? msg.model : "",
+    speed: usage.speed || "",
+    service_tier: usage.service_tier || "",
+    input_tokens: usage.input_tokens || 0,
+    cache_creation_input_tokens: usage.cache_creation_input_tokens || 0,
+    cache_read_input_tokens: usage.cache_read_input_tokens || 0,
+    ephemeral_1h_input_tokens: cc.ephemeral_1h_input_tokens || 0,
+    ephemeral_5m_input_tokens: cc.ephemeral_5m_input_tokens || 0,
+    web_search_requests: sti.web_search_requests || 0,
   };
 }
 
-export { buildRecord, LOG_PATH };
+export function extractMessageDeltaFields(event) {
+  if (!event || event.type !== "message_delta") return null;
+  if (!event.usage) return null;
+  return { output_tokens: event.usage.output_tokens || 0 };
+}
+
+function num(headers, key) {
+  const v = headers?.[key];
+  if (v === undefined || v === null || v === "") return null;
+  const n = parseFloat(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function intOf(headers, key) {
+  const v = headers?.[key];
+  if (v === undefined || v === null || v === "") return 0;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function strOf(headers, key) {
+  const v = headers?.[key];
+  return typeof v === "string" ? v : "";
+}
+
+export function parseQuotaHeaders(headers) {
+  const h = headers || {};
+  return {
+    q5h: num(h, "anthropic-ratelimit-unified-5h-utilization") ?? 0,
+    q7d: num(h, "anthropic-ratelimit-unified-7d-utilization") ?? 0,
+    q5h_reset: intOf(h, "anthropic-ratelimit-unified-5h-reset"),
+    q7d_reset: intOf(h, "anthropic-ratelimit-unified-7d-reset"),
+    qstatus: strOf(h, "anthropic-ratelimit-unified-status"),
+    qoverage: strOf(h, "anthropic-ratelimit-unified-overage-status"),
+    qclaim: strOf(h, "anthropic-ratelimit-unified-claim"),
+    qfallback_pct: num(h, "anthropic-ratelimit-unified-fallback-percentage") ?? 0,
+    qoverage_util: num(h, "anthropic-ratelimit-unified-overage-utilization"),
+    qrepresentative_claim: strOf(h, "anthropic-ratelimit-unified-representative-claim") || undefined,
+    org_id_raw: strOf(h, "anthropic-organization-id") || undefined,
+    overage_disabled_reason: strOf(h, "anthropic-ratelimit-unified-overage-disabled-reason") || undefined,
+  };
+}
+
+export function computeDelta(current, previous) {
+  if (previous === null || previous === undefined) return 0;
+  if (typeof current !== "number" || typeof previous !== "number") return 0;
+  return current - previous;
+}
+
+export function assembleRecord({ start, delta, quota, requestedModel, sid, prevQ5h, prevQ7d, now = new Date() }) {
+  const s = start || {};
+  const d = delta || {};
+  const q = quota || {};
+
+  const inputTokens = s.input_tokens || 0;
+  const outputTokens = d.output_tokens || 0;
+  const cacheRead = s.cache_read_input_tokens || 0;
+  const cacheCreation = s.cache_creation_input_tokens || 0;
+  const totalIn = inputTokens + cacheCreation + cacheRead;
+  const cacheHitRate = totalIn > 0 ? cacheRead / totalIn : 0;
+
+  const record = {
+    v: 1,
+    ts: now.toISOString(),
+    sid,
+    model: s.model || "",
+    speed: s.speed || "",
+    service_tier: s.service_tier || "",
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cache_creation_input_tokens: cacheCreation,
+    cache_read_input_tokens: cacheRead,
+    ephemeral_1h_input_tokens: s.ephemeral_1h_input_tokens || 0,
+    ephemeral_5m_input_tokens: s.ephemeral_5m_input_tokens || 0,
+    web_search_requests: s.web_search_requests || 0,
+    q5h: q.q5h ?? 0,
+    q7d: q.q7d ?? 0,
+    q5h_reset: q.q5h_reset || 0,
+    q7d_reset: q.q7d_reset || 0,
+    qstatus: q.qstatus || "",
+    qoverage: q.qoverage || "",
+    qclaim: q.qclaim || "",
+    qfallback_pct: q.qfallback_pct ?? 0,
+    cache_hit_rate: cacheHitRate,
+    q5h_delta: computeDelta(q.q5h, prevQ5h),
+    q7d_delta: computeDelta(q.q7d, prevQ7d),
+  };
+
+  // Optional fields are OMITTED (not present as undefined) when source absent.
+  if (requestedModel) {
+    record.requested_model = requestedModel;
+    if (record.model && requestedModel !== record.model) {
+      record.model_mismatch = true;
+    }
+  }
+  if (q.qoverage_util !== null && q.qoverage_util !== undefined) {
+    record.qoverage_util = q.qoverage_util;
+  }
+  if (q.qrepresentative_claim) {
+    record.qrepresentative_claim = q.qrepresentative_claim;
+  }
+  const orgIdHashed = hashOrgId(q.org_id_raw);
+  if (orgIdHashed) {
+    record.org_id = orgIdHashed;
+  }
+  if (q.overage_disabled_reason) {
+    record.overage_disabled_reason = q.overage_disabled_reason;
+  }
+
+  return record;
+}
+
+// --- I/O ---
+
+async function appendJsonl(record, path = LOG_PATH) {
+  await mkdir(join(homedir(), ".claude"), { recursive: true });
+  await appendFile(path, JSON.stringify(record) + "\n");
+}
+
+// Test helper: write a record to a caller-supplied path. Bypasses env-var
+// lookup so tests don't race on a shared env.
+export async function writeRecord(record, path) {
+  await mkdir(path.substring(0, path.lastIndexOf("/")), { recursive: true });
+  await appendFile(path, JSON.stringify(record) + "\n");
+}
+
+// Test helper: reset module-scope delta state.
+export function _resetDeltaStateForTest() {
+  _lastQ5h = null;
+  _lastQ7d = null;
+}
+
+export { LOG_PATH };
+
+// --- Extension contract ---
 
 export default {
   name: "usage-log",
-  description: "Append per-call usage record to ~/.claude/usage.jsonl",
+  description: "Append per-call usage record to ~/.claude/usage.jsonl (MeterRowSchema v:1)",
   enabled: false,
   order: 650,
 
   async onStreamEvent(ctx) {
-    if (!ctx.event || ctx.event.type !== "message_delta" || !ctx.event.usage) return;
-
-    const record = buildRecord(ctx.meta, ctx.telemetry || {}, ctx.responseHeaders);
+    if (!ctx || !ctx.event) return;
 
     try {
-      await mkdir(join(homedir(), ".claude"), { recursive: true });
-      await appendFile(LOG_PATH, JSON.stringify(record) + "\n");
-    } catch {}
+      // message_start: capture per-response state into ctx.meta._usageLog.
+      if (ctx.event.type === "message_start") {
+        const start = extractMessageStartFields(ctx.event);
+        if (start) {
+          ctx.meta = ctx.meta || {};
+          ctx.meta._usageLog = { start };
+        }
+        return;
+      }
+
+      // message_delta: assemble and emit the final record.
+      if (ctx.event.type !== "message_delta" || !ctx.event.usage) return;
+
+      const start = ctx.meta?._usageLog?.start;
+      if (!start) return; // no message_start was observed for this response
+
+      const delta = extractMessageDeltaFields(ctx.event);
+      const quota = parseQuotaHeaders(ctx.responseHeaders || {});
+      const requestedModel = ctx.telemetry?.requestedModel || undefined;
+
+      const record = assembleRecord({
+        start,
+        delta,
+        quota,
+        requestedModel,
+        sid: _sid,
+        prevQ5h: _lastQ5h,
+        prevQ7d: _lastQ7d,
+        now: new Date(),
+      });
+
+      // Update delta tracking AFTER assembly so the first call's delta is 0
+      // (per the directive contract: first call after restart → deltas zero).
+      _lastQ5h = quota.q5h;
+      _lastQ7d = quota.q7d;
+
+      await appendJsonl(record, process.env.CACHE_FIX_USAGE_LOG || LOG_PATH);
+    } catch {
+      // Fail-open: never throw to the pipeline.
+    }
   },
 };

--- a/test/proxy-usage-log.test.mjs
+++ b/test/proxy-usage-log.test.mjs
@@ -1,89 +1,483 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import ext, { buildRecord } from "../proxy/extensions/usage-log.mjs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
 
-// --- Unit tests ---
+import ext, {
+  generateSid,
+  hashOrgId,
+  extractMessageStartFields,
+  extractMessageDeltaFields,
+  parseQuotaHeaders,
+  assembleRecord,
+  computeDelta,
+  writeRecord,
+  _resetDeltaStateForTest,
+} from "../proxy/extensions/usage-log.mjs";
 
-test("buildRecord: produces complete record with all fields", () => {
-  const meta = {
-    cacheStats: { inputTokens: 5, outputTokens: 100, cacheRead: 300000, cacheCreation: 500 },
-    _quotaData: {
-      five_hour: { pct: 25 },
-      seven_day: { pct: 5 },
+async function newTmp() {
+  return mkdtemp(join(tmpdir(), "usage-log-test-"));
+}
+
+async function freshExt() {
+  const mod = await import(`../proxy/extensions/usage-log.mjs?t=${Date.now()}`);
+  mod._resetDeltaStateForTest();
+  return mod;
+}
+
+function mkHeaders(overrides = {}) {
+  return {
+    "anthropic-ratelimit-unified-5h-utilization": "0.5",
+    "anthropic-ratelimit-unified-7d-utilization": "0.3",
+    "anthropic-ratelimit-unified-5h-reset": "1700000000",
+    "anthropic-ratelimit-unified-7d-reset": "1700100000",
+    "anthropic-ratelimit-unified-status": "allowed",
+    "anthropic-ratelimit-unified-overage-status": "allowed",
+    "anthropic-ratelimit-unified-claim": "five_hour",
+    "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+    ...overrides,
+  };
+}
+
+function mkMessageStart(overrides = {}) {
+  return {
+    type: "message_start",
+    message: {
+      model: "claude-opus-4-7",
+      usage: {
+        input_tokens: 100,
+        cache_creation_input_tokens: 50,
+        cache_read_input_tokens: 1000,
+        speed: "standard",
+        service_tier: "standard",
+        cache_creation: { ephemeral_1h_input_tokens: 50, ephemeral_5m_input_tokens: 0 },
+        server_tool_use: { web_search_requests: 0 },
+        ...overrides.usage,
+      },
+      ...overrides.message,
     },
   };
-  const telemetry = { model: "claude-opus-4-7" };
+}
 
-  const record = buildRecord(meta, telemetry, {});
+// --- 1. Schema match ---
 
-  assert.equal(record.model, "claude-opus-4-7");
-  assert.equal(record.input_tokens, 5);
-  assert.equal(record.output_tokens, 100);
-  assert.equal(record.cache_read_input_tokens, 300000);
-  assert.equal(record.cache_creation_input_tokens, 500);
-  assert.equal(record.q5h_pct, 25);
-  assert.equal(record.q7d_pct, 5);
-  assert.equal(typeof record.timestamp, "string");
-  assert.equal(typeof record.peak_hour, "boolean");
+test("1. assembled record matches MeterRowSchema v:1 exactly", () => {
+  const start = extractMessageStartFields(mkMessageStart());
+  const delta = { output_tokens: 200 };
+  const quota = parseQuotaHeaders(mkHeaders());
+  const record = assembleRecord({
+    start,
+    delta,
+    quota,
+    sid: "abcdef01",
+    prevQ5h: null,
+    prevQ7d: null,
+    now: new Date("2026-04-25T10:00:00Z"),
+  });
+
+  // v MUST be the literal number 1
+  assert.equal(record.v, 1);
+
+  // Required fields present
+  for (const f of [
+    "v", "ts", "sid", "model", "speed", "service_tier",
+    "input_tokens", "output_tokens", "cache_creation_input_tokens",
+    "cache_read_input_tokens", "ephemeral_1h_input_tokens",
+    "ephemeral_5m_input_tokens", "web_search_requests",
+    "q5h", "q7d", "q5h_reset", "q7d_reset",
+    "qstatus", "qoverage", "qclaim", "qfallback_pct",
+    "cache_hit_rate", "q5h_delta", "q7d_delta",
+  ]) {
+    assert.ok(f in record, `expected required field ${f}`);
+  }
+
+  // Type/regex constraints (subset)
+  assert.match(record.sid, /^[0-9a-f]{8}$/);
+  assert.match(record.model, /^[a-z0-9._-]+$/);
+  assert.match(record.qstatus, /^[a-z_]*$/);
+  assert.equal(typeof record.cache_hit_rate, "number");
+  assert.ok(record.cache_hit_rate >= 0 && record.cache_hit_rate <= 1);
+  assert.equal(typeof record.q5h, "number");
+  assert.ok(record.q5h >= 0 && record.q5h <= 2);
 });
 
-test("buildRecord: handles missing cache stats", () => {
-  const record = buildRecord({}, {}, {});
-  assert.equal(record.input_tokens, 0);
-  assert.equal(record.output_tokens, 0);
-  assert.equal(record.cache_read_input_tokens, 0);
-  assert.equal(record.model, "unknown");
-  assert.equal(record.q5h_pct, null);
+// --- 2. Optional fields omitted when absent ---
+
+test("2. optional fields absent when source data missing", () => {
+  const start = extractMessageStartFields(mkMessageStart());
+  const quota = parseQuotaHeaders({}); // no quota headers at all
+  const record = assembleRecord({
+    start,
+    delta: { output_tokens: 100 },
+    quota,
+    sid: "abcdef01",
+  });
+  // org_id, qoverage_util, qrepresentative_claim, overage_disabled_reason,
+  // requested_model, model_mismatch — none should be present.
+  assert.equal("org_id" in record, false);
+  assert.equal("qoverage_util" in record, false);
+  assert.equal("qrepresentative_claim" in record, false);
+  assert.equal("overage_disabled_reason" in record, false);
+  assert.equal("requested_model" in record, false);
+  assert.equal("model_mismatch" in record, false);
 });
 
-test("buildRecord: handles missing quota data", () => {
-  const meta = {
-    cacheStats: { cacheRead: 100 },
-  };
-  const record = buildRecord(meta, { model: "test" }, {});
-  assert.equal(record.q5h_pct, null);
-  assert.equal(record.q7d_pct, null);
-});
+// --- 3. Required-with-default zero when source absent ---
 
-// --- onStreamEvent ---
-
-test("onStreamEvent: triggers on message_delta with usage", async () => {
-  const ctx = {
-    event: { type: "message_delta", usage: { output_tokens: 50 } },
-    telemetry: { model: "claude-opus-4-7" },
-    meta: {
-      cacheStats: { inputTokens: 1, outputTokens: 50, cacheRead: 200000, cacheCreation: 300 },
-      _quotaData: { five_hour: { pct: 10 }, seven_day: { pct: 3 } },
+test("3. web_search_requests / ephemeral split default to 0 when source absent", () => {
+  // Construct a minimal message_start manually so cache_creation and
+  // server_tool_use are truly absent (mkMessageStart's spread-merge would
+  // preserve the defaults).
+  const event = {
+    type: "message_start",
+    message: {
+      model: "claude-opus-4-7",
+      usage: {
+        input_tokens: 100,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        speed: "standard",
+        service_tier: "standard",
+        // No cache_creation, no server_tool_use.
+      },
     },
-    responseHeaders: {},
   };
-
-  // Extension writes to file — just verify it doesn't throw
-  await ext.onStreamEvent(ctx);
+  const start = extractMessageStartFields(event);
+  const record = assembleRecord({
+    start,
+    delta: { output_tokens: 50 },
+    quota: parseQuotaHeaders({}),
+    sid: "abcdef01",
+  });
+  assert.equal(record.web_search_requests, 0);
+  assert.equal(record.ephemeral_1h_input_tokens, 0);
+  assert.equal(record.ephemeral_5m_input_tokens, 0);
 });
 
-test("onStreamEvent: skips non-message_delta events", async () => {
+// --- 4. message_start state capture ---
+
+test("4. message_start populates ctx.meta._usageLog with full start fields", async () => {
+  const mod = await freshExt();
   const ctx = {
-    event: { type: "message_start", message: {} },
-    telemetry: {},
     meta: {},
+    event: mkMessageStart(),
+    telemetry: {},
+    responseHeaders: mkHeaders(),
   };
-
-  await ext.onStreamEvent(ctx);
-  // No error = pass
+  await mod.default.onStreamEvent(ctx);
+  assert.ok(ctx.meta._usageLog, "expected _usageLog to be set");
+  assert.ok(ctx.meta._usageLog.start, "expected start fields");
+  assert.equal(ctx.meta._usageLog.start.model, "claude-opus-4-7");
+  assert.equal(ctx.meta._usageLog.start.speed, "standard");
+  assert.equal(ctx.meta._usageLog.start.service_tier, "standard");
+  assert.equal(ctx.meta._usageLog.start.input_tokens, 100);
+  assert.equal(ctx.meta._usageLog.start.cache_creation_input_tokens, 50);
+  assert.equal(ctx.meta._usageLog.start.cache_read_input_tokens, 1000);
+  assert.equal(ctx.meta._usageLog.start.ephemeral_1h_input_tokens, 50);
 });
 
-test("onStreamEvent: skips message_delta without usage", async () => {
-  const ctx = {
-    event: { type: "message_delta" },
-    telemetry: {},
-    meta: {},
-  };
+// --- 5. message_delta finalization ---
 
-  await ext.onStreamEvent(ctx);
+test("5. message_delta reads ctx.meta._usageLog and emits final record", async () => {
+  const mod = await freshExt();
+  const dir = await newTmp();
+  const path = join(dir, "usage.jsonl");
+  process.env.CACHE_FIX_USAGE_LOG = path;
+  try {
+    const ctx = {
+      meta: {},
+      event: mkMessageStart(),
+      telemetry: { requestedModel: "claude-opus-4-7" },
+      responseHeaders: mkHeaders(),
+    };
+    await mod.default.onStreamEvent(ctx);
+    ctx.event = { type: "message_delta", usage: { output_tokens: 200 } };
+    await mod.default.onStreamEvent(ctx);
+    const text = await readFile(path, "utf8");
+    const record = JSON.parse(text.trim());
+    assert.equal(record.v, 1);
+    assert.equal(record.output_tokens, 200);
+    assert.equal(record.model, "claude-opus-4-7");
+    assert.equal(record.requested_model, "claude-opus-4-7");
+    assert.equal(record.model_mismatch, undefined, "no mismatch when models match");
+  } finally {
+    delete process.env.CACHE_FIX_USAGE_LOG;
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
-test("onStreamEvent: skips null event", async () => {
-  const ctx = { event: null, telemetry: {}, meta: {} };
-  await ext.onStreamEvent(ctx);
+// --- 6. Delta computation ---
+
+test("6. q5h_delta computed correctly from previous reading", () => {
+  assert.equal(computeDelta(0.6, 0.5), 0.1.toFixed ? 0.6 - 0.5 : null);
+  // strict numeric check (allow tiny float drift)
+  const d = computeDelta(0.6, 0.5);
+  assert.ok(Math.abs(d - 0.1) < 1e-9);
+});
+
+// --- 7. First-call deltas zero ---
+
+test("7. first call after module load → deltas are 0", () => {
+  assert.equal(computeDelta(0.5, null), 0);
+  assert.equal(computeDelta(0.5, undefined), 0);
+});
+
+// --- 8. Session ID stability ---
+
+test("8. multiple calls within process see the same sid", async () => {
+  const mod = await freshExt();
+  const dir = await newTmp();
+  const path = join(dir, "usage.jsonl");
+  process.env.CACHE_FIX_USAGE_LOG = path;
+  try {
+    for (let i = 0; i < 3; i++) {
+      const ctx = {
+        meta: {},
+        event: mkMessageStart(),
+        telemetry: {},
+        responseHeaders: mkHeaders(),
+      };
+      await mod.default.onStreamEvent(ctx);
+      ctx.event = { type: "message_delta", usage: { output_tokens: 50 } };
+      await mod.default.onStreamEvent(ctx);
+    }
+    const text = await readFile(path, "utf8");
+    const lines = text.split("\n").filter(Boolean);
+    const sids = new Set(lines.map((l) => JSON.parse(l).sid));
+    assert.equal(sids.size, 1, "all records in one process should share the same sid");
+  } finally {
+    delete process.env.CACHE_FIX_USAGE_LOG;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- 9. Session ID format ---
+
+test("9. generateSid matches /^[0-9a-f]{8}$/", () => {
+  for (let i = 0; i < 50; i++) {
+    const sid = generateSid();
+    assert.match(sid, /^[0-9a-f]{8}$/, `sid ${sid} must be 8 lowercase hex chars`);
+  }
+});
+
+// --- 10. Cache hit rate ---
+
+test("10. cache_hit_rate computed correctly; zero when total is zero", () => {
+  // 80 read out of 100 total → 0.8
+  const r1 = assembleRecord({
+    start: { input_tokens: 10, cache_creation_input_tokens: 10, cache_read_input_tokens: 80 },
+    delta: { output_tokens: 5 },
+    quota: parseQuotaHeaders({}),
+    sid: "abcdef01",
+  });
+  assert.ok(Math.abs(r1.cache_hit_rate - 0.8) < 1e-9);
+
+  // total 0 → 0
+  const r2 = assembleRecord({
+    start: { input_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    delta: { output_tokens: 0 },
+    quota: parseQuotaHeaders({}),
+    sid: "abcdef01",
+  });
+  assert.equal(r2.cache_hit_rate, 0);
+});
+
+// --- 11. org_id hashing bit-exact match with claude-meter ---
+
+test("11. org_id hashing matches sha256(raw).digest('hex').slice(0, 16) bit-exactly", () => {
+  const raw = "acct-abc123-deadbeef";
+  const expected = createHash("sha256").update(raw).digest("hex").slice(0, 16);
+  assert.equal(hashOrgId(raw), expected);
+  // Hashed value MUST NOT be the original
+  assert.notEqual(hashOrgId(raw), raw);
+  // Length is exactly 16 hex chars
+  assert.match(hashOrgId(raw), /^[a-f0-9]{16}$/);
+});
+
+test("11b. assembled record stores hashed org_id, never raw", () => {
+  const raw = "acct-secret-do-not-leak-XYZ";
+  const headers = mkHeaders({ "anthropic-organization-id": raw });
+  const record = assembleRecord({
+    start: extractMessageStartFields(mkMessageStart()),
+    delta: { output_tokens: 100 },
+    quota: parseQuotaHeaders(headers),
+    sid: "abcdef01",
+  });
+  assert.equal(record.org_id, hashOrgId(raw));
+  // Raw value MUST NOT appear anywhere in the record
+  assert.equal(JSON.stringify(record).includes(raw), false, "raw org_id must not leak into record");
+});
+
+// --- 12. Schema version ---
+
+test("12. every record has v: 1 (literally the number 1)", () => {
+  const record = assembleRecord({
+    start: extractMessageStartFields(mkMessageStart()),
+    delta: { output_tokens: 100 },
+    quota: parseQuotaHeaders(mkHeaders()),
+    sid: "abcdef01",
+  });
+  assert.equal(record.v, 1);
+  // Must be number, not string
+  assert.equal(typeof record.v, "number");
+});
+
+// --- 13. peak_hour absent ---
+
+test("13. peak_hour is NOT in the emitted record", () => {
+  const record = assembleRecord({
+    start: extractMessageStartFields(mkMessageStart()),
+    delta: { output_tokens: 100 },
+    quota: parseQuotaHeaders(mkHeaders()),
+    sid: "abcdef01",
+  });
+  assert.equal("peak_hour" in record, false, "peak_hour must not be in MeterRowSchema records");
+});
+
+// --- 14. Disabled extension (no per-call file mutation) ---
+
+test("14. when extension is disabled (no message_start observed), nothing is emitted", async () => {
+  const mod = await freshExt();
+  const dir = await newTmp();
+  const path = join(dir, "usage.jsonl");
+  process.env.CACHE_FIX_USAGE_LOG = path;
+  try {
+    // Send only message_delta with no preceding message_start.
+    const ctx = {
+      meta: {},
+      event: { type: "message_delta", usage: { output_tokens: 50 } },
+      telemetry: {},
+      responseHeaders: mkHeaders(),
+    };
+    await mod.default.onStreamEvent(ctx);
+    let exists = false;
+    try { await readFile(path, "utf8"); exists = true; } catch {}
+    assert.equal(exists, false, "no file should be written when no start state was captured");
+  } finally {
+    delete process.env.CACHE_FIX_USAGE_LOG;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- 15. Concurrency: 50 parallel writes ---
+
+test("15. 50 parallel appendFile writes produce 50 well-formed JSON lines", async () => {
+  const dir = await newTmp();
+  const path = join(dir, "usage.jsonl");
+  try {
+    const records = Array.from({ length: 50 }, (_, i) => ({
+      v: 1,
+      ts: `2026-04-25T10:00:${String(i).padStart(2, "0")}Z`,
+      sid: "abcdef01",
+      model: "claude-opus-4-7",
+      seq: i,
+    }));
+    await Promise.all(records.map((r) => writeRecord(r, path)));
+    const text = await readFile(path, "utf8");
+    const lines = text.split("\n").filter(Boolean);
+    assert.equal(lines.length, 50, `expected 50 lines, got ${lines.length}`);
+    for (const line of lines) {
+      JSON.parse(line);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- 16. Header absence resilience ---
+
+test("16. record assembled with safe defaults when every quota header is absent", () => {
+  const record = assembleRecord({
+    start: extractMessageStartFields(mkMessageStart()),
+    delta: { output_tokens: 50 },
+    quota: parseQuotaHeaders({}),
+    sid: "abcdef01",
+  });
+  assert.equal(record.q5h, 0);
+  assert.equal(record.q7d, 0);
+  assert.equal(record.q5h_reset, 0);
+  assert.equal(record.q7d_reset, 0);
+  assert.equal(record.qstatus, "");
+  assert.equal(record.qoverage, "");
+  assert.equal(record.qclaim, "");
+  assert.equal(record.qfallback_pct, 0);
+});
+
+// --- Bonus tests ---
+
+test("requested_model + model_mismatch when they differ", () => {
+  const record = assembleRecord({
+    start: extractMessageStartFields(mkMessageStart({ message: { model: "claude-opus-4-6" } })),
+    delta: { output_tokens: 100 },
+    quota: parseQuotaHeaders({}),
+    sid: "abcdef01",
+    requestedModel: "claude-opus-4-7",
+  });
+  assert.equal(record.requested_model, "claude-opus-4-7");
+  assert.equal(record.model, "claude-opus-4-6");
+  assert.equal(record.model_mismatch, true);
+});
+
+test("requested_model + no model_mismatch when they match", () => {
+  const record = assembleRecord({
+    start: extractMessageStartFields(mkMessageStart()),
+    delta: { output_tokens: 100 },
+    quota: parseQuotaHeaders({}),
+    sid: "abcdef01",
+    requestedModel: "claude-opus-4-7",
+  });
+  assert.equal(record.requested_model, "claude-opus-4-7");
+  assert.equal("model_mismatch" in record, false);
+});
+
+test("optional qoverage_util present when header has it", () => {
+  const record = assembleRecord({
+    start: extractMessageStartFields(mkMessageStart()),
+    delta: { output_tokens: 100 },
+    quota: parseQuotaHeaders(mkHeaders({ "anthropic-ratelimit-unified-overage-utilization": "0.42" })),
+    sid: "abcdef01",
+  });
+  assert.equal(record.qoverage_util, 0.42);
+});
+
+test("end-to-end: two responses → second has non-zero deltas", async () => {
+  const mod = await freshExt();
+  const dir = await newTmp();
+  const path = join(dir, "usage.jsonl");
+  process.env.CACHE_FIX_USAGE_LOG = path;
+  try {
+    // Response 1 — q5h=0.5
+    let ctx = {
+      meta: {},
+      event: mkMessageStart(),
+      telemetry: {},
+      responseHeaders: mkHeaders({ "anthropic-ratelimit-unified-5h-utilization": "0.5" }),
+    };
+    await mod.default.onStreamEvent(ctx);
+    ctx.event = { type: "message_delta", usage: { output_tokens: 100 } };
+    await mod.default.onStreamEvent(ctx);
+
+    // Response 2 — q5h=0.6
+    ctx = {
+      meta: {},
+      event: mkMessageStart(),
+      telemetry: {},
+      responseHeaders: mkHeaders({ "anthropic-ratelimit-unified-5h-utilization": "0.6" }),
+    };
+    await mod.default.onStreamEvent(ctx);
+    ctx.event = { type: "message_delta", usage: { output_tokens: 100 } };
+    await mod.default.onStreamEvent(ctx);
+
+    const lines = (await readFile(path, "utf8")).split("\n").filter(Boolean);
+    assert.equal(lines.length, 2);
+    const r1 = JSON.parse(lines[0]);
+    const r2 = JSON.parse(lines[1]);
+    assert.equal(r1.q5h_delta, 0, "first record has zero delta");
+    assert.ok(Math.abs(r2.q5h_delta - 0.1) < 1e-9, "second record has 0.1 delta");
+  } finally {
+    delete process.env.CACHE_FIX_USAGE_LOG;
+    await rm(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Stage: directive

Closes #70 (when implemented and merged).

This PR seeds the directive for the cross-repo refactor that restores `claude-code-meter` for users on CC v2.1.113+ (Bun binary, NODE_OPTIONS no longer applies). The fix: expand the proxy's existing `usage-log` extension to a superset record schema matching claude-meter's `MeterRowSchema`, then refactor claude-meter to ingest from `~/.claude/usage.jsonl` instead of via the broken preload.

### What this PR contains right now
- `docs/directives/proxy-claude-meter-compat.md` — full directive (cross-repo scope split, schema reconciliation, v:2 superset shape, test plans for both sides, reviewer checklist).

### What this PR will contain after implementation (cache-fix side only)
- `proxy/extensions/usage-log.mjs` expanded to v:2 schema with sessionId, q5h/q7d delta tracking, all 24+ MeterRowSchema fields
- `tests/usage-log.test.mjs` — 13 cases per test plan
- README updates documenting the new schema and the claude-meter integration path
- `extensions.json` retains `enabled: false` default (default-on is a v3.3.0 decision)

### What lands in the claude-meter repo (separate PR there)
- New `src/ingest/jsonl-tailer.mjs` — reads usage.jsonl forward from a saved offset
- `bin/claude-meter.mjs` adds `ingest [--source <path>] [--once] [--watch]` subcommand
- `src/log/schema.mjs` accepts v:2; marks proxy-not-yet-emitting fields optional
- `src/interceptor/preload.mjs` gets a deprecation notice; `package.json` drops the `./preload` export

### Key design choices to flag for review
1. **Single canonical wire format.** The proxy's `usage.jsonl` becomes the source of truth. claude-meter validates each row through its existing `MeterRowSchema`. No duplicate collection logic.
2. **Schema-version 2.** Bumping `v: 1 → 2` is an explicit breaking change for anyone parsing the old 9-field shape. Documented in CHANGELOG.
3. **Optional vs required fields tracked exactly to MeterRowSchema constraints.** Optional fields (`org_id`, `qoverage_util`, `qrepresentative_claim`, `overage_disabled_reason`) emitted only when source headers are present; previously-required-with-default fields (`web_search_requests`) emitted as `0` when absent.
4. **`org_id` is hashed with sha256 prefix, never raw.** Same privacy guarantee claude-meter has always had.
5. **`enabled: false` stays as the default for v3.2.0.** Users opt in. We can revisit default-on in v3.3.0 once adoption is observed and disk-usage concerns surface.

### Out of scope (explicit, in directive)
- Default-enabling `usage-log` (deferred v3.3.0)
- Share-protocol or upload-endpoint changes (claude-meter side unchanged)
- Backfill of historical preload-written `~/.claude/claude-meter.jsonl`
- Real-time streaming beyond watch-mode polling

Labeled `directive-stage`. Will move to `implementation-stage` once the directive is approved.

— AI Team Lead