### PR TITLE
statusline: round bar tick like fill

### DIFF
--- a/docs/code-reviews/pr155-statusline-bar-tick-codex-review-2026-05-28.md
+++ b/docs/code-reviews/pr155-statusline-bar-tick-codex-review-2026-05-28.md
@@ -1,0 +1,23 @@
+# Review: statusline bar-tick rounding
+
+Date: 2026-05-28
+Reviewed: PR #155 (`tools/quota-statusline.sh`, `test/quota-statusline-smoke.test.mjs`)
+Label applied: changes-requested
+
+## What Is Correct
+- The patch targets the reported regression directly: T17 reproduces the 15% consumed / 19.64% elapsed case and the shared cell conversion moves the tick back to the fill boundary.
+- The T8 expectation change is internally consistent with the new cell mapping, and the requested smoke suite still passes on the PR branch (`node --test test/quota-statusline-smoke.test.mjs`: 18/18).
+- Bounds handling remains safe: both percentages are clamped to `[0, 100]`, and the tick is still clamped to the 10-cell bar.
+
+## Blockers
+- `draw_bar()` now uses `round()` for both fill and tick in `tools/quota-statusline.sh:118-124`, but under `python3` that is banker's rounding, not always-up `.5` rounding. That collapses some genuine over-pace states back to the boundary instead of keeping the tick inside the filled run. Reproducer: `consumed_pct=25`, `elapsed_pct=15` now renders `[██┃░░░░░░░]` because `round(2.5) == 2` and `round(1.5) == 2`, while the previous logic rendered `[█┃█░░░░░░░]`. The same loss of signal appears at 45/35 and 65/55. Since the bar's stated purpose is to preserve the under-pace vs over-pace read, this is a behavioral regression, not just a cosmetic shift. The updated tests in `test/quota-statusline-smoke.test.mjs:209-223` and `:354-369` do not cover an exact `.5` over-pace boundary, so the regression currently passes unnoticed.
+
+## What Needs Attention
+- `draw_bar()` still cannot represent the right-edge boundary once `fill == width`; equal high-end cases such as 95%/95% still place the tick at index 9 because of the `width - 1` clamp. That is pre-existing rather than introduced here, but if the bar semantics are being tightened it is worth keeping explicit in comments or tests.
+
+## Recommendations
+- Replace `round()` with an explicit half-up cell conversion, or keep symmetric rounding but post-adjust the relationship so `consumed_pct > elapsed_pct` still forces `tick < fill` whenever there is room inside the bar.
+- Add a regression test for an exact `.5` over-pace boundary, for example 25% consumed with 45 minutes elapsed in Q5h (15% elapsed), so the intended warning signal is contract-tested.
+
+## Bottom Line
+Revise before merge. This patch fixes the reported community bug, but the current implementation trades it for false-neutral readings on exact half-cell over-pace cases because Python's rounding semantics are not the ones the patch rationale assumes.

--- a/test/quota-statusline-smoke.test.mjs
+++ b/test/quota-statusline-smoke.test.mjs
@@ -191,7 +191,7 @@ test("T8 (format). under-pace: tick past fill; `exhaust` and `reset` both shown"
   try {
     // 5h: 30% used, 2h elapsed of 5h = 40% elapsed (tick at idx 4).
     //     exhaust = 70 * 7200 / 30 = 16800s = 4h40m; reset = 3h00m.
-    // 7d: 53% used, 4d elapsed of 7d ≈ 57% elapsed (tick at idx 5).
+    // 7d: 53% used, 4d elapsed of 7d ≈ 57.1% elapsed (tick at idx 6).
     //     exhaust = 47 * 345600 / 53 ≈ 306475s = 3d13h; reset = 3d0h.
     writeFileSync(env.account, formatAccount({
       q5hPct: 30, q5hOffsetSec: 3 * 3600,
@@ -200,7 +200,7 @@ test("T8 (format). under-pace: tick past fill; `exhaust` and `reset` both shown"
     const r = runScript(env.home, '{"session_id":"x"}');
     assert.equal(r.status, 0, r.stderr);
     assert.match(r.stdout, /Q5h \[███░┃░░░░░\] 30% \(exhaust 4h40m, reset 3h00m\)/);
-    assert.match(r.stdout, /Q7d \[█████┃░░░░\] 53% \(exhaust 3d13h, reset 3d0h\)/);
+    assert.match(r.stdout, /Q7d \[█████░┃░░░\] 53% \(exhaust 3d13h, reset 3d0h\)/);
   } finally {
     env.cleanup();
   }
@@ -346,6 +346,27 @@ test("T16 (format). burn-warmup gate: 100s elapsed (between legacy 60s gate and 
     assert.equal(r.status, 0, r.stderr);
     assert.doesNotMatch(r.stdout, /\bexhaust\b/);
     assert.match(r.stdout, /Q5h \[.{10}\] 20% \(reset 4h58m\)/);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("T17 (format). under-pace at rounding boundary: tick must not flip into fill", () => {
+  // Regression for a field report:
+  //   Q7d [█┃█░░░░░░░] 15% (exhaust 7d15h, reset 5d15h)
+  // 15% consumed, 1d9h elapsed of 7d (= 19.64% elapsed) is clearly under-pace
+  // (exhaust > reset), yet the bar drew ┃ inside the filled run. Cause:
+  // fill = int(round(1.5)) = 2 but tick = int(1.964) = 1 — round vs. truncate.
+  // With symmetric rounding both land on 2 and ┃ sits at the fill boundary.
+  const env = setupHome();
+  try {
+    writeFileSync(env.account, formatAccount({
+      q5hPct: 0, q5hOffsetSec: 5 * 3600,
+      q7dPct: 15, q7dOffsetSec: 5 * 86400 + 15 * 3600,
+    }));
+    const r = runScript(env.home, '{"session_id":"x"}');
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /Q7d \[██┃░░░░░░░\] 15%/);
   } finally {
     env.cleanup();
   }

--- a/tools/quota-statusline.sh
+++ b/tools/quota-statusline.sh
@@ -115,11 +115,13 @@ def draw_bar(consumed_pct, elapsed_pct, width=BAR_WIDTH):
     # Tick overlays a fill cell when consumed > elapsed, keeping bar width
     # constant — that's what makes the over-pace state legible (┃ inside the
     # filled run) rather than just pushing fill cells around.
-    fill = int(round(max(0, min(100, consumed_pct)) / 100 * width))
+    def to_cells(pct):
+        return int(round(max(0, min(100, pct)) / 100 * width))
+    fill = to_cells(consumed_pct)
     if elapsed_pct is None:
         tick = -1
     else:
-        tick = min(int(max(0, min(100, elapsed_pct)) / 100 * width), width - 1)
+        tick = min(to_cells(elapsed_pct), width - 1)
     cells = []
     remaining = fill
     for i in range(width):


### PR DESCRIPTION
draw_bar rounded fill but truncated the tick. With consumed=15% and elapsed=19.6% that gave fill=2 and tick=1, placing the tick inside the filled run ([█┃█░░░░░░░]) — the visual reserved for over-pace. Field- reported on a clearly under-pace Q7d.

Round both: monotonicity keeps tick at-or-past fill whenever consumed <= elapsed. T17 locks the reported case; T8 shifts by one cell because the symmetric round is more accurate.

Fyi this is the last of my planned fixes on this.