### PR TITLE
feat(proxy): expose embeddable factory for in-process hosting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "3.5.5",
   "description": "Cache optimization proxy and interceptor for Claude Code. Fixes prompt cache bugs, stabilizes prefix, reduces quota burn.",
   "type": "module",
-  "exports": "./preload.mjs",
+  "exports": {
+    ".": "./preload.mjs",
+    "./proxy/server": "./proxy/server.mjs"
+  },
   "main": "./preload.mjs",
   "bin": {
     "cache-fix-proxy": "./bin/claude-via-proxy.mjs"

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -1,4 +1,5 @@
 import http from "node:http";
+import { pathToFileURL } from "node:url";
 import config from "./config.mjs";
 import { forwardRequest } from "./upstream.mjs";
 import { streamResponse, createTelemetryRecord } from "./stream.mjs";
@@ -138,36 +139,102 @@ function handleNotFound(_req, res) {
   res.end(JSON.stringify({ error: "not_found" }));
 }
 
-const server = http.createServer((req, res) => {
-  if (req.method === "GET" && req.url === "/health") {
-    return handleHealth(req, res);
-  }
-  if (req.method === "POST" && req.url?.startsWith("/v1/messages")) {
-    return handleMessages(req, res);
-  }
-  handleNotFound(req, res);
-});
-
-function shutdown() {
-  server.close(() => process.exit(0));
-  setTimeout(() => process.exit(1), 5000);
-}
-
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
-
-async function initPipeline() {
-  try {
-    await loadExtensions(config.extensionsDir, config.extensionsConfig);
-    startWatcher(config.extensionsDir, config.extensionsConfig);
-  } catch {}
-}
-
-initPipeline().then(() => {
-  server.listen(config.port, config.bind, () => {
-    const addr = server.address();
-    process.stdout.write(`proxy listening on ${addr.address}:${addr.port}\n`);
+/**
+ * Builds an http.Server with the proxy's request handler wired in. The
+ * returned server is **not** listening and the extension pipeline has not
+ * been initialized — callers wanting a one-call setup should use
+ * `startProxy()` instead.
+ *
+ * Exposed so callers can embed the proxy in their own process (e.g.
+ * Bun-compiled binaries, test harnesses) without forking a child or
+ * shelling out to the `cache-fix-proxy` bin.
+ */
+export function createProxyServer() {
+  return http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/health") {
+      return handleHealth(req, res);
+    }
+    if (req.method === "POST" && req.url?.startsWith("/v1/messages")) {
+      return handleMessages(req, res);
+    }
+    handleNotFound(req, res);
   });
-});
+}
 
-export { server };
+/**
+ * Builds the server, loads the extension pipeline, optionally starts the
+ * extensions-config file watcher, and starts listening. Returns a handle
+ * with the bound port (resolved when port 0 is requested) and a `close`
+ * function for graceful shutdown.
+ *
+ * All options fall back to the same env vars / defaults used by the CLI
+ * entrypoint, so existing deployments behave identically.
+ *
+ *   await startProxy()                               // env-driven, CLI parity
+ *   await startProxy({ port: 0 })                    // OS-assigned port
+ *   await startProxy({ port: 0, watch: false })      // embedded, no fs.watch
+ */
+export async function startProxy(options = {}) {
+  const port = options.port ?? config.port;
+  const bind = options.bind ?? config.bind;
+  const extensionsDir = options.extensionsDir ?? config.extensionsDir;
+  const extensionsConfig = options.extensionsConfig ?? config.extensionsConfig;
+  const watch = options.watch !== false;
+
+  try {
+    await loadExtensions(extensionsDir, extensionsConfig);
+    if (watch) startWatcher(extensionsDir, extensionsConfig);
+  } catch {}
+
+  const server = createProxyServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, bind, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const addr = server.address();
+  return {
+    server,
+    port: addr.port,
+    address: addr.address,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+// CLI entrypoint — preserves the v3.x behavior of `node proxy/server.mjs`
+// (used by `cache-fix-proxy server` and by `fork(SERVER_PATH)` in the
+// wrapper). When this module is imported as a library, none of this runs.
+const invokedAsScript =
+  typeof process !== "undefined" &&
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedAsScript) {
+  let active;
+  startProxy()
+    .then((handle) => {
+      active = handle;
+      process.stdout.write(`proxy listening on ${handle.address}:${handle.port}\n`);
+    })
+    .catch((err) => {
+      process.stderr.write(`proxy failed to start: ${err.message}\n`);
+      process.exit(1);
+    });
+
+  const shutdown = () => {
+    if (!active) {
+      process.exit(0);
+      return;
+    }
+    active.close().finally(() => process.exit(0));
+    setTimeout(() => process.exit(1), 5000).unref();
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+}

--- a/test/proxy-server-embeddable.test.mjs
+++ b/test/proxy-server-embeddable.test.mjs
@@ -1,0 +1,66 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { createProxyServer, startProxy } from "../proxy/server.mjs";
+
+function get(port, path) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ hostname: "127.0.0.1", port, method: "GET", path }, (res) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("embeddable proxy", () => {
+  it("createProxyServer returns an http.Server that is not yet listening", () => {
+    const server = createProxyServer();
+    assert.ok(server instanceof http.Server);
+    assert.equal(server.listening, false);
+  });
+
+  it("startProxy({port:0}) resolves with an OS-assigned port", async () => {
+    const handle = await startProxy({ port: 0, watch: false });
+    try {
+      assert.equal(typeof handle.port, "number");
+      assert.ok(handle.port > 0);
+      assert.equal(handle.address, "127.0.0.1");
+      assert.equal(handle.server.listening, true);
+
+      const res = await get(handle.port, "/health");
+      assert.equal(res.status, 200);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it("two startProxy instances coexist on different ports", async () => {
+    const a = await startProxy({ port: 0, watch: false });
+    const b = await startProxy({ port: 0, watch: false });
+    try {
+      assert.notEqual(a.port, b.port);
+      assert.equal((await get(a.port, "/health")).status, 200);
+      assert.equal((await get(b.port, "/health")).status, 200);
+    } finally {
+      await a.close();
+      await b.close();
+    }
+  });
+
+  it("close() lets the port be reused", async () => {
+    const first = await startProxy({ port: 0, watch: false });
+    const port = first.port;
+    await first.close();
+    assert.equal(first.server.listening, false);
+
+    const second = await startProxy({ port, bind: "127.0.0.1", watch: false });
+    try {
+      assert.equal(second.port, port);
+    } finally {
+      await second.close();
+    }
+  });
+});

--- a/test/proxy-server.test.mjs
+++ b/test/proxy-server.test.mjs
@@ -1,22 +1,10 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
+import { startProxy } from "../proxy/server.mjs";
 
-let server;
+let handle;
 let proxyPort;
-
-async function startProxy() {
-  const testPort = 19801 + Math.floor(Math.random() * 1000);
-  process.env.CACHE_FIX_PROXY_PORT = String(testPort);
-  process.env.CACHE_FIX_PROXY_BIND = "127.0.0.1";
-  const mod = await import("../proxy/server.mjs");
-  server = mod.server;
-  await new Promise((resolve) => {
-    if (server.listening) resolve();
-    else server.on("listening", resolve);
-  });
-  proxyPort = server.address().port;
-}
 
 function request(method, path, body) {
   return new Promise((resolve, reject) => {
@@ -38,11 +26,15 @@ function request(method, path, body) {
 
 describe("proxy server", () => {
   before(async () => {
-    await startProxy();
+    // Port 0 → OS-assigned ephemeral port. Avoids the prior random-port
+    // collision risk on parallel test runs and exercises the new factory's
+    // resolved-port plumbing.
+    handle = await startProxy({ port: 0, watch: false });
+    proxyPort = handle.port;
   });
 
-  after((_, done) => {
-    server.close(done);
+  after(async () => {
+    await handle.close();
   });
 
   it("GET /health returns 200 with status ok", async () => {


### PR DESCRIPTION
## Summary

Expose `createProxyServer()` and `startProxy(options)` from `proxy/server.mjs` so the cache-fix proxy can be embedded in another Node/Bun process instead of being spawned as a child via the `cache-fix-proxy` bin. The CLI entrypoint (`node proxy/server.mjs`, used by the `server` subcommand and the v3.x wrapper fork path) is preserved — auto-listen is gated behind an `import.meta.url` main-module check, so library imports have no side effects.

## Motivation

We want to ship a Bun-compiled agent binary that runs the cache-fix proxy in the same process, instead of forking a Node child. Today this isn't possible because:

1. `package.json` `exports` is the string `"./preload.mjs"`, which makes `claude-code-cache-fix/proxy/server` an `ERR_PACKAGE_PATH_NOT_EXPORTED`.
2. `proxy/server.mjs` calls `server.listen()` and registers `SIGTERM`/`SIGINT` handlers at module load, so a bare `import` binds a port and `process.exit`s on signals — incompatible with embedding.

## Changes

- **`proxy/server.mjs`**
  - New `createProxyServer()` — builds the `http.Server` with the request handler wired in. Not listening, pipeline not loaded. Useful for tests and for callers that want to manage the lifecycle themselves.
  - New `async startProxy(options?)` — convenience that loads the extension pipeline, optionally starts the file watcher, and listens. Returns `{ server, port, address, close }`. Options:
    - `port` (default: env `CACHE_FIX_PROXY_PORT` / `9801`; pass `0` for an OS-assigned port)
    - `bind` (default: env / `127.0.0.1`)
    - `extensionsDir` / `extensionsConfig` (default: env / package paths)
    - `watch` (default: `true`; pass `false` to skip `fs.watch` for embedded / compiled-binary use)
  - Auto-listen + signal handlers are now gated behind `import.meta.url === pathToFileURL(process.argv[1]).href`, so they run when invoked as a script but not when imported as a library. The CLI bootstrap uses `startProxy()` so both paths share the same code.

- **`package.json`**
  - `exports` changed from `"./preload.mjs"` (string) to an object map:
    \`\`\`json
    {
      ".": "./preload.mjs",
      "./proxy/server": "./proxy/server.mjs"
    }
    \`\`\`
  - Root import (`import "claude-code-cache-fix"`) is unchanged.

- **`test/proxy-server.test.mjs`** — updated to use `startProxy({ port: 0 })`. Previously relied on auto-listen-on-import + a hand-rolled random-port picker; the new flow exercises the factory and removes port-collision risk.

- **`test/proxy-server-embeddable.test.mjs`** — new. Covers:
  - `createProxyServer()` returns a non-listening `http.Server`
  - `startProxy({ port: 0 })` resolves with the OS-assigned port
  - Two embedded instances coexist on different ports
  - `close()` releases the port for reuse

## Backwards compatibility

- `node proxy/server.mjs` — unchanged behavior (still self-listens, still prints `proxy listening on <addr>:<port>`, still shuts down on SIGTERM/SIGINT). The `cache-fix-proxy server` subcommand and the wrapper's `fork(SERVER_PATH)` path both rely on this and continue to work.
- Root import `import "claude-code-cache-fix"` — unchanged (still resolves to `preload.mjs`).
- All existing extension behavior, env vars, and config paths — unchanged.

## Test plan

- [x] Full suite: \`npm test\` — 792 pass, 1 skipped (pre-existing), 0 fail
- [x] CLI entrypoint smoke test: \`node proxy/server.mjs\` self-listens, responds to \`GET /health\`, shuts down cleanly on \`SIGTERM\`
- [x] Consumer install test: \`npm pack\` → install tarball in an unrelated project → \`import { startProxy } from "claude-code-cache-fix/proxy/server"\` → bind port 0 → \`GET /health\` → \`close()\` — all work end-to-end
- [x] Root import unchanged: \`import "claude-code-cache-fix"\` still exports the same 36 preload symbols

## Context

We're the Crunchloop DAP team (credited in the README's Contributors section for prior debug work on v1.5.1 / v1.6.2). We just bumped our devcontainer past CC v2.1.113, which makes the `NODE_OPTIONS=--import` preload a no-op on the Bun-compiled CLI, and we're migrating to the v3 proxy. Our broader goal is to Bun-compile our agent into a single binary, which is why in-process hosting matters: it avoids shipping Node alongside the binary just to fork a proxy.

Happy to adjust API shape, naming, or split this further if preferred.