### PR TITLE
release: v3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.2.1 (2026-04-27)
+
+**Oversized-image guard for `image-strip`** (#84, requested by @X-15):
+
+New `CACHE_FIX_IMAGE_MAX_DIM=<pixels>` env var on the existing `image-strip` extension. When an image's pixel dimensions exceed the cap (Anthropic's per-image dimension ceiling for many-image requests is 2000px), the image is replaced with a forensic placeholder noting the original dimensions and tool_use_id. Covers both user-message direct images and tool_result-nested images. Pure-JS PNG and JPEG header parsing in new `proxy/image-dimensions.mjs` — no native dependencies.
+
+Composes with the existing `CACHE_FIX_IMAGE_KEEP_LAST` (count axis): when both are set, `KEEP_LAST` runs first (drops images from old messages), then `MAX_DIM` runs on whatever survives (caps the size of the kept ones). Common triggers for the dimension axis: hi-res manuscript scans, retina screenshots, photos at full resolution.
+
+**Tests**: 526 → 553 (27 new — 16 in `proxy-image-dimensions.test.mjs` covering synthesized PNG/JPEG headers, 11 in `proxy-image-strip.test.mjs` covering MAX_DIM behavior, fail-open semantics, and KEEP_LAST + MAX_DIM composition).
+
+No behavior change for users not setting `CACHE_FIX_IMAGE_MAX_DIM`. No migration required.
+
+---
+
 ## 3.2.0 (2026-04-25)
 
 Three new opt-in extensions plus a `usage-log` rewrite that aligns the proxy's per-call JSONL with `claude-code-meter`'s strict validator.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ docker run -d --name cache-fix-proxy --restart=always -p 9801:9801 \
   ghcr.io/cnighswonger/claude-code-cache-fix:latest
 ```
 
-Image tags: `latest`, `3`, `3.2`, `3.2.0` (semver-ladder, so `3` always points to the newest 3.x). `latest` always tracks the newest tagged release.
+Image tags: `latest`, `3`, `3.2`, `3.2.1` (semver-ladder, so `3` always points to the newest 3.x). `latest` always tracks the newest tagged release.
 
 **Linux note:** the chained-upstream `host.docker.internal` example below is automatic on Docker Desktop (macOS / Windows). On plain Linux Docker Engine you usually need `--add-host=host.docker.internal:host-gateway` so the name resolves to the host bridge. Without it, the container's name lookup fails and the proxy can't reach the upstream service running on the host. Example chaining cache-fix proxy through `llm-relay` running on the host:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-cache-fix",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Cache optimization proxy and interceptor for Claude Code. Fixes prompt cache bugs, stabilizes prefix, reduces quota burn.",
   "type": "module",
   "exports": "./preload.mjs",


### PR DESCRIPTION
## Summary

- Bumps to v3.2.1 with the image-strip oversized-image guard merged in #84 as `ac4de40`
- CHANGELOG entry, README docker-tag bump, version bump in package.json
- No code changes beyond the version+docs files; all functional changes already on main since #84

## Why standalone (not bundled)

PR #85 (`read-dedupe` extension proposal) was on the table for bundling, but the design has an open empirical question — where CC places `cache_control` breakpoints relative to a Read re-issue. Until that's measured on a captured request body, we can't be confident the dedupe is purely suffix-side and won't invalidate the prefix cache. Shipping image-strip standalone gets the field-validated fix to @X-15 and other affected users today; #85 takes its time in v3.3.0.

## Test plan

- [x] `npm test` — 553/553 passing on release branch
- [x] CHANGELOG version + date match package.json
- [x] README docker tag example updated to 3.2.1
- [x] No version-stale references elsewhere (`grep -rn "3\.2\.0"` only hits historical CHANGELOG entries and proxy/rates.mjs comments which document v3.2.0's shipped behavior)

— AI Team Lead