### PR TITLE
Fix upstream url forming on forwardRequest

### DIFF
--- a/docs/code-reviews/pr-188-round-2-codex.md
+++ b/docs/code-reviews/pr-188-round-2-codex.md
@@ -1,0 +1,34 @@
+# Review: PR #188 Fix upstream url forming on forwardRequest
+
+Date: 2026-06-07
+Reviewed: PR #188 at `3c3fd17`
+Round: 2
+Label applied: approved-by-codex-agent
+
+## What Is Correct
+
+- `buildUpstreamUrl` in `proxy/upstream.mjs:194` is a faithful extraction of the already-reviewed `2bead94` URL-building logic: trim one trailing slash from the configured base, force a leading slash on `clientUrl`, then construct the final URL from the concatenated string. `forwardRequest` now just delegates to that helper at `proxy/upstream.mjs:202`, with no semantic change beyond the original fix.
+- The new regression table in `test/proxy-upstream-corp-proxy.test.mjs:68` covers the actual failure mode from PR #188: RFC 3986 relative resolution dropping the configured base path when the request URL is path-absolute. The cases also meaningfully pin the surrounding invariants that matter here: no-path upstreams, trailing-slash normalization, multi-segment mirror paths, preserved query strings, and non-default `http` ports.
+- Verification passed on the PR head: `node --test test/proxy-upstream-corp-proxy.test.mjs` and the full `npm test` suite both passed at `3c3fd17` (1005/1005).
+
+## Blockers
+
+None.
+
+## What Needs Attention
+
+None.
+
+## Bloat / Non-Functional
+
+None.
+
+## Recommendations
+
+- Refresh the stale Codex review state on the PR by reapplying `reviewed-by-codex-agent` and adding `approved-by-codex-agent` on the current HEAD.
+
+## Bottom Line
+
+This is a clean refresh review. The only post-approval code change is a behavior-preserving helper extraction plus focused regression coverage for the exact corp-proxy/base-path bug the PR fixes, and the full test suite stays green at `3c3fd17`.
+
+— Codex review

--- a/proxy/upstream.mjs
+++ b/proxy/upstream.mjs
@@ -185,7 +185,9 @@ function getAgent(isHTTPS, hostname) {
 
 export function forwardRequest(clientReq, body, signal) {
   return new Promise((resolve, reject) => {
-    const upstreamUrl = new URL(clientReq.url, config.upstream);
+    const base = config.upstream.endsWith('/') ? config.upstream.slice(0, -1) : config.upstream;
+    const relative = clientReq.url.startsWith('/') ? clientReq.url : '/' + clientReq.url;
+    const upstreamUrl = new URL(base + relative);
 
     const headers = buildUpstreamHeaders(clientReq.headers, upstreamUrl.hostname);
     if (body) {

--- a/proxy/upstream.mjs
+++ b/proxy/upstream.mjs
@@ -183,11 +183,23 @@ function getAgent(isHTTPS, hostname) {
   return agent;
 }
 
+// Build the upstream URL by concatenating the configured base (with any path
+// component preserved) with the client request URL. The historical
+// `new URL(clientReq.url, base)` approach is RFC 3986 relative-resolution,
+// which drops the base's path component when the relative is path-absolute
+// (`/v1/messages`). That breaks corp-proxy / mirror setups where the
+// configured upstream is `https://corp-proxy.example.net/anthropic-mirror`
+// — the request would land at `https://corp-proxy.example.net/v1/messages`
+// with `/anthropic-mirror` silently dropped. See PR #188 / @nisqatsi.
+export function buildUpstreamUrl(base, clientUrl) {
+  const trimmedBase = base.endsWith("/") ? base.slice(0, -1) : base;
+  const relative = clientUrl.startsWith("/") ? clientUrl : "/" + clientUrl;
+  return new URL(trimmedBase + relative);
+}
+
 export function forwardRequest(clientReq, body, signal) {
   return new Promise((resolve, reject) => {
-    const base = config.upstream.endsWith('/') ? config.upstream.slice(0, -1) : config.upstream;
-    const relative = clientReq.url.startsWith('/') ? clientReq.url : '/' + clientReq.url;
-    const upstreamUrl = new URL(base + relative);
+    const upstreamUrl = buildUpstreamUrl(config.upstream, clientReq.url);
 
     const headers = buildUpstreamHeaders(clientReq.headers, upstreamUrl.hostname);
     if (body) {

--- a/test/proxy-upstream-corp-proxy.test.mjs
+++ b/test/proxy-upstream-corp-proxy.test.mjs
@@ -65,6 +65,72 @@ test("selectProxyUrl: lowercase env vars are honored", async () => {
   }
 });
 
+test("buildUpstreamUrl: preserves base-path component (PR #188 regression)", async () => {
+  // The blocker @nisqatsi caught: `new URL(clientReq.url, base)` is RFC 3986
+  // relative-resolution, which drops the base's path component when the
+  // relative URL is path-absolute (`/v1/messages`). For mirror / corp-proxy
+  // setups the base path is load-bearing — losing it routes the request to
+  // the wrong host path. Table-test the fixed concatenation logic so
+  // future refactors don't regress this case.
+  const { buildUpstreamUrl } = await import("../proxy/upstream.mjs");
+
+  const cases = [
+    // [base, clientUrl, expectedHref, label]
+    [
+      "https://api.anthropic.com",
+      "/v1/messages",
+      "https://api.anthropic.com/v1/messages",
+      "no-path base behaves as before",
+    ],
+    [
+      "https://api.anthropic.com/",
+      "/v1/messages",
+      "https://api.anthropic.com/v1/messages",
+      "trailing slash on base is normalized",
+    ],
+    [
+      "https://corp-proxy.example.net/anthropic-mirror",
+      "/v1/messages",
+      "https://corp-proxy.example.net/anthropic-mirror/v1/messages",
+      "base-path preserved (the bug @nisqatsi caught)",
+    ],
+    [
+      "https://corp-proxy.example.net/anthropic-mirror/",
+      "/v1/messages",
+      "https://corp-proxy.example.net/anthropic-mirror/v1/messages",
+      "base-path preserved AND trailing slash idempotent",
+    ],
+    [
+      "https://corp-proxy.example.net/deep/nested/path",
+      "/v1/messages",
+      "https://corp-proxy.example.net/deep/nested/path/v1/messages",
+      "multi-segment base path preserved",
+    ],
+    [
+      "https://api.anthropic.com",
+      "/v1/messages?beta=true&x=y",
+      "https://api.anthropic.com/v1/messages?beta=true&x=y",
+      "query string flows through cleanly",
+    ],
+    [
+      "https://corp-proxy.example.net/mirror",
+      "/v1/messages?beta=true",
+      "https://corp-proxy.example.net/mirror/v1/messages?beta=true",
+      "query string preserved across the base-path fix",
+    ],
+    [
+      "http://localhost:9802/anthropic",
+      "/v1/messages",
+      "http://localhost:9802/anthropic/v1/messages",
+      "http + non-standard port + base-path",
+    ],
+  ];
+
+  for (const [base, clientUrl, expected, label] of cases) {
+    assert.equal(buildUpstreamUrl(base, clientUrl).href, expected, label);
+  }
+});
+
 test("forwardRequest is exported and module loads cleanly with no proxy env vars (no regression)", async () => {
   const saved = {
     HTTPS_PROXY: process.env.HTTPS_PROXY, https_proxy: process.env.https_proxy,


### PR DESCRIPTION
Upstream URL path after top-level domain was cut off by forwardRequest() on URL combining, e.g.:
```
config.upstream           clientReq.url                upstreamUrl - "/d/e" path lost
"https://a.b.c.net/d/e" + "/v1/messages?param=value" = "https://a.b.c.net/v1/messages?param=value"
```