### PR TITLE
Add Apache 2.0 attribution for NDJSON schema from claude-usage-dashboard

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -1,0 +1,15 @@
+Third-Party Licenses
+====================
+
+1. claude-usage-dashboard — NDJSON proxy log schema
+
+   Source:  https://github.com/fgrosswig/claude-usage-dashboard
+   Author:  Falk Grosswig (@fgrosswig)
+   License: Apache License 2.0
+
+   The proxy NDJSON log schema used by tools/usage-to-dashboard-ndjson.mjs
+   (field names, structure, file naming convention, cache_health semantics,
+   and cost_factor methodology) originates from the claude-usage-dashboard.
+
+   Used under the Apache License, Version 2.0.
+   https://www.apache.org/licenses/LICENSE-2.0

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "claude-fixed.bat",
     "proxy/",
     "bin/",
-    "templates/"
+    "templates/",
+    "THIRD_PARTY_LICENSES"
   ],
   "engines": {
     "node": ">=18"

--- a/tools/usage-to-dashboard-ndjson.mjs
+++ b/tools/usage-to-dashboard-ndjson.mjs
@@ -82,8 +82,13 @@
  *   ANTHROPIC_PROXY_LOG_DIR  Override output directory (matches fgrosswig's
  *                            dashboard env var so both tools stay in sync).
  *
- * Part of claude-code-cache-fix. MIT licensed.
+ * Part of claude-code-cache-fix.
  *   https://github.com/cnighswonger/claude-code-cache-fix
+ *
+ * The NDJSON proxy log schema (field names, structure, file naming convention,
+ * cache_health semantics) originates from fgrosswig/claude-usage-dashboard
+ * and is used under the Apache License 2.0.
+ *   https://github.com/fgrosswig/claude-usage-dashboard
  */
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, statSync, watch } from 'node:fs';


### PR DESCRIPTION
Hey Chris,

The `usage-to-dashboard-ndjson` translator and `docs/dashboard-integration.md` use the NDJSON proxy log schema from my [claude-usage-dashboard](https://github.com/fgrosswig/claude-usage-dashboard) — field names, structure, `proxy-YYYY-MM-DD.ndjson` file convention, `cache_health` semantics, and the `cost_factor` methodology.

The dashboard is licensed under **Apache License 2.0**. Apache 2.0 requires a license notice and copyright attribution (Section 4), so this PR adds the formal attribution that keeps the license chain clean for npm shipping.

### Changes

1. **`THIRD_PARTY_LICENSES`** (new file) — documents the Apache 2.0 origin of the NDJSON proxy log schema
2. **`tools/usage-to-dashboard-ndjson.mjs`** — updated file header to reference the Apache 2.0 origin for the schema portion

No code changes, no behavior changes. cache-fix remains MIT licensed.

— Falk