### PR TITLE
statusline: autoselect d/h vs h/m, name time-unit constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ The interceptor can only *help* or *do nothing*. It cannot make things worse.
 Both modes write quota state on every API call. Proxy mode (v3.5.0+) splits into `~/.claude/quota-status/account.json` (account-global fields: Q5h/Q7d, status, overage) plus `~/.claude/quota-status/sessions/<id>.json` (per-session cache fields: TTL tier, hit rate). Preload mode keeps the legacy `~/.claude/quota-status.json` (single-session by construction). The included `tools/quota-statusline.sh` script displays a live status line showing:
 
 - **Q5h** quota bar `[███░┃░░░░░]` + percent + `(exhaust X, reset Y)`. Filled cells are consumed quota; the heavy-vertical tick is wall-clock elapsed position in the window. Tick to the right of the fill = under pace; tick inside the fill = burning faster than time (over pace). `exhaust` is the projected time-to-100% at the current burn rate; `reset` is the wall-clock time until the window rolls over. When `exhaust < reset`, you will hit 100% before the window resets — back off.
-- **Q7d** same shape with day-scale durations (e.g. `(exhaust 3d 13h, reset 3d 0h)`).
+- **Q7d** same shape with day-scale durations (e.g. `(exhaust 3d13h, reset 3d0h)`). Below a day, the suffix auto-switches to `h/m` format (e.g. `(exhaust 1h41m, reset 0h30m)`).
 - **TTL tier** — `TTL:1h` when healthy, **`TTL:5m` in red when the server has downgraded you** (typically at Q5h ≥ 100%)
 - **PEAK** in yellow during weekday peak hours (13:00–19:00 UTC)
 - **Cache hit rate %**
@@ -367,10 +367,10 @@ Both modes write quota state on every API call. Proxy mode (v3.5.0+) splits into
 Example line (mid-window, healthy state):
 
 ```
-Q5h [███░┃░░░░░] 30% (exhaust 4h40m, reset 3h00m) | Q7d [█████┃░░░░] 53% (exhaust 3d 13h, reset 3d 0h) | TTL:1h 98.3%
+Q5h [███░┃░░░░░] 30% (exhaust 4h40m, reset 3h00m) | Q7d [█████┃░░░░] 53% (exhaust 3d13h, reset 3d0h) | TTL:1h 98.3%
 ```
 
-The `(exhaust …, reset …)` suffix is dropped piecewise when projection isn't meaningful: at 0% (fresh window) and 100% (already exhausted) only `reset` is shown; in the first minute (Q5h) or six minutes (Q7d) after window start the burn rate isn't stable enough to project, so `exhaust` is held back until then; a stale `resets_at` (the server-reported value sits in the past, before the next API call refreshes it) drops both.
+The `(exhaust …, reset …)` suffix is dropped piecewise when projection isn't meaningful: at 0% (fresh window) and 100% (already exhausted) only `reset` is shown; in the first 5 minutes after window start the burn rate isn't stable enough to project (a single early call dominates the rate), so `exhaust` is held back until then on both Q5h and Q7d; a stale `resets_at` (the server-reported value sits in the past, before the next API call refreshes it) drops both.
 
 The bar uses Unicode block characters (`█┃░`) — most modern terminals render these correctly. If your terminal substitutes boxes or replacement glyphs, configure a Unicode-capable font (any DejaVu, Fira, Iosevka, JetBrains Mono, etc.).
 

--- a/docs/code-reviews/pr-143-statusline-time-bar-rereview-2026-05-24.md
+++ b/docs/code-reviews/pr-143-statusline-time-bar-rereview-2026-05-24.md
@@ -1,0 +1,28 @@
+# Review: PR #143 statusline time bar
+
+Date: 2026-05-24
+Reviewed: README.md, test/quota-statusline-smoke.test.mjs
+Label applied: approved-by-codex-agent
+
+## What Is Correct
+
+- `README.md:361,370,373` now matches the statusline contract shipped by `tools/quota-statusline.sh`: the Q7d examples use the compact `3d13h` / `3d0h` form, the sample line matches that tokenization, and the warmup text now documents the shared 5-minute projection gate with the right rationale.
+- `test/quota-statusline-smoke.test.mjs:333-348` adds the missing contract coverage for the unified `BURN_WARMUP_SEC=300` behavior. This closes the gap from the prior review because `100s` elapsed would have passed the old Q5h `60s` gate but must still suppress `exhaust` under the new shared warmup.
+- The previously added format coverage remains coherent with the doc change: `test/quota-statusline-smoke.test.mjs:313-327` still pins the under-one-day Q7d `h/m` fallback, and the README now explains that fallback explicitly.
+- Verification at `630c55b` is clean. I reran `node --test test/quota-statusline-smoke.test.mjs` and it passed `17/17`. I also reran the full `npm test` suite and it passed `833/833`, including the earlier `dispatch back-compat: --proxy-port + claude-arg passes through to wrapper mode` test.
+
+## Blockers
+
+None
+
+## What Needs Attention
+
+None
+
+## Recommendations
+
+- Merge when the other required reviews are satisfied.
+
+## Bottom Line
+
+Approve. The only blocking issue from the prior review was README contract drift, and that is now resolved in-tree. The added T16 test is a good follow-through because it proves the new warmup policy instead of only describing it.

--- a/docs/code-reviews/pr-143-statusline-time-bar-review-2026-05-24.md
+++ b/docs/code-reviews/pr-143-statusline-time-bar-review-2026-05-24.md
@@ -1,0 +1,28 @@
+# Review: PR #143 statusline time bar
+
+Date: 2026-05-24
+Reviewed: tools/quota-statusline.sh, test/quota-statusline-smoke.test.mjs
+Label applied: changes-requested
+
+## What Is Correct
+
+- `tools/quota-statusline.sh` now centralizes duration rendering in a single `fmt_time()` helper, which keeps Q5h on the existing `h/m` shape while fixing the Q7d `< 1 day` case that previously surfaced as `0d13h`.
+- The shared `BURN_WARMUP_SEC = 5 * SECS_PER_MIN` gate is implemented consistently for both windows, which matches the stated goal of a single 5-minute warmup policy instead of separate 1-minute and 6-minute thresholds.
+- The smoke coverage is materially better. `test/quota-statusline-smoke.test.mjs` updates the existing format assertions for the compact `d/h` output and adds `T15` to pin the under-one-day Q7d rendering path.
+- I reran `node --test test/quota-statusline-smoke.test.mjs` locally; all 16 tests passed. A broader `npm test` run surfaced an unrelated existing failure in `dispatch back-compat: --proxy-port + claude-arg passes through to wrapper mode`, so I did not treat the full-suite result as a signal on this PR.
+
+## Blockers
+
+- `tools/quota-statusline.sh:107-110,135-143,180-181` and `test/quota-statusline-smoke.test.mjs:189-203,278-290,313-329` intentionally move the public statusline contract, but `README.md:361,370,373` still documents the old one. The shipped README still shows `3d 13h` / `3d 0h` examples and still says `exhaust` is suppressed for the first minute (Q5h) or six minutes (Q7d), while the implementation now emits `3d13h` / `3d0h` and uses one shared 5-minute warmup. Because this script's output is a documented user-facing surface, merging the code/test change without updating the README leaves the primary docs wrong on day one.
+
+## What Needs Attention
+
+- None beyond the README drift above.
+
+## Recommendations
+
+- Update the statusline section in `README.md` in the same PR: change the Q7d examples to the compact `d/h` format, refresh the full sample line, and rewrite the warmup explanation to describe the unified 5-minute gate.
+
+## Bottom Line
+
+Revise before approval. The implementation itself looks coherent and the targeted smoke coverage is good, but the PR currently changes a documented user-visible contract without updating the documentation that publishes that contract.

--- a/test/quota-statusline-smoke.test.mjs
+++ b/test/quota-statusline-smoke.test.mjs
@@ -192,7 +192,7 @@ test("T8 (format). under-pace: tick past fill; `exhaust` and `reset` both shown"
     // 5h: 30% used, 2h elapsed of 5h = 40% elapsed (tick at idx 4).
     //     exhaust = 70 * 7200 / 30 = 16800s = 4h40m; reset = 3h00m.
     // 7d: 53% used, 4d elapsed of 7d ≈ 57% elapsed (tick at idx 5).
-    //     exhaust = 47 * 345600 / 53 ≈ 306475s = 3d 13h; reset = 3d 0h.
+    //     exhaust = 47 * 345600 / 53 ≈ 306475s = 3d13h; reset = 3d0h.
     writeFileSync(env.account, formatAccount({
       q5hPct: 30, q5hOffsetSec: 3 * 3600,
       q7dPct: 53, q7dOffsetSec: 3 * 86400,
@@ -200,7 +200,7 @@ test("T8 (format). under-pace: tick past fill; `exhaust` and `reset` both shown"
     const r = runScript(env.home, '{"session_id":"x"}');
     assert.equal(r.status, 0, r.stderr);
     assert.match(r.stdout, /Q5h \[███░┃░░░░░\] 30% \(exhaust 4h40m, reset 3h00m\)/);
-    assert.match(r.stdout, /Q7d \[█████┃░░░░\] 53% \(exhaust 3d 13h, reset 3d 0h\)/);
+    assert.match(r.stdout, /Q7d \[█████┃░░░░\] 53% \(exhaust 3d13h, reset 3d0h\)/);
   } finally {
     env.cleanup();
   }
@@ -269,7 +269,7 @@ test("T12 (format). quota at 0% (fresh window): exhaust dropped, reset shown", (
     assert.equal(r.status, 0, r.stderr);
     assert.doesNotMatch(r.stdout, /\bexhaust\b/);
     assert.match(r.stdout, /Q5h \[┃░░░░░░░░░\] 0% \(reset 5h00m\)/);
-    assert.match(r.stdout, /Q7d \[┃░░░░░░░░░\] 0% \(reset 7d 0h\)/);
+    assert.match(r.stdout, /Q7d \[┃░░░░░░░░░\] 0% \(reset 7d0h\)/);
   } finally {
     env.cleanup();
   }
@@ -278,7 +278,7 @@ test("T12 (format). quota at 0% (fresh window): exhaust dropped, reset shown", (
 test("T13 (format). elapsed below min: exhaust dropped (noisy projection), reset shown", () => {
   const env = setupHome();
   try {
-    // Q5h elapsed = 30s (below 60s gate). Q7d elapsed = 120s (below 360s gate).
+    // Q5h elapsed = 30s, Q7d elapsed = 120s — both below the 300s burn-warmup gate.
     writeFileSync(env.account, formatAccount({
       q5hPct: 2, q5hOffsetSec: 5 * 3600 - 30,
       q7dPct: 1, q7dOffsetSec: 7 * 86400 - 120,
@@ -287,7 +287,7 @@ test("T13 (format). elapsed below min: exhaust dropped (noisy projection), reset
     assert.equal(r.status, 0, r.stderr);
     assert.doesNotMatch(r.stdout, /\bexhaust\b/);
     assert.match(r.stdout, /Q5h \[.{10}\] 2% \(reset 4h59m\)/);
-    assert.match(r.stdout, /Q7d \[.{10}\] 1% \(reset 6d 23h\)/);
+    assert.match(r.stdout, /Q7d \[.{10}\] 1% \(reset 6d23h\)/);
   } finally {
     env.cleanup();
   }
@@ -304,7 +304,27 @@ test("T14 (format). quota at 100% (already exhausted): exhaust dropped, reset sh
     assert.equal(r.status, 0, r.stderr);
     assert.doesNotMatch(r.stdout, /\bexhaust\b/);
     assert.match(r.stdout, /Q5h \[.{10}\] 100% \(reset 1h00m\)/);
-    assert.match(r.stdout, /Q7d \[.{10}\] 100% \(reset 1d 0h\)/);
+    assert.match(r.stdout, /Q7d \[.{10}\] 100% \(reset 1d0h\)/);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("T15 (format). Q7d autoselect: durations under a day render as h/m, not 0d Xh", () => {
+  const env = setupHome();
+  try {
+    // Q7d 99% used, reset 30 min away → elapsed ≈ 6d 23h 30m, secs_left = 1800.
+    //   exhaust = 1 * 603000 / 99 ≈ 6091s = 1h41m (days==0 → h/m fallback)
+    //   reset   = 1800s = 0h30m                    (days==0 → h/m fallback)
+    writeFileSync(env.account, formatAccount({
+      q5hPct: 0, q5hOffsetSec: 5 * 3600,
+      q7dPct: 99, q7dOffsetSec: 1800,
+    }));
+    const r = runScript(env.home, '{"session_id":"x"}');
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /Q7d \[.{10}\] 99% \(exhaust 1h41m, reset 0h30m\)/);
+    // Belt and suspenders: no `0d` token should appear when days collapse to 0.
+    assert.doesNotMatch(r.stdout, /0d/);
   } finally {
     env.cleanup();
   }

--- a/test/quota-statusline-smoke.test.mjs
+++ b/test/quota-statusline-smoke.test.mjs
@@ -330,6 +330,27 @@ test("T15 (format). Q7d autoselect: durations under a day render as h/m, not 0d 
   }
 });
 
+test("T16 (format). burn-warmup gate: 100s elapsed (between legacy 60s gate and new 300s gate) suppresses exhaust", () => {
+  const env = setupHome();
+  try {
+    // Pins the unified BURN_WARMUP_SEC=300 against the prior per-window asymmetry
+    // (Q5h=60s, Q7d=360s). At 100s elapsed with 20% Q5h used, the legacy 60s gate
+    // would have projected an exhaust; the new 300s gate correctly suppresses.
+    // T13's 30s elapsed passes both old and new gates, so without T16 the gate
+    // value isn't actually contract-tested.
+    writeFileSync(env.account, formatAccount({
+      q5hPct: 20, q5hOffsetSec: 5 * 3600 - 100,   // elapsed = 100s
+      q7dPct: 1,  q7dOffsetSec: 7 * 86400 - 60,   // elapsed = 60s, also below gate
+    }));
+    const r = runScript(env.home, '{"session_id":"x"}');
+    assert.equal(r.status, 0, r.stderr);
+    assert.doesNotMatch(r.stdout, /\bexhaust\b/);
+    assert.match(r.stdout, /Q5h \[.{10}\] 20% \(reset 4h58m\)/);
+  } finally {
+    env.cleanup();
+  }
+});
+
 test("T6 (security #108). triple-quote injection payload does NOT execute — heredoc isolation intact", () => {
   // Regression for cnighswonger/claude-code-cache-fix#108: pre-v3.5.2,
   // tools/quota-statusline.sh interpolated stdin into a Python triple-quoted

--- a/tools/quota-statusline.sh
+++ b/tools/quota-statusline.sh
@@ -98,6 +98,17 @@ ts = sess.get('timestamp') or acc.get('timestamp', '')
 
 now = datetime.fromisoformat(ts.replace('Z', '+00:00')) if ts else datetime.now(timezone.utc)
 
+SECS_PER_MIN = 60
+MINS_PER_HR = 60
+HRS_PER_DAY = 24
+SECS_PER_HR = SECS_PER_MIN * MINS_PER_HR
+SECS_PER_DAY = SECS_PER_HR * HRS_PER_DAY
+
+# Minimum elapsed time in a window before we'll project an exhaust ETA from
+# its burn rate. Below this the rate is dominated by a single early call and
+# the projection is noise.
+BURN_WARMUP_SEC = 5 * SECS_PER_MIN
+
 BAR_WIDTH = 10
 
 def draw_bar(consumed_pct, elapsed_pct, width=BAR_WIDTH):
@@ -121,15 +132,15 @@ def draw_bar(consumed_pct, elapsed_pct, width=BAR_WIDTH):
             cells.append('░')
     return '[' + ''.join(cells) + ']'
 
-def fmt_hm(secs):
+def fmt_time(secs):
+    # Autoselect scale: `{D}d{H}h` for >=1 day, `{H}h{MM}m` below that.
+    # One formatter so the Q5h (always h/m) and Q7d (h/m or d/h depending on
+    # how close to reset) callers don't need to pick.
     if secs is None or secs <= 0:
         return ''
-    return '{}h{:02d}m'.format(int(secs // 3600), int((secs % 3600) // 60))
-
-def fmt_dh(secs):
-    if secs is None or secs <= 0:
-        return ''
-    return '{}d {}h'.format(int(secs // 86400), int((secs % 86400) // 3600))
+    if secs >= SECS_PER_DAY:
+        return '{}d{}h'.format(int(secs // SECS_PER_DAY), int((secs % SECS_PER_DAY) // SECS_PER_HR))
+    return '{}h{:02d}m'.format(int(secs // SECS_PER_HR), int((secs % SECS_PER_HR) // SECS_PER_MIN))
 
 def window_view(reset_ts, window_secs):
     # Returns (elapsed_sec, secs_left). elapsed_sec may be negative (server
@@ -150,7 +161,7 @@ def time_to_exhaust_sec(pct, elapsed_sec, min_elapsed_sec):
         return None
     return (100 - pct) * elapsed_sec / pct
 
-def format_window(name, pct, elapsed_sec, window_secs, secs_left, fmt_time, min_elapsed_sec):
+def format_window(name, pct, elapsed_sec, window_secs, secs_left, min_elapsed_sec):
     ep = None if elapsed_sec is None or elapsed_sec < 0 else elapsed_sec / window_secs * 100
     extras = []
     stale = secs_left is not None and secs_left <= 0
@@ -163,11 +174,11 @@ def format_window(name, pct, elapsed_sec, window_secs, secs_left, fmt_time, min_
     tail = ' (' + ', '.join(extras) + ')' if extras else ''
     return '{} {} {}%{}'.format(name, draw_bar(pct, ep), pct, tail)
 
-elapsed_5h, left_5h = window_view(q5h_reset, 5 * 3600)
-elapsed_7d, left_7d = window_view(q7d_reset, 7 * 86400)
+elapsed_5h, left_5h = window_view(q5h_reset, 5 * SECS_PER_HR)
+elapsed_7d, left_7d = window_view(q7d_reset, 7 * SECS_PER_DAY)
 
-label = format_window('Q5h', q5h, elapsed_5h, 5 * 3600, left_5h, fmt_hm, 60)
-label += ' | ' + format_window('Q7d', q7d, elapsed_7d, 7 * 86400, left_7d, fmt_dh, 360)
+label = format_window('Q5h', q5h, elapsed_5h, 5 * SECS_PER_HR, left_5h, BURN_WARMUP_SEC)
+label += ' | ' + format_window('Q7d', q7d, elapsed_7d, 7 * SECS_PER_DAY, left_7d, BURN_WARMUP_SEC)
 if overage == 'active':
     label += ' | OVERAGE'
 


### PR DESCRIPTION
Hey @cnighswonger , a tiny update to the recent statusbar changes:

- better time formatting: autoswitch between d-h and h-m display, and be consistent about spacing
- a consistent 5m burn warmup period before showing burn rates
- use named constants instead of int literals

The user-visible changes are `3d 13h` -> `3d13h` and `0d13h` -> `13h25m`.