### PR TITLE
Honor CLAUDE_CONFIG_DIR for all on-disk proxy state

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,12 @@ The shipped [`tools/quota-statusline.sh`](tools/quota-statusline.sh) is the refe
 
 On multi-agent hosts (multiple Claude Code sessions sharing one proxy), the pre-v3.5.0 single global file caused every session to overwrite the others' cache stats with each response. A statusline reading from session A would show session B's TTL tier whenever B sent a request more recently. Per-session files plus an account-global quota file resolve this without losing the easy account-wide view. See [#104](https://github.com/cnighswonger/claude-code-cache-fix/issues/104) for the original report.
 
+### `CLAUDE_CONFIG_DIR`
+
+Claude Code reads `CLAUDE_CONFIG_DIR` to relocate its config root away from the default `~/.claude` (used to keep multiple independent config roots in separate directories). The proxy now honors the same variable for **all** of its on-disk state: `quota-status/`, `usage.jsonl`, `cache-fix-state/`, session mirrors, snapshots, and OAuth events all land under `$CLAUDE_CONFIG_DIR` instead of a hardcoded `~/.claude`. When it's unset the proxy uses `~/.claude` exactly as before (no change for the common single-config case).
+
+This matters when you run **one proxy per config dir**: without it, every proxy writes to `~/.claude/quota-status/account.json` and they clobber each other's quota state. Give each proxy the same `CLAUDE_CONFIG_DIR` its Claude Code client uses, and their state stays cleanly separated.
+
 ## Image stripping (preload mode)
 
 Images read via the Read tool persist as base64 in conversation history, riding along on every subsequent API call. A single 500KB image costs ~62,500 tokens per turn on Opus 4.6, and **~85,000+ on Opus 4.7** due to the new tokenizer. Image stripping is strongly recommended on 4.7.

--- a/proxy/claude-home.mjs
+++ b/proxy/claude-home.mjs
@@ -1,0 +1,12 @@
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// The Claude Code config root. Honors CLAUDE_CONFIG_DIR, which Claude Code reads
+// to relocate its config root away from the default ~/.claude. Without this,
+// every proxy's state (quota-status, usage.jsonl, session-mirrors, snapshots,
+// oauth) is hardcoded to ~/.claude, so running one proxy per config dir makes
+// them clobber each other's account.json. Falls back to ~/.claude when unset.
+// Read live (not cached) for test isolation, mirroring config.mjs.
+export function claudeHome() {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+}

--- a/proxy/extensions/bootstrap-defense.mjs
+++ b/proxy/extensions/bootstrap-defense.mjs
@@ -1,7 +1,7 @@
 import { appendFileSync, statSync, renameSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { homedir } from "node:os";
 import { createHash } from "node:crypto";
+import { claudeHome } from "../claude-home.mjs";
 
 const LOG_ROTATE_BYTES = 5 * 1024 * 1024;
 const SCHEMA_VERSION = 2;
@@ -10,7 +10,7 @@ const EXTENSION_VERSION = "v3.7.1";
 const LEGACY_PROMPT_KEY = "tengu_heron_brook";
 
 function logPath() {
-  return process.env.CACHE_FIX_BOOTSTRAP_LOG_PATH || join(homedir(), ".claude", "cache-fix-bootstrap-log.jsonl");
+  return process.env.CACHE_FIX_BOOTSTRAP_LOG_PATH || join(claudeHome(), "cache-fix-bootstrap-log.jsonl");
 }
 
 // Single-tier rotation by design: any previous .1 gets overwritten. The audit

--- a/proxy/extensions/cache-telemetry.mjs
+++ b/proxy/extensions/cache-telemetry.mjs
@@ -8,19 +8,17 @@ import {
   statSync,
 } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { createHash, randomBytes } from "node:crypto";
 
 // Paths are resolved per call (not cached at module load) so tests can swap
-// $HOME between cases. The homedir() call is essentially free.
+// CLAUDE_CONFIG_DIR / $HOME between cases; claudeHome() reads the env live.
 function paths() {
-  const home = homedir();
-  const quotaDir = join(home, ".claude", "quota-status");
+  const quotaDir = join(claudeHome(), "quota-status");
   return {
     quotaDir,
     accountPath: join(quotaDir, "account.json"),
     sessionsDir: join(quotaDir, "sessions"),
-    legacyPath: join(home, ".claude", "quota-status.json"),
+    legacyPath: join(claudeHome(), "quota-status.json"),
   };
 }
 
@@ -52,6 +50,7 @@ const SAME_FAMILY_STICKY_THRESHOLD = 3;
 // reader that imports it from this module; new call sites should import
 // directly from `../model-families.mjs`.
 import { modelFamily } from "../model-families.mjs";
+import { claudeHome } from "../claude-home.mjs";
 export { modelFamily } from "../model-families.mjs";
 
 // Read the persisted per-session JSON's divergence fields, guarded on

--- a/proxy/extensions/deferred-tools-restore.mjs
+++ b/proxy/extensions/deferred-tools-restore.mjs
@@ -37,8 +37,8 @@ import {
   rename as _rename,
 } from "node:fs/promises";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { createHash } from "node:crypto";
+import { claudeHome } from "../claude-home.mjs";
 
 const SKIP = process.env.CACHE_FIX_SKIP_DEFERRED_TOOLS_RESTORE === "1";
 const DEBUG = process.env.CACHE_FIX_DEBUG === "1";
@@ -56,7 +56,7 @@ const DEFAULT_FS = {
 };
 
 function getSnapshotDir() {
-  return join(homedir(), ".claude", "cache-fix-state");
+  return join(claudeHome(), "cache-fix-state");
 }
 
 function debug(msg) {

--- a/proxy/extensions/image-retry-circuit-breaker.mjs
+++ b/proxy/extensions/image-retry-circuit-breaker.mjs
@@ -1,9 +1,9 @@
 import { appendFileSync, statSync, renameSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 import { imageHashesFromBody } from "../image-hash.mjs";
 import { resolveSessionId } from "./cache-telemetry.mjs";
+import { claudeHome } from "../claude-home.mjs";
 
 // Directive: docs/directives/proxy-image-retry-circuit-breaker.md (merged at d12cc05)
 // Upstream: anthropics/claude-code#66815
@@ -39,7 +39,7 @@ function maxEntries() {
 
 function logPath() {
   return process.env.CACHE_FIX_IMAGE_RETRY_LOG_PATH ||
-    join(homedir(), ".claude", "image-retry-events.jsonl");
+    join(claudeHome(), "image-retry-events.jsonl");
 }
 
 // Single-tier rotation matching bootstrap-defense's rotateIfNeeded — any

--- a/proxy/extensions/overage-warning.mjs
+++ b/proxy/extensions/overage-warning.mjs
@@ -14,9 +14,9 @@
 
 import { appendFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
-import { homedir } from "node:os";
 
 import { WEIGHTED_TOKEN_COST_USD_COARSE } from "../rates.mjs";
+import { claudeHome } from "../claude-home.mjs";
 
 // Env-gated runtime flags read on each call. Reading at module load would
 // freeze the values and make per-test isolation impossible. The check is
@@ -244,7 +244,7 @@ function checkAndMarkDedup(threshold, q5h_resets_at) {
 // --- I/O ---
 
 async function appendJsonl(record, dir) {
-  const outDir = dir || (process.env.CACHE_FIX_OVERAGE_WARNING_DIR || join(homedir(), ".claude"));
+  const outDir = dir || (process.env.CACHE_FIX_OVERAGE_WARNING_DIR || claudeHome());
   const outPath = join(outDir, "overage-warnings.jsonl");
   await mkdir(outDir, { recursive: true });
   await appendFile(outPath, JSON.stringify(record) + "\n");

--- a/proxy/extensions/prefix-diff.mjs
+++ b/proxy/extensions/prefix-diff.mjs
@@ -24,8 +24,8 @@ import {
   rename as _rename,
 } from "node:fs/promises";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { createHash } from "node:crypto";
+import { claudeHome } from "../claude-home.mjs";
 
 const ENABLED = process.env.CACHE_FIX_PREFIXDIFF === "1";
 const DEBUG = process.env.CACHE_FIX_DEBUG === "1";
@@ -38,7 +38,7 @@ const DEFAULT_FS = {
 };
 
 function getSnapshotDir() {
-  return join(homedir(), ".claude", "cache-fix-snapshots");
+  return join(claudeHome(), "cache-fix-snapshots");
 }
 
 function debug(msg) {

--- a/proxy/extensions/rate-limit-log.mjs
+++ b/proxy/extensions/rate-limit-log.mjs
@@ -34,16 +34,15 @@
 import { mkdir, appendFile } from "node:fs/promises";
 import { readdirSync, statSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { homedir } from "node:os";
+import { claudeHome } from "../claude-home.mjs";
 
-// Paths resolved per call so tests can swap $HOME between cases. The
-// homedir() call is essentially free.
+// Paths resolved per call so tests can swap CLAUDE_CONFIG_DIR / $HOME between
+// cases; claudeHome() reads the env live.
 function paths() {
-  const home = homedir();
   return {
-    logPath: join(home, ".claude", "usage-log", "rate-limit-events.jsonl"),
-    accountPath: join(home, ".claude", "quota-status", "account.json"),
-    sessionsDir: join(home, ".claude", "quota-status", "sessions"),
+    logPath: join(claudeHome(), "usage-log", "rate-limit-events.jsonl"),
+    accountPath: join(claudeHome(), "quota-status", "account.json"),
+    sessionsDir: join(claudeHome(), "quota-status", "sessions"),
   };
 }
 

--- a/proxy/extensions/upstream-change-detection.mjs
+++ b/proxy/extensions/upstream-change-detection.mjs
@@ -28,8 +28,8 @@ import {
   appendFile as _appendFile,
 } from "node:fs/promises";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { createHash, randomBytes } from "node:crypto";
+import { claudeHome } from "../claude-home.mjs";
 
 // --- Allowlists ---
 //
@@ -110,7 +110,7 @@ export function _resetForTest() {
 }
 
 function getOutputDir() {
-  return process.env.CACHE_FIX_UPSTREAM_DIR || join(homedir(), ".claude");
+  return process.env.CACHE_FIX_UPSTREAM_DIR || claudeHome();
 }
 
 function getBaselinePath(dir) {

--- a/proxy/extensions/upstream-error-log.mjs
+++ b/proxy/extensions/upstream-error-log.mjs
@@ -37,13 +37,13 @@
 
 import { appendFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
-import { homedir } from "node:os";
+import { claudeHome } from "../claude-home.mjs";
 
 const ENV_VAR = "CACHE_FIX_UPSTREAM_ERROR_LOG";
 
 function logPath() {
   return process.env.CACHE_FIX_UPSTREAM_ERROR_LOG_PATH ||
-    join(homedir(), ".claude", "usage-log", "upstream-errors.jsonl");
+    join(claudeHome(), "usage-log", "upstream-errors.jsonl");
 }
 
 // Detection predicate — every non-200 upstream response is in scope.

--- a/proxy/extensions/usage-log.mjs
+++ b/proxy/extensions/usage-log.mjs
@@ -53,10 +53,10 @@
 
 import { appendFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { createHash } from "node:crypto";
+import { claudeHome } from "../claude-home.mjs";
 
-const LOG_PATH = process.env.CACHE_FIX_USAGE_LOG || join(homedir(), ".claude", "usage.jsonl");
+const LOG_PATH = process.env.CACHE_FIX_USAGE_LOG || join(claudeHome(), "usage.jsonl");
 
 // --- Module-scope state ---
 
@@ -271,7 +271,7 @@ export function assembleRecord({ start, delta, quota, requestedModel, sid, prevQ
 // --- I/O ---
 
 async function appendJsonl(record, path = LOG_PATH) {
-  await mkdir(join(homedir(), ".claude"), { recursive: true });
+  await mkdir(claudeHome(), { recursive: true });
   await appendFile(path, JSON.stringify(record) + "\n");
 }
 

--- a/proxy/extensions/usage-log.mjs
+++ b/proxy/extensions/usage-log.mjs
@@ -56,7 +56,12 @@ import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { claudeHome } from "../claude-home.mjs";
 
-const LOG_PATH = process.env.CACHE_FIX_USAGE_LOG || join(claudeHome(), "usage.jsonl");
+// Resolve live per call so CACHE_FIX_USAGE_LOG and CLAUDE_CONFIG_DIR (via
+// claudeHome()) are honored at write time, not frozen at import. Matches the
+// paths() / logPath() shape in the sibling log extensions.
+function logPath() {
+  return process.env.CACHE_FIX_USAGE_LOG || join(claudeHome(), "usage.jsonl");
+}
 
 // --- Module-scope state ---
 
@@ -270,7 +275,7 @@ export function assembleRecord({ start, delta, quota, requestedModel, sid, prevQ
 
 // --- I/O ---
 
-async function appendJsonl(record, path = LOG_PATH) {
+async function appendJsonl(record, path = logPath()) {
   await mkdir(claudeHome(), { recursive: true });
   await appendFile(path, JSON.stringify(record) + "\n");
 }
@@ -288,7 +293,7 @@ export function _resetDeltaStateForTest() {
   _lastQ7d = null;
 }
 
-export { LOG_PATH };
+export { logPath };
 
 // --- Extension contract ---
 
@@ -342,7 +347,7 @@ export default {
       _lastQ5h = quota.q5h;
       _lastQ7d = quota.q7d;
 
-      await appendJsonl(record, process.env.CACHE_FIX_USAGE_LOG || LOG_PATH);
+      await appendJsonl(record, logPath());
     } catch {
       // Fail-open: never throw to the pipeline.
     }

--- a/proxy/extensions/workflow-agent-id-synthesis.mjs
+++ b/proxy/extensions/workflow-agent-id-synthesis.mjs
@@ -33,10 +33,10 @@
 
 import { appendFileSync, statSync, renameSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { homedir } from "node:os";
 
 import { resolveSessionId, sessionFilename } from "./cache-telemetry.mjs";
 import { matchWorkflowMarker } from "../workflow-markers.mjs";
+import { claudeHome } from "../claude-home.mjs";
 import {
   deriveAgentId,
   deriveParentAgentId,
@@ -56,7 +56,7 @@ const _lastCanaryEmitMs = new Map();
 
 function logPath() {
   return process.env.CACHE_FIX_WORKFLOW_DERIVATION_LOG_PATH
-    || join(homedir(), ".claude", "workflow-derivation-events.jsonl");
+    || join(claudeHome(), "workflow-derivation-events.jsonl");
 }
 
 // Single-tier rotation precedent — see `bootstrap-defense.mjs:20-25`.

--- a/proxy/oauth/events.mjs
+++ b/proxy/oauth/events.mjs
@@ -9,8 +9,8 @@
 // primary discipline is at the call site.
 
 import { appendFileSync, mkdirSync, statSync, renameSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { claudeHome } from "../claude-home.mjs";
 
 const FORBIDDEN_KEYS = new Set([
   "accessToken", "refreshToken", "access_token", "refresh_token",
@@ -22,7 +22,7 @@ const MAX_BYTES = 1_000_000;
 
 function eventsPath() {
   return process.env.CACHE_FIX_OAUTH_EVENTS_LOG ||
-    join(homedir(), ".claude", "cache-fix-oauth-events.jsonl");
+    join(claudeHome(), "cache-fix-oauth-events.jsonl");
 }
 
 function rotateIfLarge(path) {

--- a/proxy/oauth/refresher.mjs
+++ b/proxy/oauth/refresher.mjs
@@ -19,13 +19,13 @@ import {
   readFileSync, writeFileSync, renameSync, openSync, fsyncSync, closeSync,
   lstatSync, statSync, mkdirSync,
 } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { randomBytes } from "node:crypto";
 import properLockfile from "proper-lockfile";
 
 import { emitOAuthEvent } from "./events.mjs";
 import config from "../config.mjs";
+import { claudeHome } from "../claude-home.mjs";
 
 const TOKEN_URL_DEFAULT = "https://platform.claude.com/v1/oauth/token";
 // The client_id is the public OAuth client id baked into the Claude Code
@@ -75,7 +75,7 @@ function nowMs() { return Date.now(); }
 
 function credPath() {
   return process.env.CACHE_FIX_OAUTH_CRED_PATH ||
-    join(homedir(), ".claude", ".credentials.json");
+    join(claudeHome(), ".credentials.json");
 }
 
 function tokenUrl() {

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -12,13 +12,13 @@ import { startOAuthRefresher, stopOAuthRefresher } from "./oauth/refresher.mjs";
 // Env is read on every call so tests (and operators flipping the flag at
 // runtime) see live behavior — same pattern as image-strip's #98 gate.
 import { appendFileSync, mkdirSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import util from "node:util";
+import { claudeHome } from "./claude-home.mjs";
 
 function debugLogPath() {
   return process.env.CACHE_FIX_DEBUG_LOG ||
-    join(homedir(), ".claude", "cache-fix-debug.log");
+    join(claudeHome(), "cache-fix-debug.log");
 }
 
 // Never spread raw headers to the log: Authorization / x-api-key / cookies

--- a/proxy/session-mirror-writer.mjs
+++ b/proxy/session-mirror-writer.mjs
@@ -1,7 +1,7 @@
 import { appendFileSync, statSync, mkdirSync, readdirSync, unlinkSync, rmdirSync, renameSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { homedir } from "node:os";
 import { sessionFilename } from "./extensions/cache-telemetry.mjs";
+import { claudeHome } from "./claude-home.mjs";
 
 // Directive: docs/directives/proxy-jsonl-session-mirror.md
 // Storage root: ~/.claude/session-mirrors/<sessionFilename(sessionId)>/<timestamp>.jsonl
@@ -15,7 +15,7 @@ const SWEEP_THROTTLE_MS = 60_000;
 
 function mirrorRoot() {
   return process.env.CACHE_FIX_SESSION_MIRROR_DIR ||
-    join(homedir(), ".claude", "session-mirrors");
+    join(claudeHome(), "session-mirrors");
 }
 
 function eventLogPath() {

--- a/test/proxy-claude-home.test.mjs
+++ b/test/proxy-claude-home.test.mjs
@@ -1,0 +1,119 @@
+// Tests for CLAUDE_CONFIG_DIR honoring across the proxy's on-disk path builders
+// (PR #246). claudeHome() is the single source of truth every path builder
+// derives from (credential path, oauth-events path, quota-status, usage log,
+// session mirrors, snapshots). It must:
+//   - read the env live (positive: honor a set CLAUDE_CONFIG_DIR),
+//   - fall back to ~/.claude when unset AND when empty-string (negative, not CWD),
+//   - be consulted at write time by every builder — including usage-log, which
+//     previously froze its path in a module-level const at import.
+//
+// The credential path (oauth/refresher credPath()) is module-private; it is
+// join(claudeHome(), ".credentials.json"), so its root resolution is pinned by
+// the direct claudeHome() cases below. The oauth-events path is proven
+// behaviorally here via emitOAuthEvent().
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtempSync, existsSync, readFileSync, rmSync } from "node:fs";
+
+import { claudeHome } from "../proxy/claude-home.mjs";
+import { logPath } from "../proxy/extensions/usage-log.mjs";
+import { getLogPath } from "../proxy/extensions/rate-limit-log.mjs";
+import { emitOAuthEvent } from "../proxy/oauth/events.mjs";
+
+// Env keys that shadow claudeHome()-derived defaults. Clear them so each case
+// exercises the CLAUDE_CONFIG_DIR path, then restore the prior environment.
+const ENV_KEYS = ["CLAUDE_CONFIG_DIR", "CACHE_FIX_USAGE_LOG", "CACHE_FIX_OAUTH_EVENTS_LOG"];
+
+function withEnv(overrides, fn) {
+  const saved = {};
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  try {
+    for (const k of ENV_KEYS) delete process.env[k];
+    for (const [k, v] of Object.entries(overrides)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    return fn();
+  } finally {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+function tmpDir() {
+  return mkdtempSync(join(tmpdir(), "cfgdir-"));
+}
+
+const DEFAULT_HOME = join(homedir(), ".claude");
+
+test("claudeHome(): unset CLAUDE_CONFIG_DIR falls back to ~/.claude", () => {
+  withEnv({}, () => {
+    assert.equal(claudeHome(), DEFAULT_HOME);
+  });
+});
+
+test("claudeHome(): a set CLAUDE_CONFIG_DIR is honored", () => {
+  const dir = tmpDir();
+  try {
+    withEnv({ CLAUDE_CONFIG_DIR: dir }, () => {
+      assert.equal(claudeHome(), dir);
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("claudeHome(): empty CLAUDE_CONFIG_DIR falls back to ~/.claude (not CWD)", () => {
+  withEnv({ CLAUDE_CONFIG_DIR: "" }, () => {
+    assert.equal(claudeHome(), DEFAULT_HOME);
+  });
+});
+
+test("path builders resolve under CLAUDE_CONFIG_DIR at call time", () => {
+  const dir = tmpDir();
+  try {
+    withEnv({ CLAUDE_CONFIG_DIR: dir }, () => {
+      // usage-log: the builder that previously froze its path at import.
+      assert.equal(logPath(), join(dir, "usage.jsonl"));
+      // rate-limit-log (quota-status family): its exported path accessor.
+      assert.equal(getLogPath(), join(dir, "usage-log", "rate-limit-events.jsonl"));
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("oauth-events log writes under CLAUDE_CONFIG_DIR (security-sensitive path, behavioral)", () => {
+  const dir = tmpDir();
+  try {
+    withEnv({ CLAUDE_CONFIG_DIR: dir }, () => {
+      emitOAuthEvent("test_event", { note: "claude-home-test" });
+      const p = join(dir, "cache-fix-oauth-events.jsonl");
+      assert.ok(existsSync(p), "oauth-events file should be created under CLAUDE_CONFIG_DIR");
+      assert.match(readFileSync(p, "utf8").trim(), /"event":"test_event"/);
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("usage-log honors CLAUDE_CONFIG_DIR flipped at runtime (live read, not import-frozen)", () => {
+  const a = tmpDir();
+  const b = tmpDir();
+  try {
+    let first, second;
+    withEnv({ CLAUDE_CONFIG_DIR: a }, () => { first = logPath(); });
+    withEnv({ CLAUDE_CONFIG_DIR: b }, () => { second = logPath(); });
+    assert.equal(first, join(a, "usage.jsonl"));
+    assert.equal(second, join(b, "usage.jsonl"));
+    assert.notEqual(first, second); // proves the path is not frozen at import
+  } finally {
+    rmSync(a, { recursive: true, force: true });
+    rmSync(b, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
First off, thank you for this project. We've been running it daily and it's saved us a lot of quota. Really appreciate the work. Small contribution back.

## Problem

The proxy hardcodes `os.homedir()/.claude` for every runtime path it writes: `quota-status/`, `usage.jsonl`, `cache-fix-state/`, session mirrors, snapshots, OAuth events, and the debug log. Claude Code, however, reads `CLAUDE_CONFIG_DIR` to relocate its config root away from the default `~/.claude`.

When you run **one proxy per config dir** (each pointed at a different `CLAUDE_CONFIG_DIR`), every proxy still writes to `~/.claude/quota-status/account.json` and they clobber each other's quota state on every response, so statuslines read the wrong session's cache stats and `account.json` bounces between values. This is the same class of problem #104 fixed for per-session files, one level up (per config dir).

## Fix

Add a small helper `proxy/claude-home.mjs`:

```js
export function claudeHome() {
  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
}
```

and route all 15 runtime path builders through it instead of the hardcoded `join(homedir(), ".claude", ...)`.

- When `CLAUDE_CONFIG_DIR` is **unset**, `claudeHome()` returns `~/.claude`, i.e. **identical behavior to today**, so single-config users see no change.
- When it's **set**, each proxy's state lands under its own `$CLAUDE_CONFIG_DIR`, so proxies pointed at different config dirs stay cleanly separated.

The helper reads the env live (not cached at module load) to match the existing test-isolation pattern in `config.mjs`.

## Scope

- `proxy/claude-home.mjs` (new, 12 lines)
- 15 files: mechanical `homedir()/.claude` -> `claudeHome()` substitution across `proxy/server.mjs`, `proxy/session-mirror-writer.mjs`, `proxy/oauth/*`, and the `proxy/extensions/*` that write state.
- README: a short `CLAUDE_CONFIG_DIR` subsection under "Why per-session".

No behavior change when `CLAUDE_CONFIG_DIR` is unset. `node --check` is clean on all touched files.
