### PR TITLE
feat: image-strip — add CACHE_FIX_IMAGE_MAX_DIM oversized-image guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,9 +340,20 @@ Keeps images in the last 3 user messages, replaces older ones with a text placeh
 export CACHE_FIX_IMAGE_MAX_DIM=2000
 ```
 
-Anthropic enforces a per-image dimension ceiling on multi-image requests; any image exceeding the limit (currently 2000px on a side) fails the entire request with `"An image in the conversation exceeds the dimension limit for many-image requests (2000px). Start a new session with fewer images."` Common triggers: hi-res scans, retina screenshots, photos at full resolution.
+The Anthropic API enforces TWO image-related limits on multi-image requests, and the same error message can fire for either:
 
-`CACHE_FIX_IMAGE_MAX_DIM=2000` enables a per-request scan that strips oversized PNG/JPEG images (in both user messages and tool results) and replaces each with a forensic placeholder noting the original dimensions. Pure-JS header parsing — no native deps. Composes with `CACHE_FIX_IMAGE_KEEP_LAST` (keep_last runs first, max_dim then runs on what remains). Other formats (GIF, WebP, AVIF, BMP) pass through unchanged.
+> `"An image in the conversation exceeds the dimension limit for many-image requests (2000px). Start a new session with fewer images."`
+
+Two pressure axes to address them:
+
+| Pressure | Variable | What it does |
+|---|---|---|
+| **Too many images in conversation** | `CACHE_FIX_IMAGE_KEEP_LAST=N` | Strips images from old user messages, keeps only the last N. |
+| **Any single image too large** | `CACHE_FIX_IMAGE_MAX_DIM=2000` | Replaces images exceeding the dimension limit with a forensic placeholder noting the original dimensions. Covers both user-message direct images and tool_result-nested images. |
+
+The two compose: with both set, `KEEP_LAST` runs first (drops the count), then `MAX_DIM` runs on what remains (caps the size of the kept ones). Common triggers for the dimension axis: hi-res manuscript scans, retina screenshots, photos at full resolution.
+
+Pure-JS PNG and JPEG header parsing — no native deps. Other formats (GIF, WebP, AVIF, BMP) pass through unchanged regardless of dimension. Fail-open: images whose dimensions can't be parsed (truncated header, unsupported format) are kept rather than stripped — better to send a request that might error than to strip a valid image we just couldn't measure.
 
 ## System prompt rewrite (preload mode, optional)
 

--- a/README.md
+++ b/README.md
@@ -334,6 +334,16 @@ export CACHE_FIX_IMAGE_KEEP_LAST=3
 
 Keeps images in the last 3 user messages, replaces older ones with a text placeholder. Only targets `tool_result` blocks — user-pasted images are never touched.
 
+### Oversized-image guard
+
+```bash
+export CACHE_FIX_IMAGE_MAX_DIM=2000
+```
+
+Anthropic enforces a per-image dimension ceiling on multi-image requests; any image exceeding the limit (currently 2000px on a side) fails the entire request with `"An image in the conversation exceeds the dimension limit for many-image requests (2000px). Start a new session with fewer images."` Common triggers: hi-res scans, retina screenshots, photos at full resolution.
+
+`CACHE_FIX_IMAGE_MAX_DIM=2000` enables a per-request scan that strips oversized PNG/JPEG images (in both user messages and tool results) and replaces each with a forensic placeholder noting the original dimensions. Pure-JS header parsing — no native deps. Composes with `CACHE_FIX_IMAGE_KEEP_LAST` (keep_last runs first, max_dim then runs on what remains). Other formats (GIF, WebP, AVIF, BMP) pass through unchanged.
+
 ## System prompt rewrite (preload mode, optional)
 
 The interceptor can rewrite Claude Code's `# Output efficiency` system-prompt section. Disabled by default. Enable with `CACHE_FIX_OUTPUT_EFFICIENCY_REPLACEMENT`. See [docs/output-efficiency-prompts.md](docs/output-efficiency-prompts.md) for the three known prompt variants and usage instructions.

--- a/docs/code-reviews/pr-84-image-strip-max-dim-impl-review-2026-04-27.md
+++ b/docs/code-reviews/pr-84-image-strip-max-dim-impl-review-2026-04-27.md
@@ -1,0 +1,34 @@
+# Review: image-strip max-dim implementation
+
+Date: 2026-04-27
+Reviewed: PR #84 (`feat: image-strip — add CACHE_FIX_IMAGE_MAX_DIM oversized-image guard`)
+Label applied: approved-by-codex-agent
+
+## What Is Correct
+
+- `proxy/image-dimensions.mjs` cleanly isolates pure helpers with no non-stdlib imports. `parsePngDimensions`, `parseJpegDimensions`, and `parseImageDimensions` all fail closed to `null` on malformed or unsupported inputs instead of throwing.
+- PNG parsing is correct: signature bytes are verified, the `IHDR` chunk identifier is checked, and width/height are read from the correct big-endian offsets.
+- JPEG parsing is implemented defensibly: SOF markers include the baseline/progressive variants plus the rarer SOF forms that share the same layout, non-SOF segments are skipped by their declared length, and the scan loop is bounded.
+- `proxy/extensions/image-strip.mjs` preserves default behavior when `CACHE_FIX_IMAGE_MAX_DIM` is unset, keeps the legacy `ctx.meta.imageStripStats` shape intact for `KEEP_LAST`, and writes the new oversized-image stats to a separate `ctx.meta.imageStripOversizedStats` field.
+- Oversized-image stripping covers both required locations: direct user-message image blocks and `tool_result.content` nested image blocks.
+- Composition order is correct: `KEEP_LAST` runs first, then max-dimension stripping operates on the surviving images.
+- Fail-open behavior is preserved: images with unknown or unparseable dimensions are retained rather than breaking or mutating the request.
+- The placeholder text includes the original dimensions, which preserves useful forensic context for downstream debugging.
+- Test coverage is good for the new surface area. Focused tests pass (`36/36`) and the full suite passes (`553/553`).
+
+## Blockers
+
+None.
+
+## What Needs Attention
+
+- The directive scoped README and `docs/extension-impact-guide.md` updates for the new `CACHE_FIX_IMAGE_MAX_DIM` env var, but this PR does not include those documentation changes. That is not a correctness issue in the runtime path, but it is a scope mismatch worth cleaning up before or immediately after merge.
+
+## Recommendations
+
+- Add the scoped documentation updates so operators can discover the new opt-in guard without reading the implementation or directive.
+- Consider a future regression test with a JPEG header that contains a larger pre-SOF metadata segment, to pin the current bounded-probe assumption more explicitly.
+
+## Bottom Line
+
+Ship it. The implementation matches the directive’s reviewer checklist, preserves backward compatibility, composes correctly with the existing `KEEP_LAST` behavior, and passes both targeted and full test suites. The only gap I found is missing end-user documentation for the new env var, which should be cleaned up but does not justify blocking the implementation.

--- a/docs/directives/proxy-image-strip-max-dim.md
+++ b/docs/directives/proxy-image-strip-max-dim.md
@@ -1,0 +1,147 @@
+# Directive: Strip oversized images in image-strip extension
+
+**Issue:** filed by Alexander (X-15) via Chris on 2026-04-26
+**Branch:** `feature/image-strip-max-dim`
+**Stage:** directive + implementation (single PR)
+**Milestone:** v3.3.0 (or v3.2.1 if treated as enhancement-of-existing-feature)
+
+## Goal
+
+Extend the existing `image-strip` extension to detect images whose largest dimension exceeds a configurable threshold (default off; opt-in via `CACHE_FIX_IMAGE_MAX_DIM=<pixels>`) and strip them before they reach the API. Prevents the Anthropic API error:
+
+> "An image in the conversation exceeds the dimension limit for many-image requests (2000px). Start a new session with fewer images."
+
+## Why
+
+Two practitioners independently hit this limit:
+
+1. **Alexander** asked for it after running into the error during normal CC use.
+2. **Chris** hits it routinely on the Chronology research project — manuscript scans are commonly 5000-10000px on a side. A single hi-res scan plus a few other images in the conversation triggers the error mid-task.
+
+Without intervention, the request fails entirely. Users have no choice but to start a fresh session, losing context. The current `image-strip` extension's `CACHE_FIX_IMAGE_KEEP_LAST=N` behavior only addresses the OLD-images problem; it doesn't help when the user actively wants to attach a hi-res image to the current turn.
+
+## Scope (single PR)
+
+In scope:
+
+1. **New env var: `CACHE_FIX_IMAGE_MAX_DIM=<pixels>`**. Numeric. Default unset = no enforcement (current behavior unchanged). Set to e.g. `2000` to enable.
+2. **Image dimension detection** for PNG and JPEG via pure-JS header parsing (no native deps).
+3. **Strip oversized images** in BOTH code paths where images can appear:
+   - `tool_result.content` items with `type: "image"` (existing image-strip code path)
+   - User message `content` blocks with `type: "image"` (new — current image-strip doesn't scan these)
+4. **Forensic placeholder** preserves the original dimensions for the model: `[image stripped — exceeded {limit}px max dimension (was {W}x{H}px)]`.
+5. **Composes with `CACHE_FIX_IMAGE_KEEP_LAST`**: both can be on simultaneously. KEEP_LAST applies first (strips OLD images entirely), MAX_DIM then applies to whatever images remain (strips OVERSIZED among the kept).
+6. New test file `test/proxy-image-dimensions.test.mjs` covering the parsing functions in isolation.
+7. Extend `test/proxy-image-strip.test.mjs` (or co-located) with end-to-end tests of the new behavior.
+
+Out of scope:
+
+- **Resizing/downsampling.** Would require a native image-manipulation dep (sharp or similar), which we've intentionally avoided. Strip-only solves the immediate "request fails" problem; resize is a Phase 2 if multiple users ask.
+- **GIF, WebP, AVIF, BMP support.** Not in CC's typical image-source pipeline. Add support reactively if practitioners report it.
+- **Detecting "many-image" threshold.** Anthropic's exact threshold for when the 2000px limit kicks in isn't documented. Safe approach: enforce the ceiling whenever MAX_DIM is set, regardless of how many images are in the request. Never creates a NEW error, only prevents one.
+
+## Implementation
+
+### `proxy/image-dimensions.mjs` (new module)
+
+Pure functions, easy to unit-test:
+
+```js
+// Returns { width, height } or null if undetectable.
+export function parsePngDimensions(buffer)   // buffer: Buffer or Uint8Array
+export function parseJpegDimensions(buffer)
+export function parseImageDimensions(mediaType, base64Data)  // dispatches based on media_type
+```
+
+PNG: magic check (`89 50 4E 47 0D 0A 1A 0A`), then width/height as 32-bit big-endian at offsets 16 and 20 in the IHDR chunk.
+
+JPEG: magic check (`FF D8 FF`), then scan for SOF markers (`FF C0`, `FF C1`, `FF C2`). Height/width are 16-bit big-endian at marker+5 and marker+7 in the SOF segment. Skip non-SOF segments using their length field.
+
+For both: decode only the first ~200 bytes from the base64 (enough for headers; PNG's IHDR is always early, JPEG's SOF usually within the first KB but we should bound the scan).
+
+### `proxy/extensions/image-strip.mjs` (extend)
+
+Add a second pass after the existing KEEP_LAST stripping:
+
+```js
+const MAX_DIM = parseInt(process.env.CACHE_FIX_IMAGE_MAX_DIM || "0", 10);
+
+function stripOversizedImages(messages, maxDim) {
+  if (!maxDim || maxDim <= 0 || !Array.isArray(messages)) {
+    return { messages, stats: null };
+  }
+  // Walk every user-message content block AND every tool_result.content item;
+  // for each `type: "image"`, parse dimensions and replace if over the limit.
+}
+```
+
+Order in `onRequest`:
+1. Run KEEP_LAST stripping (existing behavior on tool_result images in old messages).
+2. Run MAX_DIM stripping on what remains (both user-message images and tool_result images).
+
+Stats merged into the existing log line: `image-strip: {keepLast stats} {maxDim stats}`.
+
+### Activation
+
+Already-loaded extension (existing `enabled: true` in `extensions.json` if user opted in to image-strip; otherwise their existing config is unchanged). Both env vars are gates — if MAX_DIM is unset, only the existing KEEP_LAST behavior runs.
+
+## Test plan
+
+`test/proxy-image-dimensions.test.mjs` (new):
+
+1. **PNG: valid header, 100x100** → returns `{width: 100, height: 100}`
+2. **PNG: valid header, 3000x2000** → returns `{width: 3000, height: 2000}`
+3. **PNG: truncated header** → returns `null`
+4. **PNG: wrong magic** → returns `null`
+5. **JPEG: SOF0 at standard offset, 1920x1080** → returns `{width: 1920, height: 1080}`
+6. **JPEG: SOF2 (progressive) at non-zero offset** → returns correct dimensions
+7. **JPEG: malformed length field** → returns `null` (doesn't crash)
+8. **`parseImageDimensions("image/png", b64)`** → dispatches correctly
+9. **`parseImageDimensions("image/jpeg", b64)`** → dispatches correctly
+10. **`parseImageDimensions("image/gif", b64)`** → returns `null` (unsupported, fail-open)
+11. **`parseImageDimensions("image/png", "")`** → returns `null`
+
+`test/proxy-image-strip.test.mjs` (extend):
+
+12. **MAX_DIM unset → oversized images NOT stripped** (current behavior preserved)
+13. **MAX_DIM=2000, image 1000x1000 → kept**
+14. **MAX_DIM=2000, image 3000x1500 → stripped, placeholder includes "was 3000x1500px"**
+15. **MAX_DIM=2000, image 1500x3000 → stripped (height exceeds)**
+16. **MAX_DIM=2000, image 2000x2000 → kept (boundary, dimension equals limit)**
+17. **User-message direct image (not in tool_result) gets MAX_DIM treatment too**
+18. **MAX_DIM + KEEP_LAST=2 compose**: 5 user messages each with 1 image, last 3 oversized → KEEP_LAST strips first 3, MAX_DIM strips the remaining 3 oversized (placeholder), only the small image survives; both stats logged
+19. **Image with unparseable dimensions** → kept (fail-open: don't strip what we can't measure)
+20. **Stats correctly track oversized count + bytes**
+
+## Files modified / created
+
+| File | Change |
+|---|---|
+| `proxy/image-dimensions.mjs` | NEW |
+| `proxy/extensions/image-strip.mjs` | EXTEND — add MAX_DIM behavior |
+| `test/proxy-image-dimensions.test.mjs` | NEW (~11 tests) |
+| `test/proxy-image-strip.test.mjs` | EXTEND (~9 new tests) |
+| `README.md` | Document new env var in image-strip section |
+| `docs/extension-impact-guide.md` | Update image-strip section |
+
+## Reviewer checklist
+
+- [ ] Pure dimension-parsing functions exported from `proxy/image-dimensions.mjs` with no native deps.
+- [ ] PNG magic and dimensions verified at correct offsets.
+- [ ] JPEG SOF marker scan handles all three SOF variants (FFC0, FFC1, FFC2) and skips other segments correctly using their length field.
+- [ ] Truncated/malformed/unsupported inputs return `null` rather than throwing.
+- [ ] MAX_DIM behavior is opt-in via env var; default behavior unchanged when unset.
+- [ ] Both image locations covered: user-message direct + tool_result-nested.
+- [ ] Strip placeholder includes original dimensions for forensic value.
+- [ ] Composes correctly with KEEP_LAST when both env vars are set.
+- [ ] Fail-open: images whose dimensions can't be parsed are kept (never break a request because we couldn't measure).
+- [ ] Tests pass on Node 18, 20, 22 (CI matrix).
+- [ ] No new top-level dependencies.
+
+## Out of scope (explicit)
+
+- Image resizing (Phase 2 if requested; needs sharp or similar)
+- GIF/WebP/AVIF/BMP detection
+- Detecting Anthropic's exact "many-image" threshold
+
+— AI Team Lead

--- a/docs/extension-impact-guide.md
+++ b/docs/extension-impact-guide.md
@@ -146,6 +146,25 @@ These features only work with the preload interceptor (`NODE_OPTIONS="--import .
 
 **Measured impact:** In a session with 4 screenshots, disabling image stripping added ~250K tokens per turn — equivalent to doubling the context window usage.
 
+### Oversized-image guard (`CACHE_FIX_IMAGE_MAX_DIM=N`)
+
+**What it fixes:** Anthropic enforces a per-image dimension ceiling on multi-image requests. When any single image exceeds the limit (currently 2000px on a side), the API returns:
+
+> "An image in the conversation exceeds the dimension limit for many-image requests (2000px). Start a new session with fewer images."
+
+This fails the request entirely. Common triggers: hi-res manuscript scans, retina screenshots, photo attachments at full resolution.
+
+**ON (e.g. =2000):** On every request, scan all PNG/JPEG images in both user messages and tool results. Replace any whose width OR height exceeds the limit with a forensic placeholder: `[image stripped — exceeded 2000px max dimension (was 3000x1500px)]`. The original dimensions stay visible to the model so it knows why the image was dropped.
+
+**OFF (default):** No dimension check. Hi-res images pass through and the request fails with the dimension-limit error.
+
+**Composes with `CACHE_FIX_IMAGE_KEEP_LAST`:** when both are set, `KEEP_LAST` runs first (drops images from old messages), then `MAX_DIM` runs on whatever remains (strips the oversized).
+
+**Implementation notes:**
+- Pure-JS PNG and JPEG header parsing — no native deps. Other formats (GIF, WebP, AVIF, BMP) are not detected; images of those types pass through unchanged regardless of dimension.
+- Fail-open: if dimensions can't be parsed (truncated header, unsupported format), the image is kept rather than stripped. Better to send a request that might error than to strip a valid image we just couldn't measure.
+- Pre-process locally when you can (`magick convert input.png -resize 2000x2000\> output.png`). This extension is the safety net for sources you forgot to pre-process.
+
 ### Output efficiency rewrite (`CACHE_FIX_OUTPUT_EFFICIENCY_REPLACEMENT`)
 
 **What it fixes:** Nothing directly — allows replacing CC's `# Output efficiency` system prompt section with custom text.

--- a/proxy/extensions/image-strip.mjs
+++ b/proxy/extensions/image-strip.mjs
@@ -1,5 +1,12 @@
+import { parseImageDimensions } from "../image-dimensions.mjs";
+
 const KEEP_LAST = parseInt(process.env.CACHE_FIX_IMAGE_KEEP_LAST || "0", 10);
+const MAX_DIM = parseInt(process.env.CACHE_FIX_IMAGE_MAX_DIM || "0", 10);
 const PLACEHOLDER = "[image stripped from history — file may still be on disk]";
+
+function oversizedPlaceholder(maxDim, w, h) {
+  return `[image stripped — exceeded ${maxDim}px max dimension (was ${w}x${h}px)]`;
+}
 
 function stripOldToolResultImages(messages, keepLast) {
   if (!keepLast || keepLast <= 0 || !Array.isArray(messages)) {
@@ -58,26 +65,116 @@ function stripOldToolResultImages(messages, keepLast) {
   return { messages: strippedCount > 0 ? result : messages, stats };
 }
 
-export { stripOldToolResultImages, PLACEHOLDER };
+// Strip oversized images from BOTH user-message direct content and
+// tool_result-nested content. Orthogonal to KEEP_LAST: scans every image
+// remaining in the message list and replaces any whose width or height
+// exceeds maxDim. Fail-open: images we can't measure (unsupported format,
+// truncated header) are kept rather than stripped.
+//
+// Stripping by oversize prevents the Anthropic API error:
+//   "An image in the conversation exceeds the dimension limit for many-image
+//    requests (2000px). Start a new session with fewer images."
+function stripOversizedImages(messages, maxDim) {
+  if (!maxDim || maxDim <= 0 || !Array.isArray(messages)) {
+    return { messages, stats: null };
+  }
+
+  let strippedCount = 0;
+  let strippedBytes = 0;
+
+  function maybeStrip(item) {
+    if (!item || item.type !== "image") return item;
+    const src = item.source;
+    if (!src || !src.data || !src.media_type) return item;
+    const dims = parseImageDimensions(src.media_type, src.data);
+    if (!dims) return item; // can't measure → keep
+    if (dims.width <= maxDim && dims.height <= maxDim) return item;
+    strippedCount++;
+    strippedBytes += src.data.length;
+    return { type: "text", text: oversizedPlaceholder(maxDim, dims.width, dims.height) };
+  }
+
+  const result = messages.map((msg) => {
+    if (!Array.isArray(msg.content)) return msg;
+    let mutated = false;
+    const newContent = msg.content.map((block) => {
+      // Direct image block on a user message
+      if (block && block.type === "image") {
+        const replaced = maybeStrip(block);
+        if (replaced !== block) {
+          mutated = true;
+          return replaced;
+        }
+        return block;
+      }
+      // Image nested inside a tool_result.content array
+      if (block && block.type === "tool_result" && Array.isArray(block.content)) {
+        let toolMutated = false;
+        const newToolContent = block.content.map((item) => {
+          const replaced = maybeStrip(item);
+          if (replaced !== item) toolMutated = true;
+          return replaced;
+        });
+        if (toolMutated) {
+          mutated = true;
+          return { ...block, content: newToolContent };
+        }
+      }
+      return block;
+    });
+    return mutated ? { ...msg, content: newContent } : msg;
+  });
+
+  const stats = strippedCount > 0
+    ? { strippedCount, strippedBytes, estimatedTokens: Math.ceil(strippedBytes * 0.125) }
+    : null;
+
+  return { messages: strippedCount > 0 ? result : messages, stats };
+}
+
+export { stripOldToolResultImages, stripOversizedImages, PLACEHOLDER, oversizedPlaceholder };
 
 export default {
   name: "image-strip",
-  description: "Strip base64 images from old tool results to reduce token waste",
+  description:
+    "Strip base64 images from old tool results AND optionally strip oversized images that would trigger Anthropic's many-image dimension limit",
   enabled: false,
   order: 150,
 
   async onRequest(ctx) {
     const keepLast = parseInt(ctx.meta.imageKeepLast ?? KEEP_LAST, 10);
-    if (!keepLast || keepLast <= 0) return;
+    const maxDim = parseInt(ctx.meta.imageMaxDim ?? MAX_DIM, 10);
+    if ((!keepLast || keepLast <= 0) && (!maxDim || maxDim <= 0)) return;
     if (!ctx.body.messages) return;
 
-    const { messages, stats } = stripOldToolResultImages(ctx.body.messages, keepLast);
-    if (stats) {
+    let messages = ctx.body.messages;
+    const logParts = [];
+
+    // Pass 1: existing keep_last behavior. Sets ctx.meta.imageStripStats with
+    // the same shape as before this PR — back-compat preserved.
+    if (keepLast > 0) {
+      const r = stripOldToolResultImages(messages, keepLast);
+      if (r.stats) {
+        messages = r.messages;
+        ctx.meta.imageStripStats = r.stats;
+        logParts.push(`keep_last: ${r.stats.strippedCount} stripped (~${r.stats.estimatedTokens} tokens saved)`);
+      }
+    }
+
+    // Pass 2: new max_dim behavior. Stats land on a new field so consumers
+    // already reading imageStripStats don't see a shape change.
+    if (maxDim > 0) {
+      const r = stripOversizedImages(messages, maxDim);
+      if (r.stats) {
+        messages = r.messages;
+        ctx.meta.imageStripOversizedStats = r.stats;
+        logParts.push(`max_dim: ${r.stats.strippedCount} oversized stripped (~${r.stats.estimatedTokens} tokens saved)`);
+      }
+    }
+
+    if (logParts.length > 0) {
       ctx.body.messages = messages;
-      ctx.meta.imageStripStats = stats;
-      process.stderr.write(
-        `[image-strip] stripped ${stats.strippedCount} images (~${stats.estimatedTokens} tokens saved)\n`
-      );
+      process.stderr.write(`[image-strip] ${logParts.join("; ")}\n`);
     }
   },
 };

--- a/proxy/image-dimensions.mjs
+++ b/proxy/image-dimensions.mjs
@@ -1,0 +1,120 @@
+// Pure-JS image header dimension parsing for PNG and JPEG.
+//
+// Used by the image-strip extension to detect images exceeding a configurable
+// max dimension. Stays in a separate module so it can be unit-tested without
+// the rest of the proxy machinery.
+//
+// No native deps. Decode-only — never modifies the image data.
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+// PNG: after the 8-byte magic, the IHDR chunk begins. IHDR layout:
+//   [4 bytes length][4 bytes "IHDR"][4 bytes width BE][4 bytes height BE]...
+// Width starts at byte 16, height at byte 20, both 32-bit big-endian.
+export function parsePngDimensions(buffer) {
+  if (!buffer || buffer.length < 24) return null;
+  for (let i = 0; i < PNG_MAGIC.length; i++) {
+    if (buffer[i] !== PNG_MAGIC[i]) return null;
+  }
+  // Verify the IHDR chunk type (offset 12-15 should be ASCII "IHDR")
+  if (
+    buffer[12] !== 0x49 || buffer[13] !== 0x48 ||
+    buffer[14] !== 0x44 || buffer[15] !== 0x52
+  ) {
+    return null;
+  }
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+  if (width <= 0 || height <= 0) return null;
+  return { width, height };
+}
+
+// JPEG SOF (Start Of Frame) markers we care about. We don't differentiate
+// between SOF0 (baseline), SOF1 (extended sequential), SOF2 (progressive),
+// SOF3 (lossless) etc — all carry dimensions in the same layout.
+const JPEG_SOF_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf,
+]);
+
+// JPEG: starts with FF D8 (SOI). Each segment after is FF <marker> [length BE]
+// [data...]. We scan for an SOF marker and read width/height from its segment.
+// SOF segment layout after the marker: [length 2B][precision 1B][height 2B][width 2B]...
+export function parseJpegDimensions(buffer) {
+  if (!buffer || buffer.length < 4) return null;
+  if (buffer[0] !== 0xff || buffer[1] !== 0xd8) return null;
+
+  let i = 2;
+  const max = buffer.length;
+  // Bound iterations to keep malformed inputs from looping. JPEG headers we
+  // care about are well under 1KB; cap at the buffer size we got.
+  let iterations = 0;
+  while (i < max - 8 && iterations++ < 1000) {
+    // Each marker segment starts with 0xFF followed by the marker byte.
+    if (buffer[i] !== 0xff) {
+      // Skip over fill bytes / pad bytes (not valid in standard JPEG but tolerated)
+      i++;
+      continue;
+    }
+    // Skip multiple 0xFF prefixes (pad fill — valid per spec)
+    while (i < max - 1 && buffer[i] === 0xff) i++;
+    const marker = buffer[i];
+    i++;
+
+    // Markers without a length-prefixed segment: SOI (D8), EOI (D9), RST0-7 (D0-D7).
+    if (marker === 0xd8 || marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7)) {
+      continue;
+    }
+
+    if (i + 1 >= max) return null;
+    const segLen = (buffer[i] << 8) | buffer[i + 1];
+    if (segLen < 2 || i + segLen > max) return null;
+
+    if (JPEG_SOF_MARKERS.has(marker)) {
+      // Layout: [length 2B][precision 1B][height 2B][width 2B]
+      // i currently points at the length field's first byte.
+      if (i + 6 >= max) return null;
+      const height = (buffer[i + 3] << 8) | buffer[i + 4];
+      const width = (buffer[i + 5] << 8) | buffer[i + 6];
+      if (width <= 0 || height <= 0) return null;
+      return { width, height };
+    }
+
+    // Skip this segment to its end and continue scanning.
+    i += segLen;
+  }
+  return null;
+}
+
+// Decode a small prefix of base64 data and dispatch to the right parser based
+// on media_type. Returns { width, height } or null.
+//
+// We decode only the first ~512 bytes — enough for PNG IHDR (always near the
+// start) and the typical JPEG SOF location (most image encoders place the SOF
+// within the first few hundred bytes).
+const HEADER_PROBE_BYTES = 1024;
+
+export function parseImageDimensions(mediaType, base64Data) {
+  if (!mediaType || !base64Data || typeof base64Data !== "string") return null;
+  // Base64 expands by ~4/3, so to get HEADER_PROBE_BYTES decoded bytes we need
+  // ~HEADER_PROBE_BYTES * 4 / 3 base64 chars. Round up generously.
+  const probeChars = Math.min(base64Data.length, HEADER_PROBE_BYTES * 2);
+  let buffer;
+  try {
+    buffer = Buffer.from(base64Data.slice(0, probeChars), "base64");
+  } catch {
+    return null;
+  }
+  if (!buffer || buffer.length === 0) return null;
+
+  switch (mediaType.toLowerCase()) {
+    case "image/png":
+      return parsePngDimensions(buffer);
+    case "image/jpeg":
+    case "image/jpg":
+      return parseJpegDimensions(buffer);
+    default:
+      // Unsupported format — fail-open. Caller treats null as "can't measure"
+      // and keeps the image rather than stripping what it can't verify.
+      return null;
+  }
+}

--- a/test/proxy-image-dimensions.test.mjs
+++ b/test/proxy-image-dimensions.test.mjs
@@ -1,0 +1,161 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parsePngDimensions,
+  parseJpegDimensions,
+  parseImageDimensions,
+} from "../proxy/image-dimensions.mjs";
+
+// --- PNG synthesis ---
+//
+// Build a valid-enough PNG header (just IHDR; we don't render or display).
+// Layout: 8-byte magic + IHDR chunk (4B length + 4B "IHDR" + 4B width + 4B
+// height + 5B remaining IHDR data + 4B CRC).
+function buildPngHeader(width, height) {
+  const buf = Buffer.alloc(33);
+  // PNG magic
+  buf.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  // IHDR chunk length (always 13)
+  buf.writeUInt32BE(13, 8);
+  // "IHDR"
+  buf.set([0x49, 0x48, 0x44, 0x52], 12);
+  // width
+  buf.writeUInt32BE(width, 16);
+  // height
+  buf.writeUInt32BE(height, 20);
+  // bit depth, color type, compression, filter, interlace (5 bytes, all 0 for our purposes)
+  // CRC (4 bytes, junk for our purposes)
+  return buf;
+}
+
+// --- JPEG synthesis ---
+//
+// Build SOI (FF D8) + a JFIF APP0 segment + a SOF0 segment with the dimensions
+// we want. The parser needs to walk past APP0 to find SOF0 — exercises segment
+// skipping logic.
+function buildJpegHeader(width, height, sofMarker = 0xc0) {
+  // SOI
+  const soi = Buffer.from([0xff, 0xd8]);
+  // APP0 (JFIF) — 16-byte data: length(2) + "JFIF\0"(5) + version(2) + units(1) + xden(2) + yden(2) + xthumb(1) + ythumb(1)
+  const app0 = Buffer.from([
+    0xff, 0xe0,           // marker
+    0x00, 0x10,           // length (16, includes itself)
+    0x4a, 0x46, 0x49, 0x46, 0x00,  // "JFIF\0"
+    0x01, 0x01,           // version 1.1
+    0x00,                 // units: aspect ratio
+    0x00, 0x01,           // xdensity 1
+    0x00, 0x01,           // ydensity 1
+    0x00, 0x00,           // thumbnail w=0 h=0
+  ]);
+  // SOF — marker(2) + length(2) + precision(1) + height(2) + width(2) + components(1)
+  // We only need the parser to find marker + read height/width.
+  const sof = Buffer.alloc(11);
+  sof[0] = 0xff;
+  sof[1] = sofMarker;
+  // length (from after marker through end): 2 + 1 + 2 + 2 + 1 = 8
+  sof.writeUInt16BE(8, 2);
+  sof[4] = 8; // precision (8-bit)
+  sof.writeUInt16BE(height, 5);
+  sof.writeUInt16BE(width, 7);
+  sof[9] = 1; // num components (just for valid-shape)
+  // (then component data byte at sof[10] = 0)
+  return Buffer.concat([soi, app0, sof]);
+}
+
+// --- 1. PNG basic ---
+
+test("1. PNG header → 100x100", () => {
+  const buf = buildPngHeader(100, 100);
+  assert.deepEqual(parsePngDimensions(buf), { width: 100, height: 100 });
+});
+
+test("2. PNG header → 3000x2000 (oversized)", () => {
+  const buf = buildPngHeader(3000, 2000);
+  assert.deepEqual(parsePngDimensions(buf), { width: 3000, height: 2000 });
+});
+
+test("3. PNG: truncated buffer → null", () => {
+  const buf = buildPngHeader(100, 100).subarray(0, 18); // cut off mid-width
+  assert.equal(parsePngDimensions(buf), null);
+});
+
+test("4. PNG: wrong magic → null", () => {
+  const buf = buildPngHeader(100, 100);
+  buf[0] = 0x00; // corrupt magic
+  assert.equal(parsePngDimensions(buf), null);
+});
+
+test("4b. PNG: wrong IHDR identifier → null", () => {
+  const buf = buildPngHeader(100, 100);
+  buf[12] = 0x00; // corrupt "IHDR"
+  assert.equal(parsePngDimensions(buf), null);
+});
+
+// --- 5-7. JPEG ---
+
+test("5. JPEG SOF0 1920x1080", () => {
+  const buf = buildJpegHeader(1920, 1080, 0xc0);
+  assert.deepEqual(parseJpegDimensions(buf), { width: 1920, height: 1080 });
+});
+
+test("6. JPEG SOF2 (progressive) 4096x3072", () => {
+  const buf = buildJpegHeader(4096, 3072, 0xc2);
+  assert.deepEqual(parseJpegDimensions(buf), { width: 4096, height: 3072 });
+});
+
+test("7. JPEG malformed length → null (no crash)", () => {
+  const buf = buildJpegHeader(100, 100);
+  // Corrupt the APP0 segment length so the scanner walks off the end
+  buf[3] = 0xff; // length now huge
+  buf[2] = 0xff;
+  assert.equal(parseJpegDimensions(buf), null);
+});
+
+test("7b. JPEG wrong magic → null", () => {
+  const buf = buildJpegHeader(100, 100);
+  buf[0] = 0x00;
+  assert.equal(parseJpegDimensions(buf), null);
+});
+
+// --- 8-11. dispatch via parseImageDimensions ---
+
+test("8. parseImageDimensions(image/png) dispatches", () => {
+  const b64 = buildPngHeader(640, 480).toString("base64");
+  assert.deepEqual(parseImageDimensions("image/png", b64), { width: 640, height: 480 });
+});
+
+test("9. parseImageDimensions(image/jpeg) dispatches", () => {
+  const b64 = buildJpegHeader(640, 480).toString("base64");
+  assert.deepEqual(parseImageDimensions("image/jpeg", b64), { width: 640, height: 480 });
+});
+
+test("9b. parseImageDimensions(image/jpg) also dispatches to JPEG", () => {
+  const b64 = buildJpegHeader(640, 480).toString("base64");
+  assert.deepEqual(parseImageDimensions("image/jpg", b64), { width: 640, height: 480 });
+});
+
+test("10. parseImageDimensions(image/gif) → null (unsupported, fail-open)", () => {
+  // Even with valid PNG-shaped data, gif media_type → null
+  const b64 = buildPngHeader(100, 100).toString("base64");
+  assert.equal(parseImageDimensions("image/gif", b64), null);
+});
+
+test("11. parseImageDimensions: empty/missing inputs → null", () => {
+  assert.equal(parseImageDimensions("image/png", ""), null);
+  assert.equal(parseImageDimensions("", "abc"), null);
+  assert.equal(parseImageDimensions(null, "abc"), null);
+  assert.equal(parseImageDimensions("image/png", null), null);
+});
+
+test("11b. parseImageDimensions: media_type case-insensitive", () => {
+  const b64 = buildPngHeader(640, 480).toString("base64");
+  assert.deepEqual(parseImageDimensions("IMAGE/PNG", b64), { width: 640, height: 480 });
+  assert.deepEqual(parseImageDimensions("Image/Jpeg", buildJpegHeader(800, 600).toString("base64")), { width: 800, height: 600 });
+});
+
+test("11c. parseImageDimensions: malformed base64 → null (no throw)", () => {
+  // Buffer.from("not-valid-b64", "base64") doesn't throw — produces empty/garbage.
+  // The downstream parser should reject.
+  assert.equal(parseImageDimensions("image/png", "!!!"), null);
+});

--- a/test/proxy-image-strip.test.mjs
+++ b/test/proxy-image-strip.test.mjs
@@ -1,6 +1,41 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import ext, { stripOldToolResultImages, PLACEHOLDER } from "../proxy/extensions/image-strip.mjs";
+import ext, {
+  stripOldToolResultImages,
+  stripOversizedImages,
+  PLACEHOLDER,
+  oversizedPlaceholder,
+} from "../proxy/extensions/image-strip.mjs";
+
+// --- Helpers for synthesizing PNG headers with known dimensions ---
+function buildPngHeader(width, height) {
+  const buf = Buffer.alloc(33);
+  buf.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  buf.writeUInt32BE(13, 8);
+  buf.set([0x49, 0x48, 0x44, 0x52], 12);
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+function pngB64(width, height) {
+  return buildPngHeader(width, height).toString("base64");
+}
+function userMsgWithDirectImage(b64) {
+  return { role: "user", content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: b64 } }] };
+}
+function userMsgWithToolResultImage(toolUseId, b64) {
+  return {
+    role: "user",
+    content: [{
+      type: "tool_result",
+      tool_use_id: toolUseId,
+      content: [
+        { type: "image", source: { type: "base64", media_type: "image/png", data: b64 } },
+        { type: "text", text: "Read OK" },
+      ],
+    }],
+  };
+}
 
 function userMsg(content) {
   return { role: "user", content };
@@ -176,4 +211,138 @@ test("onRequest: no-op when keepLast is 0 or unset", async () => {
 
   await ext.onRequest(ctx);
   assert.equal(ctx.meta.imageStripStats, undefined);
+});
+
+// ── MAX_DIM behavior tests ─────────────────────────────────────────────
+// stripOversizedImages: pure function tests
+
+test("MAX_DIM: 1000x1000 image is kept (under limit)", () => {
+  const msgs = [userMsgWithToolResultImage("t1", pngB64(1000, 1000))];
+  const r = stripOversizedImages(msgs, 2000);
+  assert.equal(r.stats, null, "no stats when nothing stripped");
+  assert.equal(r.messages, msgs, "input returned unchanged when nothing stripped");
+});
+
+test("MAX_DIM: 3000x1500 image is stripped (width over)", () => {
+  const msgs = [userMsgWithToolResultImage("t1", pngB64(3000, 1500))];
+  const r = stripOversizedImages(msgs, 2000);
+  assert.equal(r.stats.strippedCount, 1);
+  const replaced = r.messages[0].content[0].content[0];
+  assert.equal(replaced.type, "text");
+  assert.match(replaced.text, /3000x1500px/);
+  assert.match(replaced.text, /2000px max/);
+});
+
+test("MAX_DIM: 1500x3000 image is stripped (height over)", () => {
+  const msgs = [userMsgWithToolResultImage("t1", pngB64(1500, 3000))];
+  const r = stripOversizedImages(msgs, 2000);
+  assert.equal(r.stats.strippedCount, 1);
+  assert.match(r.messages[0].content[0].content[0].text, /1500x3000px/);
+});
+
+test("MAX_DIM: 2000x2000 boundary is kept (dimension equals limit)", () => {
+  const msgs = [userMsgWithToolResultImage("t1", pngB64(2000, 2000))];
+  const r = stripOversizedImages(msgs, 2000);
+  assert.equal(r.stats, null);
+});
+
+test("MAX_DIM: user-message direct image (not in tool_result) gets stripped", () => {
+  const msgs = [userMsgWithDirectImage(pngB64(3000, 3000))];
+  const r = stripOversizedImages(msgs, 2000);
+  assert.equal(r.stats.strippedCount, 1);
+  assert.equal(r.messages[0].content[0].type, "text");
+  assert.match(r.messages[0].content[0].text, /3000x3000px/);
+});
+
+test("MAX_DIM: image with unparseable dimensions is kept (fail-open)", () => {
+  // Garbage base64 that doesn't decode to a valid PNG/JPEG header
+  const msgs = [userMsgWithToolResultImage("t1", "Z2FyYmFnZQ==" /* "garbage" */)];
+  const r = stripOversizedImages(msgs, 2000);
+  assert.equal(r.stats, null);
+  // Image block preserved unchanged
+  assert.equal(r.messages[0].content[0].content[0].type, "image");
+});
+
+test("MAX_DIM: stats track count and bytes correctly", () => {
+  const big1 = pngB64(3000, 1500);
+  const big2 = pngB64(4000, 2500);
+  const msgs = [
+    userMsgWithToolResultImage("t1", big1),
+    userMsgWithToolResultImage("t2", big2),
+  ];
+  const r = stripOversizedImages(msgs, 2000);
+  assert.equal(r.stats.strippedCount, 2);
+  assert.equal(r.stats.strippedBytes, big1.length + big2.length);
+  assert.ok(r.stats.estimatedTokens > 0);
+});
+
+test("MAX_DIM unset: no oversized stripping (current behavior preserved)", () => {
+  const msgs = [userMsgWithToolResultImage("t1", pngB64(5000, 5000))];
+  const r = stripOversizedImages(msgs, 0);
+  assert.equal(r.stats, null);
+  assert.equal(r.messages, msgs);
+});
+
+// ── Compose KEEP_LAST + MAX_DIM via the extension hook ───────────────
+test("KEEP_LAST + MAX_DIM compose: keep_last drops oldest, max_dim then strips remaining oversized", async () => {
+  // Build 5 user messages. The first 3 should be dropped by KEEP_LAST=2,
+  // then MAX_DIM=2000 should strip oversized from the remaining 2.
+  // But: KEEP_LAST only operates on tool_result-nested images. To make the
+  // composition test crisp, all 5 messages have tool_result images.
+  // Last 2 (indices 3 and 4) survive KEEP_LAST.
+  // index 3: 1000x1000 (under) — survives both passes
+  // index 4: 3000x3000 (over)  — survives KEEP_LAST, stripped by MAX_DIM
+  const ctx = {
+    body: {
+      messages: [
+        userMsgWithToolResultImage("t1", pngB64(500, 500)),    // dropped by keep_last
+        userMsgWithToolResultImage("t2", pngB64(500, 500)),    // dropped by keep_last
+        userMsgWithToolResultImage("t3", pngB64(500, 500)),    // dropped by keep_last
+        userMsgWithToolResultImage("t4", pngB64(1000, 1000)),  // kept by both
+        userMsgWithToolResultImage("t5", pngB64(3000, 3000)),  // kept by keep_last, stripped by max_dim
+      ],
+    },
+    headers: {},
+    meta: { imageKeepLast: 2, imageMaxDim: 2000 },
+  };
+  await ext.onRequest(ctx);
+  // Both stat objects should be present (separate fields, back-compat preserved)
+  assert.ok(ctx.meta.imageStripStats, "keep_last stats must land on imageStripStats");
+  assert.equal(ctx.meta.imageStripStats.strippedCount, 3, "3 oldest images dropped by keep_last");
+  assert.ok(ctx.meta.imageStripOversizedStats, "max_dim stats must land on imageStripOversizedStats");
+  assert.equal(ctx.meta.imageStripOversizedStats.strippedCount, 1, "1 oversized image stripped by max_dim");
+  // Verify the surviving image (t4, index 3) is intact
+  const t4Result = ctx.body.messages[3].content[0];
+  assert.equal(t4Result.content[0].type, "image", "small recent image should survive both passes");
+  // Verify the t5 image was replaced with oversized placeholder
+  const t5Result = ctx.body.messages[4].content[0];
+  assert.equal(t5Result.content[0].type, "text");
+  assert.match(t5Result.content[0].text, /3000x3000px/);
+});
+
+test("MAX_DIM only via env-equivalent meta: hook fires and emits stats", async () => {
+  const ctx = {
+    body: {
+      messages: [
+        userMsgWithToolResultImage("t1", pngB64(5000, 5000)),
+        userMsgWithToolResultImage("t2", pngB64(800, 800)),
+      ],
+    },
+    headers: {},
+    meta: { imageMaxDim: 2000 },
+  };
+  await ext.onRequest(ctx);
+  assert.ok(ctx.meta.imageStripOversizedStats);
+  assert.equal(ctx.meta.imageStripOversizedStats.strippedCount, 1);
+  assert.equal(ctx.meta.imageStripStats, undefined, "keep_last stats must be absent when keep_last is unset");
+  // First image stripped, second kept
+  assert.equal(ctx.body.messages[0].content[0].content[0].type, "text");
+  assert.equal(ctx.body.messages[1].content[0].content[0].type, "image");
+});
+
+test("oversizedPlaceholder formats as documented", () => {
+  assert.equal(
+    oversizedPlaceholder(2000, 3000, 1500),
+    "[image stripped — exceeded 2000px max dimension (was 3000x1500px)]",
+  );
 });


### PR DESCRIPTION
## Why

Asked for by Alexander (X-15) and useful for Chris's Chronology hi-res scan workflow. Prevents the Anthropic API error:

> "An image in the conversation exceeds the dimension limit for many-image requests (2000px). Start a new session with fewer images."

When the user attaches a large image (5K-10K px scan, photo, screenshot at retina res), this error fails the request entirely. Until now the only mitigation was to manually pre-resize before attaching.

## What's in the PR

- **New env var `CACHE_FIX_IMAGE_MAX_DIM=<pixels>`**. Default unset = no enforcement (current behavior unchanged). Set e.g. `2000` to enable.
- **New module `proxy/image-dimensions.mjs`** — pure-JS PNG and JPEG header parsing, no native deps.
- **`image-strip` extension extended**: scans ALL images (not just OLD ones — orthogonal to KEEP_LAST), strips any whose width OR height exceeds the limit. Covers BOTH user-message direct images AND tool_result-nested images.
- **Forensic placeholder** preserves original dimensions: `[image stripped — exceeded 2000px max dimension (was 3000x1500px)]`
- **Composes with KEEP_LAST**: keep_last runs first (drops oldest), max_dim then runs on what remains. Both stat objects persist on separate `ctx.meta` fields for back-compat (`imageStripStats` shape unchanged; new `imageStripOversizedStats` for the new pass).
- **Fail-open**: images whose dimensions can't be parsed are kept rather than stripped. Better to send a request that might error than to strip a valid image we just couldn't read.

## Tests

- 16 new in `test/proxy-image-dimensions.test.mjs` (synthesized PNG + JPEG headers, dispatch, malformed inputs, case-insensitive media_type)
- 11 new in `test/proxy-image-strip.test.mjs` (boundary cases at exactly the limit, both image locations, KEEP_LAST + MAX_DIM composition, fail-open)
- All 36 image-related tests pass; **full suite 553/553**

## Out of scope (explicit, deferred to v3.3.0+ if requested)

- Image RESIZING — would need `sharp` or similar native dep. Strip-only is the no-deps minimum viable fix.
- GIF/WebP/AVIF/BMP detection — not in CC's typical pipeline.

## Activation

Opt-in. The `image-strip` extension itself is `enabled: false` by default in `extensions.json` — users explicitly turn it on. Then set `CACHE_FIX_IMAGE_MAX_DIM=2000` (or other ceiling) to enable the new oversized guard. Both env vars compose if desired.

## Review request

Codex first via `cli_delegate`, then Alexander (since he asked for the feature). Holding for both reviews + Chris's read before any merge or release decision.

— AI Team Lead