### PR TITLE
Derive statusline ttl_tier from the measured ephemeral split (fixes #247)

### DIFF
--- a/proxy/extensions/cache-telemetry.mjs
+++ b/proxy/extensions/cache-telemetry.mjs
@@ -324,10 +324,17 @@ export default {
       }
       if (event.message?.usage) {
         const usage = event.message.usage;
+        // cache_creation may be a scalar (total) AND/OR an object carrying the
+        // per-tier split { ephemeral_1h_input_tokens, ephemeral_5m_input_tokens }.
+        // Capture the split when present so ttl_tier reflects the ACTUAL cache
+        // TTL the API used, not a heuristic guessed from cache_read presence.
+        const cco = usage.cache_creation;
         ctx.meta.cacheStats = {
           cacheRead: usage.cache_read_input_tokens || 0,
           cacheCreation: usage.cache_creation_input_tokens || 0,
           inputTokens: usage.input_tokens || 0,
+          ephemeral1h: (cco && cco.ephemeral_1h_input_tokens) || 0,
+          ephemeral5m: (cco && cco.ephemeral_5m_input_tokens) || 0,
         };
       }
     }
@@ -345,10 +352,20 @@ export default {
       const total = cr + cc;
       const hitRate = total > 0 ? ((cr / total) * 100).toFixed(1) : "N/A";
 
-      const ephemeral1h = cc;
-      const ephemeral5m = 0;
-
-      const ttl = cr > 0 ? "1h" : (cc > 0 ? "5m" : "unknown");
+      // Prefer the MEASURED per-tier split from usage.cache_creation
+      // (ephemeral_1h/5m_input_tokens). Only when the API omits the split (older
+      // shapes) do we fall back to the coarse heuristic. Previously ephemeral1h
+      // was hardcoded to cc and ttl was guessed from cache_read presence, which
+      // made ttl_tier flicker 1h<->5m across a workflow's fan-out even when the
+      // cache was uniformly 1h.
+      const ephemeral1h = stats.ephemeral1h || 0;
+      const ephemeral5m = stats.ephemeral5m || 0;
+      let ttl;
+      if (ephemeral1h > 0 || ephemeral5m > 0) {
+        ttl = ephemeral1h >= ephemeral5m ? "1h" : "5m";
+      } else {
+        ttl = cr > 0 ? "1h" : (cc > 0 ? "5m" : "unknown");
+      }
 
       const timestamp = new Date().toISOString();
       const rawSid = ctx.meta._sessionId;

--- a/test/proxy-cache-telemetry.test.mjs
+++ b/test/proxy-cache-telemetry.test.mjs
@@ -690,3 +690,74 @@ test("11. sweep failure isolation: response completes even if a deletion would f
     env.cleanup();
   }
 });
+
+// --- Issue #247: ttl_tier from the MEASURED ephemeral split, not a guess ---
+
+// driveResponse() sends only a scalar cache_creation_input_tokens; these cases
+// need the per-tier object usage.cache_creation.{ephemeral_1h,ephemeral_5m},
+// so drive the hooks inline and read the written session file.
+async function driveWithSplit({ sid, cacheRead, ephemeral1h, ephemeral5m }) {
+  const meta = {};
+  const telemetry = {};
+  await ext.onRequest({ headers: { "x-claude-code-session-id": sid }, meta });
+  await ext.onResponseStart({ headers: QUOTA_HEADERS, meta });
+  await ext.onStreamEvent({
+    event: { type: "message_start", message: { usage: {
+      cache_read_input_tokens: cacheRead,
+      cache_creation_input_tokens: ephemeral1h + ephemeral5m,
+      cache_creation: {
+        ephemeral_1h_input_tokens: ephemeral1h,
+        ephemeral_5m_input_tokens: ephemeral5m,
+      },
+      input_tokens: 5,
+    } } },
+    telemetry, meta,
+  });
+  await ext.onStreamEvent({ event: { type: "message_delta", usage: { output_tokens: 10 } }, telemetry, meta });
+}
+
+function readSession(home, sid) {
+  return JSON.parse(readFileSync(join(home, ".claude", "quota-status", "sessions", `${sid}.json`), "utf8"));
+}
+
+test("#247: 1h-dominant split with cache_read=0 labels ttl_tier 1h (was mislabeled 5m)", async () => {
+  const env = setupTmpHome();
+  try {
+    // Fresh-prefix request (a workflow subagent's first turn): cache_read=0 but
+    // the API cached it at 1h. The old heuristic (cr>0 ? 1h : 5m) said 5m.
+    await driveWithSplit({ sid: "ttl-1h", cacheRead: 0, ephemeral1h: 2000, ephemeral5m: 0 });
+    const sess = readSession(env.home, "ttl-1h");
+    assert.equal(sess.cache.ttl_tier, "1h");
+    assert.equal(sess.cache.ephemeral_1h, 2000);
+    assert.equal(sess.cache.ephemeral_5m, 0);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("#247: 5m-dominant split with cache_read>0 labels ttl_tier 5m (was mislabeled 1h)", async () => {
+  const env = setupTmpHome();
+  try {
+    // Genuine 5m downgrade: cache_read>0 but the split is 5m. The old heuristic
+    // said 1h, hiding the red TTL:5m downgrade the statusline should surface.
+    await driveWithSplit({ sid: "ttl-5m", cacheRead: 500, ephemeral1h: 0, ephemeral5m: 1500 });
+    const sess = readSession(env.home, "ttl-5m");
+    assert.equal(sess.cache.ttl_tier, "5m");
+    assert.equal(sess.cache.ephemeral_5m, 1500);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("#247: no split present falls back to the cache_read heuristic", async () => {
+  const env = setupTmpHome();
+  try {
+    // driveResponse sends a scalar cache_creation only (no ephemeral object), so
+    // the fix must fall back to the old heuristic: cc>0, cr=0 -> 5m.
+    await driveResponse({ headers: { "x-claude-code-session-id": "ttl-fallback" } });
+    const sess = readSession(env.home, "ttl-fallback");
+    assert.equal(sess.cache.ttl_tier, "5m");
+  } finally {
+    env.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #247 — `cache-telemetry.mjs` computes the statusline TTL tier from a heuristic (`cache_read > 0 ? "1h" : "5m"`) instead of the measured per-tier split the API already reports.

## Problem

The response carries the real split in `usage.cache_creation.ephemeral_1h_input_tokens` / `ephemeral_5m_input_tokens`, and this repo's own `usage-log.mjs` already reads exactly those fields. `cache-telemetry` was the outlier that guessed, producing two mislabels:

- **Fresh-prefix request** (a workflow subagent's first turn: `cache_read=0`, `cache_creation>0`, cached at **1h**): the heuristic shows `TTL:5m`. Across a fan-out the tier flickers 1h↔5m.
- **Genuine 5m downgrade** (`cache_read>0` but `ephemeral_5m>0`): the heuristic shows `TTL:1h`, hiding the red `TTL:5m` warning the statusline is meant to surface.

## Fix

Read the measured split from `usage.cache_creation`, pick the dominant tier, and fall back to the old heuristic only when the API omits the split:

```js
const ephemeral1h = stats.ephemeral1h || 0;
const ephemeral5m = stats.ephemeral5m || 0;
let ttl;
if (ephemeral1h > 0 || ephemeral5m > 0) {
  ttl = ephemeral1h >= ephemeral5m ? "1h" : "5m";
} else {
  ttl = cr > 0 ? "1h" : (cc > 0 ? "5m" : "unknown");
}
```

The `message_start` handler now also captures the split into `ctx.meta.cacheStats.ephemeral1h/5m`.

## Testing

- Adds 3 regression tests to `test/proxy-cache-telemetry.test.mjs`, driving the real session-write path and asserting the written `ttl_tier`:
  - 1h-dominant split with `cache_read=0` → `"1h"` (the fresh-prefix mislabel)
  - 5m-dominant split with `cache_read>0` → `"5m"` (the hidden-downgrade mislabel)
  - no split present → falls back to the old heuristic
- Full suite green (`node --test`), no regressions; the existing no-split session tests are unaffected (they still hit the fallback).

## Scope

One file of proxy logic (`proxy/extensions/cache-telemetry.mjs`) plus its tests. No behavior change when the API omits the split; independent of #246 and #251.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
