### PR TITLE
docs(readme): note diagnostic slash-command context bleed (#49335)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,18 @@ If you've seen the `autoCompactWindow: 1000000` setting recommended elsewhere: i
 
 If you set this flag, CC strips any tool field outside `["name", "description", "input_schema", "cache_control"]` from outgoing requests. Custom tools relying on `defer_loading` or `eager_input_streaming` will silently lose those fields and behave differently. Worth knowing before turning the flag on.
 
+## Known CC behaviors that affect cache cost
+
+These aren't bugs cache-fix patches — they're upstream CC behaviors users should be aware of when sizing their session cost.
+
+### Diagnostic slash commands inflate conversation history ([#49335](https://github.com/anthropics/claude-code/issues/49335), [#61907](https://github.com/anthropics/claude-code/issues/61907))
+
+Running `/context`, `/release-notes`, or `/mcp` appends the diagnostic output to conversation history rather than rendering terminal-only. Subsequent turns replay the inflated payload via prompt cache, compounding token cost on a state-inspection action that should be free. Empirically observed at ~3-5K tokens per `/context` invocation (more for `/release-notes`, which defaults to dumping the full changelog).
+
+Worse for diagnosis: the inflated payload that bills against your cache isn't written to the local JSONL transcript, so you can't audit the cost source locally — you can only infer it from `cache_creation_input_tokens` jumps in response usage metadata.
+
+**Workaround until upstream fix:** use these commands sparingly in long sessions. If you need them frequently in a session, consider `/compact` after a diagnostic run to reset the bleed.
+
 ## Quick Start: Preload (CC v2.1.112 and earlier)
 
 If you're on a Node.js-based CC version (v2.1.112 or earlier), the preload interceptor works without a proxy:

--- a/README.md
+++ b/README.md
@@ -246,11 +246,11 @@ If you set this flag, CC strips any tool field outside `["name", "description", 
 
 These aren't bugs cache-fix patches — they're upstream CC behaviors users should be aware of when sizing their session cost.
 
-### Diagnostic slash commands inflate conversation history ([#49335](https://github.com/anthropics/claude-code/issues/49335), [#61907](https://github.com/anthropics/claude-code/issues/61907))
+### Diagnostic slash commands inflate conversation history ([#49335](https://github.com/anthropics/claude-code/issues/49335))
 
-Running `/context`, `/release-notes`, or `/mcp` appends the diagnostic output to conversation history rather than rendering terminal-only. Subsequent turns replay the inflated payload via prompt cache, compounding token cost on a state-inspection action that should be free. Empirically observed at ~3-5K tokens per `/context` invocation (more for `/release-notes`, which defaults to dumping the full changelog).
+Running `/context`, `/release-notes` (and likely other state-inspection commands) appends the diagnostic output to conversation history rather than rendering terminal-only. Subsequent turns replay the inflated payload via prompt cache, compounding token cost on a state-inspection action that should be free. Empirically measured at +3,480 `cache_creation_input_tokens` for a single `/context` invocation on v2.1.148; another user reports ~5K on a separate session. `/release-notes` is worse — defaults to dumping the full changelog.
 
-Worse for diagnosis: the inflated payload that bills against your cache isn't written to the local JSONL transcript, so you can't audit the cost source locally — you can only infer it from `cache_creation_input_tokens` jumps in response usage metadata.
+Worse for diagnosis: the inflated payload that bills against your cache isn't written to the local JSONL transcript, so you can't audit the cost source locally — you can only infer it from `cache_creation_input_tokens` jumps in response usage metadata. (Proxy-mode users can inspect the deltas in `~/.claude/quota-status/` files, which the proxy writes directly from response headers.)
 
 **Workaround until upstream fix:** use these commands sparingly in long sessions. If you need them frequently in a session, consider `/compact` after a diagnostic run to reset the bleed.
 

--- a/docs/code-reviews/pr-142-readme-slash-cmd-bleed-note-codex-review-2026-05-25.md
+++ b/docs/code-reviews/pr-142-readme-slash-cmd-bleed-note-codex-review-2026-05-25.md
@@ -1,0 +1,29 @@
+# Review: PR 142 README slash-command bleed note
+
+Date: 2026-05-25
+Reviewed: PR #142 / `README.md` / commit `b33e3efc2f212f2f890e2a6e228bf28e60eec967`
+Label applied: approved-by-codex-agent
+
+## What Is Correct
+
+- Placement is right. This warning belongs with the existing operational guidance in `README.md`, not in the preload quick-start path.
+- The current wording is appropriately scoped to the evidence. It anchors on `#49335` for `/context` and `/release-notes`, and it now treats the broader command class as a qualified inference rather than asserting `/mcp` as a confirmed case.
+- The factual content holds up against upstream sources: `/context` inflation is independently reported in `anthropics/claude-code#49335` and `#61907`, `/release-notes` has a direct report in `#44808`, and the README's `+3,480` measured delta plus separate `~5K` anecdote match the issue history.
+- The local-audit warning is directionally correct, and the proxy-mode pointer to `~/.claude/quota-status/` adds useful repo-specific guidance instead of leaving readers with a dead-end diagnosis note.
+
+## Blockers
+
+None
+
+## What Needs Attention
+
+- The `~5K` anecdote is no longer directly linked in the README text now that `#61907` was removed, but it remains supported by the upstream duplicate issue and related discussion. Not blocking for a short README note.
+
+## Recommendations
+
+- Approve and merge as-is.
+- If this section expands later, consider adding a `See also` link to `anthropics/claude-code#44808` so `/release-notes` has a command-specific upstream reference alongside the canonical `#49335` thread.
+
+## Bottom Line
+
+Ship it. This is a proportional README-only warning, the placement is right, and the text is materially accurate without overclaiming beyond what the upstream evidence supports.


### PR DESCRIPTION
## Directive

Add a 'Known CC behaviors that affect cache cost' section to the README flagging that diagnostic slash commands (`/context`, `/release-notes`, `/mcp`) inflate conversation history with their rendered output. The inflation replays via prompt cache on subsequent turns and isn't visible in the local JSONL transcript — only in upstream `cache_creation_input_tokens` jumps.

## Motivation

Tracks two open upstream issues:
- anthropics/claude-code#49335 (filed by @tumes 2026-04-16, still open)
- anthropics/claude-code#61907 (filed by @LostBeard 2026-05-23, duplicate of #49335)

Empirically validated on a v2.1.148 install: an isolated `/context` invocation correlates with +3,480 `cache_creation_input_tokens` on the next assistant turn. Local JSONL stores only the 134-byte command-name marker — the payload that bills against the cache isn't in the saved transcript, so users can't audit the cost source locally.

This is the kind of behavior cache-fix users hit in long sessions and don't realize is happening. The README addition gives them a workaround (use sparingly, `/compact` after diagnostic runs) until upstream fixes the routing.

## Scope

- README-only change (no code, no test impact)
- New section under existing 'Recommended CC operational config' area (sibling section before 'Quick Start: Preload')
- 12 lines added, 0 removed
- Cross-references the two upstream issue numbers

## Review notes

Categorical observation worth flagging for Proxy Builder's consideration but **not** included in this PR: cache-fix could potentially detect `/context`-shaped inflation server-side (via prompt-cache `cache_creation_input_tokens` delta correlated with session-state transitions) and surface it as a warning. Out of scope for a docs PR; flagging here so the idea isn't lost.

— AI Team Lead