### PR TITLE
fix(cache-telemetry): handle overage-billing accounts that return no …

### DIFF
--- a/proxy/extensions/cache-telemetry.mjs
+++ b/proxy/extensions/cache-telemetry.mjs
@@ -71,11 +71,15 @@ function parseHeaders(headers) {
   const overage_status = get("anthropic-ratelimit-unified-overage-status");
   const overage_util = num("anthropic-ratelimit-unified-overage-utilization");
   const overage_reset = parseInt(get("anthropic-ratelimit-unified-overage-reset")) || 0;
+  const unified_reset = parseInt(get("anthropic-ratelimit-unified-reset")) || 0;
   const fallback_pct = get("anthropic-ratelimit-unified-fallback-percentage");
   const representative = get("anthropic-ratelimit-unified-representative-claim");
   const surpassed = get("anthropic-ratelimit-unified-7d-surpassed-threshold");
 
-  if (!q5h_reset && !q7d_reset) return null;
+  // Accept any reset timestamp — accounts without 5h/7d quota windows (overage
+  // billing) return anthropic-ratelimit-unified-reset and/or
+  // anthropic-ratelimit-unified-overage-reset instead.
+  if (!q5h_reset && !q7d_reset && !unified_reset && !overage_reset) return null;
 
   const now = new Date();
   const hour = now.getUTCHours();

--- a/test/proxy-cache-telemetry.test.mjs
+++ b/test/proxy-cache-telemetry.test.mjs
@@ -362,6 +362,44 @@ test("6. quota-only write skipped when no quota headers", async () => {
   }
 });
 
+test("6a. overage-billing account: writes files when only unified/overage-reset headers present", async () => {
+  // Accounts on overage billing return anthropic-ratelimit-unified-reset and
+  // anthropic-ratelimit-unified-overage-reset instead of the 5h/7d-reset headers.
+  // cache-telemetry must still write quota-status files for these accounts.
+  const env = setupTmpHome();
+  try {
+    const overageOnlyHeaders = {
+      "anthropic-ratelimit-unified-status": "allowed",
+      "anthropic-ratelimit-unified-overage-status": "allowed",
+      "anthropic-ratelimit-unified-overage-reset": "1780272000",
+      "anthropic-ratelimit-unified-overage-utilization": "0.52",
+      "anthropic-ratelimit-unified-reset": "1780272000",
+      "anthropic-ratelimit-unified-representative-claim": "overage",
+      "anthropic-ratelimit-unified-fallback-percentage": "0.5",
+    };
+    await driveResponse({
+      requestHeaders: { "x-claude-code-session-id": "overage-sess" },
+      responseHeaders: overageOnlyHeaders,
+      cacheRead: 500,
+      cacheCreation: 100,
+    });
+    const accountPath = join(env.home, ".claude", "quota-status", "account.json");
+    const sessPath = join(env.home, ".claude", "quota-status", "sessions", "overage-sess.json");
+    assert.ok(existsSync(accountPath), "account.json written for overage-billing account");
+    assert.ok(existsSync(sessPath), "session file written for overage-billing account");
+    const acc = JSON.parse(readFileSync(accountPath, "utf8"));
+    assert.strictEqual(acc.five_hour.pct, 0, "five_hour.pct is 0 (no 5h quota for this account)");
+    assert.strictEqual(acc.seven_day.pct, 0, "seven_day.pct is 0 (no 7d quota for this account)");
+    assert.strictEqual(acc.status, "allowed");
+    assert.strictEqual(acc.overage_status, "allowed");
+    const sess = JSON.parse(readFileSync(sessPath, "utf8"));
+    assert.strictEqual(sess.cache.ttl_tier, "1h", "1h TTL when cache_read > 0");
+    assert.ok(parseFloat(sess.cache.hit_rate) > 0, "hit_rate populated");
+  } finally {
+    env.cleanup();
+  }
+});
+
 test("7. atomic write: tmp file gone after rename, final exists", async () => {
   const env = setupTmpHome();
   try {


### PR DESCRIPTION
…5h/7d reset headers

Accounts on Anthropic overage billing return anthropic-ratelimit-unified-reset and anthropic-ratelimit-unified-overage-reset instead of the 5h/7d-specific headers. The parseHeaders guard required q5h_reset || q7d_reset and returned null for every request on these accounts, so cache-telemetry never wrote quota-status files and the statusline showed no TTL/hit-rate data.

Fix: parse unified_reset and expand the guard to accept any reset timestamp. The existing overage_reset was already parsed but not checked in the guard.

Adds test 6a: verifies account.json and session file are written when only unified/overage-reset headers are present, and that five_hour/seven_day pct are correctly 0 for this account type.