### PR TITLE
feat(deferred-tool-rewrite): hold tools[] byte-stable; announce additions via the mid-conversation beta

### DIFF
--- a/proxy/extensions.json
+++ b/proxy/extensions.json
@@ -19,6 +19,7 @@
   "insertion-normalization": { "enabled": true, "order": 395 },
   "cache-control-normalize": { "enabled": true, "order": 400 },
   "messages-cache-breakpoint": { "enabled": true, "order": 410 },
+  "deferred-tool-rewrite": { "enabled": true, "order": 425 },
   "ttl-management": { "enabled": true, "order": 500 },
   "cache-telemetry": { "enabled": true, "order": 600 },
   "overage-warning": { "enabled": true, "order": 610 },

--- a/proxy/extensions/deferred-tool-rewrite.mjs
+++ b/proxy/extensions/deferred-tool-rewrite.mjs
@@ -1,0 +1,650 @@
+// deferred-tool-rewrite — Phase B (robustness-threat-matrix class 6).
+//
+// Design: docs/directives/proxy-deferred-tool-rewrite.md, including the
+// 2026-07-28 Phase B addendum (documented wire shapes + persistent
+// re-injection). Spec contradiction on record: CC docs say deferred-tool
+// loads append without disturbing cache; measured 2026-07-27 12:47:56
+// (175k, ledger row tools[SendMessage:added], toolsMatch:false) says
+// otherwise on this surface. Until upstream fixes it, the proxy holds
+// tools[] byte-stable across a pure tool addition and delivers the newly
+// available schema per the DOCUMENTED mid-conversation-tool-changes
+// contract (beta mid-conversation-tool-changes-2026-07-01):
+//
+//   - the new tool goes into tools[] with defer_loading: true;
+//   - the announcement is a {"type": "tool_addition", "tool":
+//     {"type": "tool_reference", "name": ...}} content block on a
+//     {"role": "system"} message appended to messages[] — NOT a text
+//     block on top-level system (Phase A's placeholder; wrong shape AND
+//     wrong location — top-level system heads the cache prefix, so every
+//     injection there would bust the whole cache).
+//
+// STATELESSNESS: the API loads a deferred tool only when its
+// tool_addition block is present in THAT request, and CC never echoes
+// our injected message back. So both halves re-apply every request:
+// tools[] stays held with added tools permanently defer_loading:true,
+// and each injected system message is re-spliced byte-identically at a
+// content-anchored position (identity hash of the message it was
+// injected after). Anchor pruned by context management → re-anchor after
+// the latest user message, telemetry `reanchored`, one honest partial
+// re-cache. Pipeline order isolates this from insertion-normalization
+// (395 < 425): the canonical never sees the injected message.
+//
+// Detect: compare incoming tools[] against the persisted known set (keyed
+// by name). Three things can happen to a known name, and only one is an
+// honest content change:
+//   - present, byte-unchanged (fingerprint match) → carried forward using
+//     the FROZEN persisted object (not the incoming one), so its wire
+//     bytes stay stable turn over turn even if the incoming array's key
+//     order or position drifted;
+//   - ABSENT from incoming (harness GC'd a loaded deferred tool, e.g. a
+//     skills/tool-list update) → HELD: re-inserted at its first-seen
+//     position using the frozen object, exactly as if it were still
+//     present. Inert once held; costs ~0 (threat-matrix row 13). This
+//     also fixes pure reorder diffs (e.g. DeferredToolPlaceholder moving
+//     relative to its neighbors with no add/remove) as a side effect,
+//     since output order is ALWAYS the first-seen order, never the
+//     incoming array's order;
+//   - present but fingerprint-changed → the one honest case: passthrough
+//     + full reset (the directive's "never paper over a real edit" — and
+//     specifically never serve a stale schema for a name that changed).
+// A new name (not in the known set) is additively marked
+// defer_loading:true and announced via one appended tool_addition system
+// block, exactly as before. Any combination of held + new in the same
+// request composes (both are additive from the wire's perspective; only
+// a fingerprint change is destructive).
+//
+// Phase B stops at: documented shapes + persistent re-injection,
+// validated by unit tests and replay A/B (directive addendum's gates 1-2).
+// The final live acceptance probe (gate 3: one real request through the
+// proxy at a session boundary, watch for 400 vs the model using the
+// added tool) happens before the service-unit flag flips — the header
+// plumbing this depended on was fixed in server.mjs 10d33e4.
+//
+// Activation: `enabled: true` in extensions.json (always loaded), runtime
+// gate CACHE_FIX_TOOL_REWRITE=1, default OFF per directive ("Phase A (build
+// now, env-gated CACHE_FIX_TOOL_REWRITE=1, default off)"). Order 425 — after
+// sort-stabilization (200, so tools[] arrives name-sorted — comparisons and
+// output order are keyed on name, not incoming array order);
+// before ttl-management (500), consistent with the rest
+// of the body-shaping extensions running ahead of the TTL pass.
+
+import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { claudeHome } from "../claude-home.mjs";
+import { resolveSessionId } from "./cache-telemetry.mjs";
+import { hashMessageContent, conversationSubKey } from "./message-hash.mjs";
+import { systemPromptSubKey } from "./insertion-normalization.mjs";
+import { createHash } from "node:crypto";
+
+// Models known to ACCEPT the mid-conversation-tool-changes contract.
+//
+// Opt-IN, not opt-out, and that direction is the whole point. On 2026-07-28
+// a sonnet-5 subagent dispatch died with:
+//
+//     API Error: 400 tool_addition/tool_removal is not supported on this model
+//
+// The tool_addition block is a documented beta, but support is per-MODEL and
+// this extension applied it to whatever came through. A cache mitigation that
+// can HARD-FAIL a request is strictly worse than no mitigation, so an unknown
+// model gets no announcement: it degrades to forwarding the new tool
+// normally (a tools[] change, i.e. the bust we would have prevented) instead
+// of a 400 that loses the request outright.
+//
+// This file's own header prescribed exactly this check — "the final live
+// acceptance probe (gate 3: one real request through the proxy at a session
+// boundary, watch for 400 vs the model using the added tool) happens before
+// the service-unit flag flips". The flag was flipped without running it.
+//
+// Evidence, not guesswork — tools/probe-tool-addition.mjs measures a model
+// in one real request (same OAuth path as production, wire shapes imported
+// from this file). Add a prefix here only with a real request behind it.
+//
+//   claude-opus-5    ACCEPTED  sessions 58c979ce and 538c0aef, injections on
+//                              the wire, no 400.
+//   claude-sonnet-5  REJECTED  the 2026-07-28 live 400 above.
+//   claude-haiku-4-5 REJECTED  probe 2026-07-29: "tool_addition/tool_removal
+//                              requires a model that supports mid-conversation
+//                              system content; this model does not" — the
+//                              probe surfaced the CAPABILITY the beta gates
+//                              on, which the sonnet error never named.
+//   claude-fable-5   ACCEPTED  live probe 2026-07-29, session c05a754c: a
+//                              disposable `claude -p` run through a throwaway
+//                              proxy (CACHE_FIX_TOOL_ADDITION_EXTRA) injected
+//                              the announcement for a mid-run ToolSearch load;
+//                              production's capture holds the block at
+//                              messages[4], the forwarded body hash matches
+//                              the recorded outSha byte-for-byte, and the
+//                              outcome record shows the API streamed a 200.
+//                              (Direct-API probes 429 on this subscription for
+//                              ALL big models — hand-built OAuth requests are
+//                              refused regardless of quota, so the through-CC
+//                              path is the only working probe for them;
+//                              haiku's direct probe worked because CC itself
+//                              sends it free-form utility traffic.)
+const TOOL_ADDITION_MODELS = ["claude-opus-5", "claude-fable-5"];
+
+// CACHE_FIX_TOOL_ADDITION_EXTRA: comma-separated additional prefixes,
+// read per call like every gate. It exists for ONE purpose — the directive's
+// live acceptance probe: a throwaway proxy instance sets it so a disposable
+// real session can carry the announcement to a candidate model without
+// touching the production allowlist. It is never set in the service unit;
+// an ACCEPTED result graduates to TOOL_ADDITION_MODELS with its evidence,
+// the override does not substitute for the entry.
+export function supportsToolAddition(model) {
+  if (typeof model !== "string") return false;
+  const extra = (process.env.CACHE_FIX_TOOL_ADDITION_EXTRA ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return TOOL_ADDITION_MODELS.concat(extra).some((prefix) => model.startsWith(prefix));
+}
+
+const BETA_TOKEN = "mid-conversation-tool-changes-2026-07-01";
+const BETA_HEADER_NAME = "anthropic-beta";
+
+const DEFAULT_FS = { readFile, writeFile, rename, appendFile, mkdir };
+
+// Models already warned about in this process — the suppressed-announcement
+// warning fires once per model, not per request. Module state is acceptable
+// here precisely because losing it (restart, reload) only repeats a warning.
+const warnedSuppressedModels = new Set();
+
+// --- Env gates (read per-call, mirrors the insertion-normalization idiom) ---
+
+function isEnabled(env = process.env) {
+  return env.CACHE_FIX_TOOL_REWRITE === "1";
+}
+
+function isDebug(env = process.env) {
+  return env.CACHE_FIX_DEBUG === "1";
+}
+
+function debug(msg) {
+  if (isDebug()) process.stderr.write(`[deferred-tool-rewrite] DEBUG: ${msg}\n`);
+}
+
+// --- Storage (snapshots-dir idiom, mirrors insertion-normalization) ---
+
+function getSnapshotDir() {
+  return join(claudeHome(), "cache-fix-snapshots");
+}
+
+function statePath(dir, sessionKey) {
+  return join(dir, `${sessionKey}-deferred-tool-canon.json`);
+}
+
+function eventsPath(dir, sessionKey) {
+  return join(dir, `${sessionKey}-deferred-tool-events.jsonl`);
+}
+
+// State: { tools: [...], additions: [{ name, anchorHash, message }] }.
+// `additions` (Phase B) carries each injected system message byte-frozen,
+// plus the identity hash of the message it was anchored after. Old files
+// without the field read as additions=[] — no migration, sessions started
+// under Phase A simply have no pending injections.
+async function loadState(dir, sessionKey, fs) {
+  try {
+    const txt = await fs.readFile(statePath(dir, sessionKey), "utf-8");
+    const parsed = JSON.parse(txt);
+    if (!Array.isArray(parsed?.tools)) return null;
+    return { tools: parsed.tools, additions: Array.isArray(parsed.additions) ? parsed.additions : [] };
+  } catch (err) {
+    if (err && err.code !== "ENOENT") debug(`state read failed: ${err?.message ?? err}`);
+    return null;
+  }
+}
+
+async function saveState(dir, sessionKey, state, fs) {
+  await fs.mkdir(dir, { recursive: true });
+  const finalPath = statePath(dir, sessionKey);
+  const tmpPath = `${finalPath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+  await fs.writeFile(tmpPath, JSON.stringify(state, null, 2));
+  await fs.rename(tmpPath, finalPath);
+}
+
+async function appendTelemetry(dir, sessionKey, record, fs) {
+  try {
+    await fs.mkdir(dir, { recursive: true });
+    await fs.appendFile(eventsPath(dir, sessionKey), JSON.stringify(record) + "\n");
+  } catch (err) {
+    debug(`telemetry append failed: ${err?.message ?? err}`);
+  }
+}
+
+// --- Session key (same idiom as insertion-normalization) ---
+
+// Sub-keyed by system-prompt hash for the same reason insertion-normalization
+// is (threat-matrix row 14): the session-id header is shared by the main
+// thread, every subagent it dispatches, and CC's own sidecar calls
+// (title-generation etc.) — but those carry DIFFERENT tools arrays. Keyed on
+// the bare session id they all collide on one baseline, so each alternation
+// reads as "a known tool's schema changed" and takes the honest-reset path,
+// re-baselining against whichever tenant spoke last.
+//
+// Measured before this fix (2026-07-28, capture s-35d72503, 602 requests):
+// SIX distinct (tools, system-prompt) combinations shared a single baseline,
+// and enabling the rewrite RAISED main-conversation tools[] churn from 1 to 2
+// — the extension built to hold tools[] byte-stable was destabilising it.
+// The directive never considered sidecars; only replay over real multi-tenant
+// traffic surfaced it.
+// The key carries a CONVERSATION sub-key as well as the system prompt.
+//
+// Without it (until 2026-07-28) every subagent of a session shared one tools
+// baseline AND one set of persisted additions, because they all run the same
+// agent system prompt. That is not merely noisy: the tool_addition
+// announcement is anchored to a MESSAGE IDENTITY, so under a shared key the
+// stored anchor belongs to a different conversation's history, fails to
+// match, and injectAdditions falls back to "after the last user message" — a
+// different index on every request. Measured on corpus s-0edbd11c: our output
+// diverged at index 4 while CC's own history was byte-identical through index
+// 23, twice, re-billing 19 messages that never changed.
+//
+// insertion-normalization hit the identical collision and was fixed hours
+// earlier; this extension had the same key and did not get the fix. Hence
+// conversationSubKey living in message-hash.mjs rather than in either
+// extension — a second copy is a second truth, and the second consumer
+// learning the lesson late is exactly what happened here.
+export function resolveToolRewriteSessionKey(headers, body) {
+  const sid = headers ? resolveSessionId(headers) : null;
+  const conv = conversationSubKey(body?.messages);
+  if (sid) return `s-${sid.replace(/[^A-Za-z0-9_-]/g, "_")}-${systemPromptSubKey(body?.system)}-${conv}`;
+  const model = typeof body?.model === "string" ? body.model : "unknown";
+  return `c-${model}-${conv}`;
+}
+
+// --- Canonical tool comparison ---
+//
+// Only name/description/input_schema participate in the equality check —
+// any OTHER field (e.g. a defer_loading marker WE ourselves might have
+// added on a prior rewrite) is deliberately excluded, so re-classifying a
+// tool object that happens to carry that marker can never misfire as "the
+// existing tool's schema changed."
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const key of Object.keys(value).sort()) out[key] = canonicalize(value[key]);
+    return out;
+  }
+  return value;
+}
+
+// VOLATILE SUBSTRINGS inside a tool DESCRIPTION (2026-07-28). CC embeds the
+// per-session console URL in the Bash tool's description — it is the commit
+// trailer the model is instructed to write — and it does not embed it
+// consistently: measured over 640 live requests, 628 carried it and 12 did
+// not, with two transitions. Each transition is a tools[] byte change, and
+// tools[] renders BEFORE system and messages, so no cache_control breakpoint
+// can survive it; one of them cost 705k creation tokens on this session.
+//
+// Nothing about what Bash DOES changes across that flip — the session URL is
+// not part of the tool's contract. So it is excluded from the identity and
+// the first-seen description is forwarded: exactly the treatment
+// insertion-normalization already applies to <system-reminder> blocks in
+// messages, one region over.
+//
+// Deliberately NARROW: only the session-URL shape. Any other description
+// difference is still a real edit and still resets, because serving a stale
+// schema for a tool whose contract changed is the one failure this extension
+// must never produce.
+const VOLATILE_DESC_PATTERNS = [
+  // https://claude.ai/code/session_<id> — appears bare and as a
+  // "Claude-Session:" trailer line; the whole line goes either way.
+  /^.*https:\/\/claude\.ai\/code\/session_[A-Za-z0-9]+.*$/gm,
+];
+
+export function stripVolatileDescription(desc) {
+  if (typeof desc !== "string") return desc;
+  let out = desc;
+  for (const re of VOLATILE_DESC_PATTERNS) out = out.replace(re, "");
+  // Collapse the blank lines the removal leaves behind, so a description that
+  // differs ONLY by the volatile line canonicalizes identically either way.
+  return out.replace(/\n{2,}/g, "\n").trim();
+}
+
+export function toolFingerprint(tool) {
+  if (!tool || typeof tool !== "object" || typeof tool.name !== "string") return null;
+  return JSON.stringify(
+    canonicalize({
+      name: tool.name,
+      description: stripVolatileDescription(tool.description ?? null),
+      input_schema: tool.input_schema ?? null,
+    }),
+  );
+}
+
+// --- Core classifier (pure) ---
+//
+// Returns:
+//   { action: "no-baseline", knownTools }                                             — first-seen session; persist baseline, forward unchanged
+//   { action: "unchanged", knownTools }                                               — incoming === known set, same order; forward unchanged
+//   { action: "reset", knownTools, reason }                                           — a known tool's schema changed; forward unchanged, re-baseline
+//   { action: "rewrite", tools, newNames, heldNames, knownTools }                      — held removal and/or reorder and/or pure addition; onRequest forwards forwardedTools(knownTools, additions) and injects the addition message
+export function classifyToolChange(incomingTools, priorKnownTools) {
+  if (!Array.isArray(priorKnownTools)) {
+    return { action: "no-baseline", knownTools: incomingTools };
+  }
+
+  const priorByName = new Map(priorKnownTools.map((t) => [t.name, t]));
+  const incomingByName = new Map(incomingTools.map((t) => [t.name, t]));
+
+  // Schema-change scan runs over every name present in BOTH sets — absence
+  // is handled separately below (held, not reset) — so a removal elsewhere
+  // in the array never short-circuits this check.
+  for (const [name, priorTool] of priorByName) {
+    const incomingTool = incomingByName.get(name);
+    if (incomingTool && toolFingerprint(incomingTool) !== toolFingerprint(priorTool)) {
+      return { action: "reset", knownTools: incomingTools, reason: "tool-schema-changed" };
+    }
+  }
+
+  const priorOrderNames = [...priorByName.keys()];
+  const heldNames = priorOrderNames.filter((name) => !incomingByName.has(name));
+  const newNames = [...incomingByName.keys()].filter((name) => !priorByName.has(name));
+
+  const incomingOrderNames = incomingTools.map((t) => t.name);
+  const orderMatches =
+    heldNames.length === 0 &&
+    newNames.length === 0 &&
+    incomingOrderNames.length === priorOrderNames.length &&
+    incomingOrderNames.every((name, i) => name === priorOrderNames[i]);
+
+  if (orderMatches) {
+    return { action: "unchanged", knownTools: priorKnownTools };
+  }
+
+  const newTools = newNames.map((name) => incomingByName.get(name));
+  const deferredNewTools = newTools.map((t) => ({ ...t, defer_loading: true }));
+  // First-seen order, for every name ever known — held (removed) names
+  // included, using their frozen object so wire bytes never drift for a
+  // tool whose content didn't actually change.
+  const heldOrPresentTools = priorOrderNames.map((name) => priorByName.get(name));
+
+  return {
+    action: "rewrite",
+    tools: heldOrPresentTools.concat(deferredNewTools),
+    newNames,
+    heldNames,
+    knownTools: priorOrderNames.concat(newNames).map((name) => priorByName.get(name) ?? incomingByName.get(name)),
+  };
+}
+
+// --- Wire shapes (documented mid-conversation-tool-changes contract) ---
+
+// The tool_addition announcement: one system-ROLE message in messages[]
+// carrying a tool_addition block per newly-added tool. The tool must
+// already be in tools[] with defer_loading: true; the block references it
+// by name. See the directive addendum for the placement constraints this
+// satisfies.
+export function buildToolAdditionMessage(toolNames) {
+  return {
+    role: "system",
+    content: toolNames.map((name) => ({
+      type: "tool_addition",
+      tool: { type: "tool_reference", name },
+    })),
+  };
+}
+
+// Identity hash for an anchor message. hashMessageContent covers
+// block-array content; string-content messages hash their raw string
+// (same fallback family as insertion-normalization's content-derived
+// identity — never positional).
+export function anchorHash(msg) {
+  const h = hashMessageContent(msg);
+  if (h) return h;
+  const c = msg?.content;
+  if (typeof c === "string") return "s:" + createHash("sha256").update(c).digest("hex").slice(0, 16);
+  return null;
+}
+
+// Splice persisted addition messages back into messages[] at their
+// anchors. Pure: returns { messages, reanchored } without mutating input.
+// Each addition lands immediately after the message whose identity hash
+// matches its anchorHash; a vanished anchor (context-management prune)
+// re-anchors after the LAST user message — the closest stable position
+// that satisfies the "must follow a user message" placement constraint —
+// and reports it so state can be updated and telemetry emitted.
+export function injectAdditions(messages, additions) {
+  if (!Array.isArray(additions) || additions.length === 0) {
+    return { messages, reanchored: [] };
+  }
+  const out = [...messages];
+  const reanchored = [];
+  for (const add of additions) {
+    const idx = out.findIndex((m) => m.role !== "system" && anchorHash(m) === add.anchorHash);
+    if (idx >= 0) {
+      out.splice(idx + 1, 0, add.message);
+    } else {
+      let lastUser = -1;
+      for (let i = out.length - 1; i >= 0; i--) {
+        if (out[i].role === "user") {
+          lastUser = i;
+          break;
+        }
+      }
+      if (lastUser >= 0) {
+        out.splice(lastUser + 1, 0, add.message);
+        const newAnchor = anchorHash(out[lastUser]);
+        reanchored.push({ names: add.names, anchorHash: newAnchor });
+      } else {
+        // No user message at all — cannot satisfy the placement
+        // constraint; skip this injection (the tool stays deferred and
+        // unloaded this request; honest degradation, not a malformed
+        // request).
+        reanchored.push({ names: add.names, anchorHash: null });
+      }
+    }
+  }
+  return { messages: out, reanchored };
+}
+
+// The frozen tools[] to forward when additions exist: knownTools order,
+// with every name covered by an addition marked defer_loading — the
+// classifier's knownTools stores UNMARKED objects (fingerprints must
+// match CC's raw array), so the marker is applied at forward time.
+export function forwardedTools(knownTools, additions) {
+  const deferredNames = new Set(additions.flatMap((a) => a.names));
+  return knownTools.map((t) => (deferredNames.has(t.name) ? { ...t, defer_loading: true } : t));
+}
+
+// (Phase A's placeholder — a pseudo-XML text block appended to top-level
+// body.system — was removed in Phase B: wrong shape, and decisively wrong
+// location, since top-level system heads the cache prefix and every
+// injection there would have busted the whole cache.)
+
+// --- Beta header (additive token; reuses no state from auto-1m-guard, but
+// mirrors its header-token parse/join idiom rather than reimplementing ad
+// hoc string splitting) ---
+
+function findBetaHeader(headers) {
+  if (!headers) return null;
+  for (const k of Object.keys(headers)) {
+    if (k.toLowerCase() === BETA_HEADER_NAME) return { key: k, raw: headers[k] };
+  }
+  return null;
+}
+
+function parseBetaTokens(raw) {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw.map(String).map((s) => s.trim()).filter(Boolean);
+  if (typeof raw === "string") return raw.split(",").map((s) => s.trim()).filter(Boolean);
+  return [];
+}
+
+export function addBetaToken(headers) {
+  const found = findBetaHeader(headers);
+  const tokens = found ? parseBetaTokens(found.raw) : [];
+  if (tokens.includes(BETA_TOKEN)) return; // already present — idempotent
+  tokens.push(BETA_TOKEN);
+  const key = found ? found.key : BETA_HEADER_NAME;
+  headers[key] = tokens.join(", ");
+}
+
+// --- Extension contract ---
+
+export default {
+  name: "deferred-tool-rewrite",
+  description:
+    "Phase A: hold tools[] byte-stable across a pure tool addition, announcing the new tool via an appended " +
+    "tool_addition system block instead; also holds a harness-GC'd tool in place and pins output order to " +
+    "first-seen (works around CC's mid-conversation deferred-tool-load and tool-GC cache busts)",
+  enabled: false, // overridden by extensions.json
+  order: 425,
+
+  async onRequest(ctx) {
+    if (!isEnabled()) return;
+    if (!ctx || !ctx.body) return;
+
+    const body = ctx.body;
+    if (!Array.isArray(body.tools) || body.tools.length === 0) return;
+
+    const dir = getSnapshotDir();
+    const fs = DEFAULT_FS;
+    const headers = ctx.headers || null;
+    const sessionId = headers ? resolveSessionId(headers) : null;
+    const sessionKey = resolveToolRewriteSessionKey(headers, body);
+
+    try {
+      const prior = await loadState(dir, sessionKey, fs);
+      const result = classifyToolChange(body.tools, prior?.tools ?? null);
+
+      // Carry prior additions forward except on reset (a schema change
+      // re-baselines everything — the harness's own tools[] becomes truth
+      // and pending injections are abandoned with it).
+      let additions = result.action === "reset" ? [] : (prior?.additions ?? []);
+
+      // Model gate, applied at the single point everything downstream reads.
+      // Emptying `additions` here disables the announcement, the
+      // defer_loading markers forwardedTools() derives from it, AND the beta
+      // header — one place rather than three, and it also neutralises state
+      // persisted before this gate existed (a session that accumulated
+      // additions under the old build must not keep replaying them into a
+      // model that 400s on them).
+      const announceOk = supportsToolAddition(body?.model);
+      if (!announceOk) additions = [];
+
+      // A suppressed announcement is a real cost and must not be silent: the
+      // session pays a full-prefix bust per tool load exactly as if this
+      // extension were absent. The documented availability rule is "Opus
+      // onward", so a NEW model family landing here is most likely
+      // support-capable and unprobed — the warning names the probe so the
+      // gap closes in minutes instead of surviving until someone reads
+      // telemetry. Once per model per process; the telemetry entry carries
+      // `suppressed` on every occurrence.
+      const suppressed =
+        !announceOk && result.action === "rewrite" && (result.newNames?.length ?? 0) > 0;
+      if (suppressed && !warnedSuppressedModels.has(body?.model)) {
+        warnedSuppressedModels.add(body?.model);
+        process.stderr.write(
+          `[deferred-tool-rewrite] model ${body?.model} is not allowlisted for tool_addition — ` +
+            `tools[] busts are being paid (${result.newNames.join(",")}). ` +
+            `Probe it: see tools/probe-tool-addition.mjs (big models need the through-proxy method).\n`,
+        );
+      }
+
+      // The announcement path is gated on model support; the HOLD and
+      // ORDER-PIN paths are not, because neither needs the beta contract —
+      // they only ever re-send tools the model already understands.
+      if (
+        announceOk &&
+        result.action === "rewrite" &&
+        result.newNames.length > 0 &&
+        Array.isArray(body.messages) &&
+        body.messages.length > 0
+      ) {
+        // New tool(s): ONE addition message covering them all, anchored
+        // after the current last message. Injected below with any prior
+        // additions, and persisted for re-injection on every subsequent
+        // request (the API is stateless — see file header).
+        const anchorMsg = body.messages[body.messages.length - 1];
+        additions = additions.concat([
+          {
+            names: result.newNames,
+            anchorHash: anchorHash(anchorMsg),
+            message: buildToolAdditionMessage(result.newNames),
+          },
+        ]);
+      }
+
+      // Forward the frozen array whenever we hold state: rewrite uses the
+      // classifier's held order; "unchanged" ALSO re-forwards it when
+      // additions exist, because CC's incoming array never carries our
+      // defer_loading markers — forwarding it raw would silently un-defer
+      // every added tool. no-baseline and reset pass through untouched.
+      if (result.action === "rewrite") {
+        body.tools = forwardedTools(result.knownTools, additions);
+      } else if (result.action === "unchanged") {
+        // ALWAYS re-forward the frozen array here, not only when additions
+        // exist. Two reasons, and the second was measured the hard way:
+        //   - CC's incoming array never carries our defer_loading markers, so
+        //     forwarding it raw would silently un-defer every added tool;
+        //   - "unchanged" now means "identical after volatile stripping",
+        //     which includes descriptions that differ ONLY by the per-session
+        //     console URL. Forwarding CC's raw array in that case would put
+        //     the flip straight back on the wire and invalidate tools[] —
+        //     making the identity fix pointless. The frozen array is the
+        //     first-seen form, so the wire stays byte-stable.
+        body.tools = forwardedTools(prior.tools, additions);
+      }
+
+      let reanchored = [];
+      if (additions.length > 0 && Array.isArray(body.messages)) {
+        const injected = injectAdditions(body.messages, additions);
+        body.messages = injected.messages;
+        reanchored = injected.reanchored;
+        if (reanchored.length > 0) {
+          additions = additions.map((a) => {
+            const r = reanchored.find((x) => x.names.join() === a.names.join());
+            return r && r.anchorHash ? { ...a, anchorHash: r.anchorHash } : a;
+          });
+        }
+        // Beta token whenever a deferred tool / injected message is on
+        // the wire — every request after the first addition.
+        if (headers) addBetaToken(headers);
+      }
+
+      await saveState(dir, sessionKey, { tools: result.knownTools, additions }, fs);
+
+      ctx.meta = ctx.meta || {};
+      ctx.meta.deferredToolRewriteStats = {
+        action: result.action,
+        newNames: result.newNames ?? [],
+        heldNames: result.heldNames ?? [],
+        reason: result.reason ?? null,
+        injected: additions.length,
+        reanchored: reanchored.filter((r) => r.anchorHash).length,
+      };
+
+      await appendTelemetry(
+        dir,
+        sessionKey,
+        {
+          ts: new Date().toISOString(),
+          key: sessionKey,
+          sid: sessionId,
+          action: result.action,
+          newNames: result.newNames ?? [],
+          heldNames: result.heldNames ?? [],
+          injected: additions.length,
+          ...(suppressed ? { suppressed: true, model: body?.model } : {}),
+          ...(reanchored.length > 0 ? { reanchored } : {}),
+          ...(result.reason ? { reason: result.reason } : {}),
+        },
+        fs,
+      );
+
+      if (isDebug()) {
+        process.stderr.write(
+          `[deferred-tool-rewrite] action=${result.action}` +
+            (result.newNames ? ` new=${result.newNames.join(",")}` : "") +
+            (result.heldNames && result.heldNames.length ? ` held=${result.heldNames.join(",")}` : "") +
+            (result.reason ? ` reason=${result.reason}` : "") +
+            "\n",
+        );
+      }
+    } catch (err) {
+      debug(`onRequest unexpected: ${err?.message ?? err}`);
+    }
+  },
+};

--- a/proxy/extensions/deferred-tool-rewrite.mjs
+++ b/proxy/extensions/deferred-tool-rewrite.mjs
@@ -405,37 +405,62 @@ export function anchorHash(msg) {
 // re-anchors after the LAST user message — the closest stable position
 // that satisfies the "must follow a user message" placement constraint —
 // and reports it so state can be updated and telemetry emitted.
+//
+// Resolution happens in a first pass against the ORIGINAL `messages` array
+// (never mutated while resolving), so a SHARED anchor's landing position is
+// computed once regardless of how many additions target it. This is what
+// keeps the run FIFO — discovery order, oldest first — instead of the
+// previous idx+1-per-addition splice, which re-found the same anchor fresh
+// on every iteration (the search excludes role==="system", so
+// already-injected additions were invisible to it) and always landed the
+// newest addition closest to the anchor: a LIFO stack that reordered the
+// already-forwarded prefix on every new addition (probe s-dc3f8071,
+// n=372-397, 25 stability violations during an MCP discovery cascade).
 export function injectAdditions(messages, additions) {
   if (!Array.isArray(additions) || additions.length === 0) {
     return { messages, reanchored: [] };
   }
-  const out = [...messages];
+
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
   const reanchored = [];
+  // Original-array index -> messages to inject right after it, in discovery
+  // (oldest-first) order — the run for a shared anchor.
+  const byAnchorIdx = new Map();
+
   for (const add of additions) {
-    const idx = out.findIndex((m) => m.role !== "system" && anchorHash(m) === add.anchorHash);
-    if (idx >= 0) {
-      out.splice(idx + 1, 0, add.message);
-    } else {
-      let lastUser = -1;
-      for (let i = out.length - 1; i >= 0; i--) {
-        if (out[i].role === "user") {
-          lastUser = i;
-          break;
-        }
-      }
-      if (lastUser >= 0) {
-        out.splice(lastUser + 1, 0, add.message);
-        const newAnchor = anchorHash(out[lastUser]);
-        reanchored.push({ names: add.names, anchorHash: newAnchor });
+    const idx = messages.findIndex((m) => m.role !== "system" && anchorHash(m) === add.anchorHash);
+    let landingIdx = idx;
+    if (idx < 0) {
+      if (lastUserIdx >= 0) {
+        landingIdx = lastUserIdx;
+        reanchored.push({ names: add.names, anchorHash: anchorHash(messages[lastUserIdx]) });
       } else {
         // No user message at all — cannot satisfy the placement
         // constraint; skip this injection (the tool stays deferred and
         // unloaded this request; honest degradation, not a malformed
         // request).
         reanchored.push({ names: add.names, anchorHash: null });
+        continue;
       }
     }
+    if (!byAnchorIdx.has(landingIdx)) byAnchorIdx.set(landingIdx, []);
+    byAnchorIdx.get(landingIdx).push(add.message);
   }
+
+  const out = [];
+  messages.forEach((m, i) => {
+    out.push(m);
+    const injected = byAnchorIdx.get(i);
+    if (injected) out.push(...injected);
+  });
+
   return { messages: out, reanchored };
 }
 

--- a/test/deferred-tool-rewrite.test.mjs
+++ b/test/deferred-tool-rewrite.test.mjs
@@ -254,6 +254,70 @@ test("injectAdditions: no user message at all → injection skipped, reported wi
   assert.equal(reanchored[0].anchorHash, null);
 });
 
+// BITE — the LIFO bug (BACKLOG "READY — fix injectAdditions' LIFO stacking").
+// Real capture s-dc3f8071, n=372-397: an MCP-tool-discovery cascade produces
+// one new `additions` entry per request, all anchored to the SAME message
+// (the real conversation stays at 1 message the whole burst). The buggy
+// implementation re-finds the anchor fresh on every iteration (the search
+// excludes role==="system", so already-injected additions are invisible to
+// it) and always splices at anchorIdx+1 — so the newest addition always
+// lands closest to the anchor, pushing every earlier addition one slot
+// further back: a LIFO stack that reorders the already-forwarded prefix on
+// every new addition. Fix: a shared anchor's run stays in discovery order
+// (FIFO) — a new addition appends AFTER the additions already injected
+// there, so the forwarded prefix is a byte-stable prefix of every
+// subsequent output and only the tail of the run grows.
+test("injectAdditions: three additions sharing one anchor → output is discovery order (FIFO), not LIFO", () => {
+  const u0 = { role: "user", content: [{ type: "text", text: "u0" }] };
+  const sharedAnchor = anchorHash(u0);
+  const addA = buildToolAdditionMessage(["ToolA"]);
+  const addB = buildToolAdditionMessage(["ToolB"]);
+  const addC = buildToolAdditionMessage(["ToolC"]);
+
+  // additions array is in DISCOVERY order (oldest first), matching how
+  // onRequest concatenates them across successive requests.
+  const additions = [
+    { names: ["ToolA"], anchorHash: sharedAnchor, message: addA },
+    { names: ["ToolB"], anchorHash: sharedAnchor, message: addB },
+    { names: ["ToolC"], anchorHash: sharedAnchor, message: addC },
+  ];
+
+  const { messages } = injectAdditions([u0], additions);
+  assert.deepEqual(
+    messages.map((m) => m.content?.[0]?.tool?.name ?? "u0"),
+    ["u0", "ToolA", "ToolB", "ToolC"],
+    "run stays in discovery order — ToolA first (oldest), ToolC last (newest), never reordered",
+  );
+});
+
+test("injectAdditions: shared-anchor prefix stability — output N is a byte-prefix of output N+1", () => {
+  const u0 = { role: "user", content: [{ type: "text", text: "u0" }] };
+  const sharedAnchor = anchorHash(u0);
+  const addA = buildToolAdditionMessage(["ToolA"]);
+  const addB = buildToolAdditionMessage(["ToolB"]);
+
+  // Simulates two successive requests: first only ToolA has been discovered,
+  // then ToolB arrives too (additions accumulate, oldest first — as onRequest
+  // does via `additions.concat([...])`).
+  const afterFirst = injectAdditions([u0], [{ names: ["ToolA"], anchorHash: sharedAnchor, message: addA }]);
+  const afterSecond = injectAdditions(
+    [u0],
+    [
+      { names: ["ToolA"], anchorHash: sharedAnchor, message: addA },
+      { names: ["ToolB"], anchorHash: sharedAnchor, message: addB },
+    ],
+  );
+
+  const prefixBytes = JSON.stringify(afterFirst.messages);
+  const nextBytes = JSON.stringify(afterSecond.messages.slice(0, afterFirst.messages.length));
+  assert.equal(
+    nextBytes,
+    prefixBytes,
+    "the already-forwarded prefix must be byte-identical once a new addition arrives — only the tail grows",
+  );
+  assert.equal(afterSecond.messages.length, 3, "the new addition appends at the tail of the run");
+});
+
 test("forwardedTools: names covered by additions get defer_loading, others stay untouched", () => {
   const known = [tool("Read"), tool("SendMessage")];
   const additions = [{ names: ["SendMessage"], anchorHash: "h", message: {} }];
@@ -443,6 +507,53 @@ test("onRequest: pruned anchor → re-anchor once, stable thereafter", async () 
       assert.equal(ctx4.meta.deferredToolRewriteStats.reanchored, 0);
       // Anchored after uNew, which is now index 1 — so the injection is at 2.
       assert.equal(ctx4.body.messages[2].role, "system");
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("onRequest BITE: MCP-discovery cascade — same 1-message conversation, tools[] grows 3x → additions stack in discovery order, prefix stable", async () => {
+  // Mirrors the real capture (s-dc3f8071, n=372-397): CC's own progressive
+  // MCP-tool-discovery cascade at session boot sends one new tool batch per
+  // request while the real conversation never grows past 1 message, so every
+  // addition shares the identical anchor (messages[0]).
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-cascade" };
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      const u0 = { role: "user", content: [{ type: "text", text: "u0" }] };
+      const base = { system: [], messages: [u0], model: "claude-opus-5" };
+
+      await runExt({ ...base, tools: [tool("Read"), tool("Bash")] }, { headers, dir }); // no-baseline
+      const ctx1 = await runExt(
+        { ...base, tools: [tool("Read"), tool("Bash"), tool("ToolA")] },
+        { headers, dir },
+      );
+      const ctx2 = await runExt(
+        { ...base, tools: [tool("Read"), tool("Bash"), tool("ToolA"), tool("ToolB")] },
+        { headers, dir },
+      );
+      const ctx3 = await runExt(
+        { ...base, tools: [tool("Read"), tool("Bash"), tool("ToolA"), tool("ToolB"), tool("ToolC")] },
+        { headers, dir },
+      );
+
+      const names = (ctx) =>
+        ctx.body.messages
+          .filter((m) => m.role === "system" && Array.isArray(m.content) && m.content[0]?.type === "tool_addition")
+          .flatMap((m) => m.content.map((b) => b.tool.name));
+
+      assert.deepEqual(names(ctx1), ["ToolA"]);
+      assert.deepEqual(names(ctx2), ["ToolA", "ToolB"], "ToolA stays first — discovery order, not LIFO");
+      assert.deepEqual(names(ctx3), ["ToolA", "ToolB", "ToolC"], "run grows only at the tail");
+
+      // The forwarded prefix already produced must be a byte-prefix of the
+      // next request's output — this is the "reorders the already-forwarded
+      // prefix" bust the probe measured.
+      const prefixOf = (ctx, n) => JSON.stringify(ctx.body.messages.slice(0, n));
+      assert.equal(prefixOf(ctx2, ctx1.body.messages.length), JSON.stringify(ctx1.body.messages));
+      assert.equal(prefixOf(ctx3, ctx2.body.messages.length), JSON.stringify(ctx2.body.messages));
     });
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/test/deferred-tool-rewrite.test.mjs
+++ b/test/deferred-tool-rewrite.test.mjs
@@ -1,0 +1,839 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ext, {
+  resolveToolRewriteSessionKey,
+  supportsToolAddition,
+  toolFingerprint,
+  classifyToolChange,
+  buildToolAdditionMessage,
+  injectAdditions,
+  forwardedTools,
+  anchorHash,
+  addBetaToken,
+} from "../proxy/extensions/deferred-tool-rewrite.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(__dirname, "fixtures", "toolload-1247.json");
+const GC_FIXTURE_PATH = join(__dirname, "fixtures", "toolgc-1536.json");
+
+async function newTmp() {
+  return mkdtemp(join(tmpdir(), "deferred-tool-rewrite-test-"));
+}
+
+function withEnv(overrides, fn) {
+  const saved = {};
+  for (const k of Object.keys(overrides)) {
+    saved[k] = process.env[k];
+    if (overrides[k] === undefined) delete process.env[k];
+    else process.env[k] = overrides[k];
+  }
+  try {
+    return fn();
+  } finally {
+    for (const k of Object.keys(saved)) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+async function withEnvAsync(overrides, fn) {
+  const saved = {};
+  for (const k of Object.keys(overrides)) {
+    saved[k] = process.env[k];
+    if (overrides[k] === undefined) delete process.env[k];
+    else process.env[k] = overrides[k];
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const k of Object.keys(saved)) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+// The announcement path is gated on MODEL support (see supportsToolAddition):
+// a body without a model is "unknown", which is deliberately OFF. Most tests
+// here predate that gate and exercise the announcement, so they default to a
+// supported model; the tests that care about the gate set `model` explicitly.
+async function runExt(body, { headers, dir } = {}) {
+  const savedHome = process.env.CLAUDE_CONFIG_DIR;
+  if (dir) process.env.CLAUDE_CONFIG_DIR = dir;
+  try {
+    const withModel = body && body.model === undefined ? { ...body, model: "claude-opus-5" } : body;
+    const ctx = { body: withModel, meta: {}, headers: headers || {} };
+    await ext.onRequest(ctx);
+    return ctx;
+  } finally {
+    if (dir) {
+      if (savedHome === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+      else process.env.CLAUDE_CONFIG_DIR = savedHome;
+    }
+  }
+}
+
+function tool(name, extra = {}) {
+  return { name, input_schema: { type: "object", properties: {} }, ...extra };
+}
+
+// =============================================================================
+// GATE OFF = INERT
+// =============================================================================
+
+test("gate off (CACHE_FIX_TOOL_REWRITE unset) — onRequest is a no-op", async () => {
+  const dir = await newTmp();
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: undefined }, async () => {
+      const body = { tools: [tool("Read"), tool("Bash")], messages: [] };
+      const ctx = await runExt(body, { dir });
+      assert.equal(ctx.meta.deferredToolRewriteStats, undefined);
+      assert.deepEqual(ctx.body.tools, [tool("Read"), tool("Bash")]);
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// =============================================================================
+// PURE CLASSIFIER
+// =============================================================================
+
+test("classifyToolChange: no prior baseline → action no-baseline, knownTools = incoming", () => {
+  const incoming = [tool("Read"), tool("Bash")];
+  const result = classifyToolChange(incoming, null);
+  assert.equal(result.action, "no-baseline");
+  assert.deepEqual(result.knownTools, incoming);
+});
+
+test("classifyToolChange: identical tools[] → action unchanged", () => {
+  const prior = [tool("Read"), tool("Bash")];
+  const incoming = [tool("Read"), tool("Bash")];
+  const result = classifyToolChange(incoming, prior);
+  assert.equal(result.action, "unchanged");
+});
+
+test("classifyToolChange: pure addition (SendMessage added) → action rewrite, new tool marked defer_loading:true", () => {
+  const prior = [tool("Read"), tool("Bash")];
+  const incoming = [tool("Read"), tool("Bash"), tool("SendMessage")];
+  const result = classifyToolChange(incoming, prior);
+  assert.equal(result.action, "rewrite");
+  assert.deepEqual(result.newNames, ["SendMessage"]);
+  assert.equal(result.tools.length, 3);
+  assert.equal(result.tools[0].name, "Read");
+  assert.equal(result.tools[0].defer_loading, undefined, "existing tools are not marked defer_loading");
+  assert.equal(result.tools[2].name, "SendMessage");
+  assert.equal(result.tools[2].defer_loading, true);
+});
+
+test("classifyToolChange: existing tool removed → action rewrite, held in place at its first-seen position, byte-identical", () => {
+  const prior = [tool("Read"), tool("Bash")];
+  const incoming = [tool("Read")]; // Bash missing — harness GC'd it
+  const result = classifyToolChange(incoming, prior);
+  assert.equal(result.action, "rewrite");
+  assert.deepEqual(result.heldNames, ["Bash"]);
+  assert.equal(result.newNames.length, 0);
+  assert.equal(result.tools.length, 2, "held tool is re-inserted");
+  assert.deepEqual(result.tools[0], tool("Read"));
+  assert.deepEqual(result.tools[1], tool("Bash"), "held tool is byte-identical to its known form");
+});
+
+test("classifyToolChange: pure reorder (no add/remove) → action rewrite, output pinned to first-seen order", () => {
+  const prior = [tool("Read"), tool("Bash"), tool("SendMessage")];
+  const incoming = [tool("SendMessage"), tool("Read"), tool("Bash")]; // reordered, nothing added/removed
+  const result = classifyToolChange(incoming, prior);
+  assert.equal(result.action, "rewrite");
+  assert.deepEqual(result.heldNames, []);
+  assert.deepEqual(result.newNames, []);
+  assert.deepEqual(
+    result.tools.map((t) => t.name),
+    ["Read", "Bash", "SendMessage"],
+    "output order is first-seen order, not the incoming array's order",
+  );
+});
+
+test("classifyToolChange: existing tool's schema changed → action reset, reason tool-schema-changed", () => {
+  const prior = [tool("Read", { input_schema: { type: "object", properties: { file_path: { type: "string" } } } })];
+  const incoming = [tool("Read", { input_schema: { type: "object", properties: { path: { type: "string" } } } })];
+  const result = classifyToolChange(incoming, prior);
+  assert.equal(result.action, "reset");
+  assert.equal(result.reason, "tool-schema-changed");
+});
+
+test("classifyToolChange: addition AND removal in the same request → composes (held removal + additive new tool), still rewrite", () => {
+  const prior = [tool("Read"), tool("Bash")];
+  const incoming = [tool("Read"), tool("SendMessage")]; // Bash removed, SendMessage added
+  const result = classifyToolChange(incoming, prior);
+  assert.equal(result.action, "rewrite");
+  assert.deepEqual(result.heldNames, ["Bash"]);
+  assert.deepEqual(result.newNames, ["SendMessage"]);
+  assert.deepEqual(
+    result.tools.map((t) => t.name),
+    ["Read", "Bash", "SendMessage"],
+    "held tool re-inserted at its first-seen position, new tool appended",
+  );
+  assert.equal(result.tools[2].defer_loading, true);
+});
+
+test("classifyToolChange: a tool carrying OUR OWN defer_loading marker from a prior rewrite is not misread as schema-changed", () => {
+  // Simulates: prior known set was captured AFTER a rewrite had already
+  // marked a tool defer_loading:true; toolFingerprint must ignore that
+  // marker so re-comparing it against itself is still "unchanged".
+  const priorWithMarker = [tool("Read"), { ...tool("SendMessage"), defer_loading: true }];
+  const incoming = [tool("Read"), tool("SendMessage")]; // no marker this time — still the same tool
+  const result = classifyToolChange(incoming, priorWithMarker);
+  assert.equal(result.action, "unchanged");
+});
+
+test("toolFingerprint: order-independent on schema property keys", () => {
+  const a = tool("Read", { input_schema: { type: "object", properties: { a: {}, b: {} } } });
+  const b = tool("Read", { input_schema: { type: "object", properties: { b: {}, a: {} } } });
+  assert.equal(toolFingerprint(a), toolFingerprint(b));
+});
+
+test("toolFingerprint: missing tool or missing name → null", () => {
+  assert.equal(toolFingerprint(null), null);
+  assert.equal(toolFingerprint({}), null);
+});
+
+// =============================================================================
+// WIRE SHAPES
+// =============================================================================
+
+test("buildToolAdditionMessage: documented contract — system-role message with tool_addition/tool_reference blocks", () => {
+  const msg = buildToolAdditionMessage(["SendMessage", "TaskCreate"]);
+  assert.equal(msg.role, "system");
+  assert.equal(msg.content.length, 2);
+  assert.deepEqual(msg.content[0], {
+    type: "tool_addition",
+    tool: { type: "tool_reference", name: "SendMessage" },
+  });
+  assert.deepEqual(msg.content[1], {
+    type: "tool_addition",
+    tool: { type: "tool_reference", name: "TaskCreate" },
+  });
+});
+
+test("injectAdditions: splices the persisted message after its anchor, byte-identical", () => {
+  const u0 = { role: "user", content: [{ type: "text", text: "u0" }] };
+  const a1 = { role: "assistant", content: [{ type: "text", text: "a1" }] };
+  const u2 = { role: "user", content: [{ type: "text", text: "u2" }] };
+  const addMsg = buildToolAdditionMessage(["SendMessage"]);
+  const additions = [{ names: ["SendMessage"], anchorHash: anchorHash(u0), message: addMsg }];
+  const { messages, reanchored } = injectAdditions([u0, a1, u2], additions);
+  assert.equal(reanchored.length, 0);
+  assert.equal(messages.length, 4);
+  assert.equal(messages[1], addMsg, "injected immediately after the anchor");
+  assert.equal(messages[0], u0);
+  assert.equal(messages[2], a1);
+});
+
+test("injectAdditions: pruned anchor → re-anchor after last user message, reported", () => {
+  const uNew = { role: "user", content: [{ type: "text", text: "new turn" }] };
+  const addMsg = buildToolAdditionMessage(["SendMessage"]);
+  const additions = [{ names: ["SendMessage"], anchorHash: "gone-hash", message: addMsg }];
+  const { messages, reanchored } = injectAdditions([uNew], additions);
+  assert.equal(messages.length, 2);
+  assert.equal(messages[1], addMsg, "re-anchored after the last user message");
+  assert.equal(reanchored.length, 1);
+  assert.equal(reanchored[0].anchorHash, anchorHash(uNew));
+});
+
+test("injectAdditions: no user message at all → injection skipped, reported with null anchor", () => {
+  const a = { role: "assistant", content: [{ type: "text", text: "only assistant" }] };
+  const addMsg = buildToolAdditionMessage(["SendMessage"]);
+  const additions = [{ names: ["SendMessage"], anchorHash: "gone", message: addMsg }];
+  const { messages, reanchored } = injectAdditions([a], additions);
+  assert.equal(messages.length, 1, "nothing injected");
+  assert.equal(reanchored[0].anchorHash, null);
+});
+
+test("forwardedTools: names covered by additions get defer_loading, others stay untouched", () => {
+  const known = [tool("Read"), tool("SendMessage")];
+  const additions = [{ names: ["SendMessage"], anchorHash: "h", message: {} }];
+  const fwd = forwardedTools(known, additions);
+  assert.deepEqual(fwd[0], tool("Read"));
+  assert.equal(fwd[1].defer_loading, true);
+});
+
+test("addBetaToken: adds the token when header absent", () => {
+  const headers = {};
+  addBetaToken(headers);
+  assert.equal(headers["anthropic-beta"], "mid-conversation-tool-changes-2026-07-01");
+});
+
+test("addBetaToken: appends to an existing anthropic-beta header without duplicating", () => {
+  const headers = { "anthropic-beta": "other-beta-2026-01-01" };
+  addBetaToken(headers);
+  assert.equal(headers["anthropic-beta"], "other-beta-2026-01-01, mid-conversation-tool-changes-2026-07-01");
+  addBetaToken(headers); // idempotent
+  assert.equal(headers["anthropic-beta"], "other-beta-2026-01-01, mid-conversation-tool-changes-2026-07-01");
+});
+
+test("addBetaToken: case-insensitive header key lookup (Anthropic-Beta)", () => {
+  const headers = { "Anthropic-Beta": "x" };
+  addBetaToken(headers);
+  assert.equal(headers["Anthropic-Beta"], "x, mid-conversation-tool-changes-2026-07-01");
+  assert.equal(headers["anthropic-beta"], undefined, "must mutate the existing key, not add a duplicate");
+});
+
+// =============================================================================
+// EXTENSION CONTRACT — full onRequest round trip
+// =============================================================================
+
+test("onRequest: first request (no prior state) → tools forwarded unchanged, baseline persisted", async () => {
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-first" };
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      const body = { tools: [tool("Read"), tool("Bash")], system: [{ type: "text", text: "sys" }], messages: [] };
+      const ctx = await runExt(body, { headers, dir });
+      assert.equal(ctx.meta.deferredToolRewriteStats.action, "no-baseline");
+      assert.deepEqual(ctx.body.tools, [tool("Read"), tool("Bash")]);
+      assert.equal(ctx.body.system.length, 1, "no tool_addition appended on the baseline-establishing request");
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("onRequest: second request adds SendMessage → tools[] byte-stable for known tools + defer_loading on the new one + tool_addition system block + beta header", async () => {
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-add" };
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      // Same conversation across both requests: msgs[0] is what identifies
+      // one, so an empty first request would now be a DIFFERENT conversation
+      // (and no real first request is empty).
+      const u1 = { role: "user", content: [{ type: "text", text: "turn 1" }] };
+      const body1 = { tools: [tool("Read"), tool("Bash")], system: [{ type: "text", text: "sys" }], messages: [u1] };
+      await runExt(body1, { headers, dir });
+
+      const body2 = {
+        tools: [tool("Read"), tool("Bash"), tool("SendMessage")],
+        system: [{ type: "text", text: "sys" }],
+        messages: [u1],
+      };
+      const ctx2 = await runExt(body2, { headers, dir });
+
+      assert.equal(ctx2.meta.deferredToolRewriteStats.action, "rewrite");
+      assert.deepEqual(ctx2.meta.deferredToolRewriteStats.newNames, ["SendMessage"]);
+
+      // Known tools byte-stable (no defer_loading marker added to them).
+      assert.deepEqual(ctx2.body.tools[0], tool("Read"));
+      assert.deepEqual(ctx2.body.tools[1], tool("Bash"));
+      // New tool additively marked.
+      assert.equal(ctx2.body.tools[2].name, "SendMessage");
+      assert.equal(ctx2.body.tools[2].defer_loading, true);
+
+      // Top-level system UNTOUCHED (Phase A appended here — wrong location).
+      assert.equal(ctx2.body.system.length, 1);
+      // The announcement is a system-ROLE message injected into messages[],
+      // after the anchor (the last message at addition time).
+      assert.equal(ctx2.body.messages.length, 2);
+      const injected = ctx2.body.messages[1];
+      assert.equal(injected.role, "system");
+      assert.deepEqual(injected.content[0], {
+        type: "tool_addition",
+        tool: { type: "tool_reference", name: "SendMessage" },
+      });
+
+      // Beta header added.
+      assert.equal(headers["anthropic-beta"], "mid-conversation-tool-changes-2026-07-01");
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("onRequest: subsequent requests re-inject byte-identically at the same anchor (statelessness handled)", async () => {
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-stable" };
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      const u1 = { role: "user", content: [{ type: "text", text: "turn 1" }] };
+      const body1 = { tools: [tool("Read"), tool("Bash")], system: [{ type: "text", text: "sys" }], messages: [u1] };
+      await runExt(body1, { headers, dir });
+
+      const body2 = {
+        tools: [tool("Read"), tool("Bash"), tool("SendMessage")],
+        system: [{ type: "text", text: "sys" }],
+        messages: [u1],
+      };
+      const ctx2 = await runExt(body2, { headers, dir });
+      const injectedAt2 = JSON.stringify(ctx2.body.messages[1]);
+
+      // Requests 3 and 4: CC sends its own view (no injected message, no
+      // defer_loading markers) with the conversation advancing. The proxy
+      // must re-inject at the SAME anchor, byte-identically, and re-apply
+      // the frozen tools[] with the marker — every request.
+      for (const extra of [
+        [{ role: "assistant", content: [{ type: "text", text: "a2" }] }],
+        [
+          { role: "assistant", content: [{ type: "text", text: "a2" }] },
+          { role: "user", content: [{ type: "text", text: "turn 3" }] },
+        ],
+      ]) {
+        const body = {
+          tools: [tool("Read"), tool("Bash"), tool("SendMessage")],
+          system: [{ type: "text", text: "sys" }],
+          messages: [u1, ...extra],
+        };
+        const ctx = await runExt(body, { headers, dir });
+        assert.equal(ctx.meta.deferredToolRewriteStats.action, "unchanged");
+        assert.equal(ctx.meta.deferredToolRewriteStats.injected, 1);
+        // Injection sits right after the anchor (u1), byte-identical.
+        assert.equal(JSON.stringify(ctx.body.messages[1]), injectedAt2);
+        // Frozen tools[] with defer_loading re-applied.
+        assert.equal(ctx.body.tools[2].defer_loading, true);
+        // Top-level system never touched.
+        assert.equal(ctx.body.system.length, 1);
+      }
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("onRequest: pruned anchor → re-anchor once, stable thereafter", async () => {
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-prune" };
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      // msgs[0] identifies the conversation, so it must SURVIVE the prune for
+      // this to exercise re-anchoring rather than a new conversation. The
+      // addition anchors to the LAST message, so anchor and msgs[0] are
+      // deliberately different messages here.
+      const u0 = { role: "user", content: [{ type: "text", text: "turn 0" }] };
+      const u1 = { role: "user", content: [{ type: "text", text: "turn 1" }] };
+      await runExt({ tools: [tool("Read")], system: [], messages: [u0] }, { headers, dir });
+      await runExt(
+        { tools: [tool("Read"), tool("SendMessage")], system: [], messages: [u0, u1] },
+        { headers, dir },
+      );
+
+      // Context management pruned the ANCHOR message while msgs[0] survives —
+      // the same conversation, minus the turn the addition was anchored to.
+      // (Replacing msgs[0] instead would be a different conversation by
+      // design: the prefix died at index 0, so no cache survives it and a
+      // fresh state costs nothing. The re-anchor path is for this case.)
+      const uNew = { role: "user", content: [{ type: "text", text: "post-prune turn" }] };
+      const ctx3 = await runExt(
+        { tools: [tool("Read"), tool("SendMessage")], system: [], messages: [u0, uNew] },
+        { headers, dir },
+      );
+      assert.equal(ctx3.meta.deferredToolRewriteStats.reanchored, 1);
+      assert.equal(ctx3.body.messages[2].role, "system", "re-anchored after the last user message");
+
+      // Next request: the new anchor holds — no further re-anchor.
+      const ctx4 = await runExt(
+        {
+          tools: [tool("Read"), tool("SendMessage")],
+          system: [],
+          messages: [u0, uNew, { role: "assistant", content: [{ type: "text", text: "a" }] }],
+        },
+        { headers, dir },
+      );
+      assert.equal(ctx4.meta.deferredToolRewriteStats.reanchored, 0);
+      // Anchored after uNew, which is now index 1 — so the injection is at 2.
+      assert.equal(ctx4.body.messages[2].role, "system");
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("onRequest: a tool removed after an addition → HELD (rewrite, passthrough of held tool), no beta header (nothing new to defer)", async () => {
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-hold" };
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      const body1 = { tools: [tool("Read"), tool("Bash")], system: [{ type: "text", text: "sys" }], messages: [] };
+      await runExt(body1, { headers, dir });
+
+      const body2 = { tools: [tool("Read")], system: [{ type: "text", text: "sys" }], messages: [] };
+      const ctx2 = await runExt(body2, { headers, dir });
+
+      assert.equal(ctx2.meta.deferredToolRewriteStats.action, "rewrite");
+      assert.deepEqual(ctx2.meta.deferredToolRewriteStats.heldNames, ["Bash"]);
+      assert.deepEqual(ctx2.body.tools, [tool("Read"), tool("Bash")], "Bash held in place, byte-identical");
+      assert.equal(ctx2.body.system.length, 1, "a hold announces nothing — no tool_addition block appended");
+      assert.equal(headers["anthropic-beta"], undefined, "no defer_loading tool this turn -> no beta token needed");
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("onRequest: a known tool's SCHEMA changing (not removal) → still resets (honest content change, never served stale)", async () => {
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-schema-reset" };
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      const body1 = { tools: [tool("Read"), tool("Bash")], system: [{ type: "text", text: "sys" }], messages: [] };
+      await runExt(body1, { headers, dir });
+
+      const body2 = {
+        tools: [tool("Read", { input_schema: { type: "object", properties: { path: { type: "string" } } } }), tool("Bash")],
+        system: [{ type: "text", text: "sys" }],
+        messages: [],
+      };
+      const ctx2 = await runExt(body2, { headers, dir });
+
+      assert.equal(ctx2.meta.deferredToolRewriteStats.action, "reset");
+      assert.equal(ctx2.meta.deferredToolRewriteStats.reason, "tool-schema-changed");
+      assert.equal(headers["anthropic-beta"], undefined);
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("onRequest: state persists across a simulated restart (fresh dynamic import) via disk", async () => {
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-restart" };
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      const body1 = { tools: [tool("Read"), tool("Bash")], system: [{ type: "text", text: "sys" }], messages: [] };
+      await runExt(body1, { headers, dir });
+
+      // Simulate restart: fresh module import, empty in-memory state — the
+      // classifier must reload the persisted baseline from disk.
+      const { pathToFileURL } = await import("node:url");
+      const modPath = join(__dirname, "..", "proxy", "extensions", "deferred-tool-rewrite.mjs");
+      const reloaded = await import(pathToFileURL(modPath).href + "?restart-probe=" + Date.now());
+
+      const savedHome = process.env.CLAUDE_CONFIG_DIR;
+      process.env.CLAUDE_CONFIG_DIR = dir;
+      try {
+        const body2 = {
+          tools: [tool("Read"), tool("Bash"), tool("SendMessage")],
+          system: [{ type: "text", text: "sys" }],
+          messages: [],
+        };
+        const ctx2 = { body: body2, meta: {}, headers };
+        await reloaded.default.onRequest(ctx2);
+        assert.equal(ctx2.meta.deferredToolRewriteStats.action, "rewrite", "post-restart module reloaded baseline from disk");
+        assert.deepEqual(ctx2.meta.deferredToolRewriteStats.newNames, ["SendMessage"]);
+      } finally {
+        if (savedHome === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+        else process.env.CLAUDE_CONFIG_DIR = savedHome;
+      }
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// =============================================================================
+// SYNTHETIC FIXTURE (ledger SHAPE, 2026-07-27 12:47:56 — tools[SendMessage:added])
+// =============================================================================
+
+test("fixture toolload-1247.json: prior → incoming reproduces the ledger's tools[SendMessage:added] shape as a rewrite", async () => {
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-fixture" };
+  try {
+    const raw = await readFile(FIXTURE_PATH, "utf-8");
+    const fixture = JSON.parse(raw);
+
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      const ctx1 = await runExt(structuredClone(fixture.prior), { headers, dir });
+      assert.equal(ctx1.meta.deferredToolRewriteStats.action, "no-baseline");
+
+      const ctx2 = await runExt(structuredClone(fixture.incoming), { headers, dir });
+      assert.equal(ctx2.meta.deferredToolRewriteStats.action, "rewrite");
+      assert.deepEqual(ctx2.meta.deferredToolRewriteStats.newNames, ["SendMessage"]);
+
+      // Known tools (Read, Bash) byte-identical to the fixture's prior entries.
+      assert.deepEqual(ctx2.body.tools[0], fixture.prior.tools[0]);
+      assert.deepEqual(ctx2.body.tools[1], fixture.prior.tools[1]);
+      // New tool present — but NOT marked, and this is the uncomfortable part.
+      //
+      // This fixture is the real 12:47:56 event that motivated the whole
+      // extension (threat-matrix rows 6 and 13, the 175k and 766k busts), and
+      // its model is `claude-sonnet-4-6`. The mid-conversation-tool-changes
+      // contract is not supported there — a sonnet-5 request carrying it
+      // returned `400 tool_addition/tool_removal is not supported on this
+      // model` on 2026-07-28 — so the announcement path is gated off for this
+      // model family and the new tool is forwarded plainly.
+      //
+      // Which means the mitigation does NOT apply to the traffic it was
+      // designed for. Recorded in the matrix rather than papered over here:
+      // holding tools[] stable and pinning ORDER still work on every model
+      // (they need no beta), but ADDITIONS on sonnet remain an honest bust.
+      const sendMsgTool = ctx2.body.tools.find((t) => t.name === "SendMessage");
+      assert.ok(sendMsgTool, "the new tool is still forwarded — degrade, never drop");
+      assert.ok(
+        !("defer_loading" in sendMsgTool),
+        "defer_loading belongs to a contract this model rejects with a 400",
+      );
+      // tools[] count did not shrink or reorder the known prefix.
+      assert.equal(ctx2.body.tools.length, 3);
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// =============================================================================
+// SYNTHETIC FIXTURE (ledger SHAPE, 2026-07-27 15:36 — tools:REMOVE + reorder,
+// threat-matrix row 13)
+// =============================================================================
+
+test("fixture toolgc-1536.json: CronCreate removed + DeferredToolPlaceholder reordered -> held in place, first-seen order pinned", async () => {
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-gc-fixture" };
+  try {
+    const raw = await readFile(GC_FIXTURE_PATH, "utf-8");
+    const fixture = JSON.parse(raw);
+
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      const ctx1 = await runExt(structuredClone(fixture.prior), { headers, dir });
+      assert.equal(ctx1.meta.deferredToolRewriteStats.action, "no-baseline");
+
+      const ctx2 = await runExt(structuredClone(fixture.incoming), { headers, dir });
+      assert.equal(ctx2.meta.deferredToolRewriteStats.action, "rewrite");
+      assert.deepEqual(ctx2.meta.deferredToolRewriteStats.heldNames, ["CronCreate"]);
+      assert.deepEqual(ctx2.meta.deferredToolRewriteStats.newNames, []);
+
+      // Output order is first-seen order from the baseline request, not the
+      // incoming (reordered, CronCreate-missing) array's order.
+      assert.deepEqual(
+        ctx2.body.tools.map((t) => t.name),
+        ["Read", "Bash", "CronCreate", "DeferredToolPlaceholder"],
+      );
+      // Held tool is byte-identical to its baseline form.
+      assert.deepEqual(
+        ctx2.body.tools.find((t) => t.name === "CronCreate"),
+        fixture.prior.tools.find((t) => t.name === "CronCreate"),
+      );
+      // No addition -> no tool_addition block, no beta header.
+      assert.equal(ctx2.body.system.length, 1);
+      assert.equal(headers["anthropic-beta"], undefined);
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// =============================================================================
+// SESSION KEY RESOLUTION
+// =============================================================================
+
+// Volatile session URL inside a tool DESCRIPTION. CC embeds the per-session
+// console URL in Bash's description (it is the commit trailer the model is
+// told to write) and does not embed it consistently: measured over 652
+// same-key request pairs, it flipped twice. tools[] renders BEFORE system and
+// messages, so no breakpoint survives a tools[] byte change — one such flip
+// cost 705k creation tokens. Nothing about what Bash DOES changes across it.
+test("toolFingerprint: the per-session console URL does not count as a schema change", () => {
+  const withUrl = {
+    name: "Bash",
+    description:
+      "Run a command.\n\nCo-Authored-By: X\nClaude-Session: https://claude.ai/code/session_01ABC\n" +
+      "- End PR bodies with:\n\nhttps://claude.ai/code/session_01ABC",
+    input_schema: { type: "object" },
+  };
+  const without = {
+    name: "Bash",
+    description: "Run a command.\n\nCo-Authored-By: X\n- End PR bodies with:",
+    input_schema: { type: "object" },
+  };
+  assert.equal(toolFingerprint(withUrl), toolFingerprint(without));
+});
+
+// The narrowness is the safety property: serving a stale schema for a tool
+// whose contract actually changed is the one failure this extension must
+// never produce.
+test("toolFingerprint: a genuine description change IS still a schema change", () => {
+  const a = { name: "Bash", description: "Run a command.", input_schema: { type: "object" } };
+  const b = { name: "Bash", description: "Run a DIFFERENT command.", input_schema: { type: "object" } };
+  assert.notEqual(toolFingerprint(a), toolFingerprint(b));
+  // input_schema changes too, obviously.
+  const c = { name: "Bash", description: "Run a command.", input_schema: { type: "object", required: ["x"] } };
+  assert.notEqual(toolFingerprint(a), toolFingerprint(c));
+});
+
+test("resolveToolRewriteSessionKey: prefers session-id header, falls back to model string", () => {
+  // Header path is sub-keyed by system-prompt hash (threat-matrix row 14) —
+  // "nosys" when the body carries no system prompt.
+  const withHeader = resolveToolRewriteSessionKey({ "x-claude-code-session-id": "abc-123" }, { model: "x" });
+  assert.equal(withHeader, "s-abc-123-nosys-empty");
+  const withoutHeader = resolveToolRewriteSessionKey(null, { model: "claude-sonnet-4-6" });
+  assert.equal(withoutHeader, "c-claude-sonnet-4-6-empty");
+});
+
+// Regression guard for the row-14 collision this extension shipped with:
+// one session-id header, several tenants (main thread, subagents, CC's own
+// sidecar calls), each with a DIFFERENT system prompt and a different tools
+// array. Keyed on the bare session id they shared one baseline, so every
+// alternation classified as "schema changed" and re-baselined — measured on
+// real traffic as tools[] churn RISING when the extension was enabled.
+test("resolveToolRewriteSessionKey: sidecars sharing a session-id get distinct keys", () => {
+  const headers = { "x-claude-code-session-id": "abc-123" };
+  const main = resolveToolRewriteSessionKey(headers, {
+    system: [{ type: "text", text: "You are Claude Code, Anthropic's official CLI." }],
+  });
+  const sidecar = resolveToolRewriteSessionKey(headers, {
+    system: [{ type: "text", text: "You are a Claude agent, built on Anthropic's API." }],
+  });
+  assert.notEqual(main, sidecar);
+  // Same system prompt → same bucket, so the main thread stays on one baseline.
+  const mainAgain = resolveToolRewriteSessionKey(headers, {
+    system: [{ type: "text", text: "You are Claude Code, Anthropic's official CLI." }],
+  });
+  assert.equal(main, mainAgain);
+});
+
+// --- Model gate (the 400 that killed a live dispatch) ---
+//
+// 2026-07-28: a sonnet-5 subagent dispatch died with
+// `API Error: 400 tool_addition/tool_removal is not supported on this model`.
+// The contract is a documented beta but support is per-MODEL, and this
+// extension applied it to whatever came through. A cache mitigation that can
+// HARD-FAIL a request is worse than no mitigation, so the gate is opt-IN:
+// unknown models degrade to forwarding the new tool normally.
+
+test("supportsToolAddition: opt-IN, so an unknown model is OFF", () => {
+  assert.equal(supportsToolAddition("claude-opus-5"), true);
+  assert.equal(supportsToolAddition("claude-opus-5-20260101"), true, "date-suffixed ids must match by prefix");
+  // Wire evidence 2026-07-29 (probe session c05a754c: block forwarded
+  // byte-identically, API streamed 200).
+  assert.equal(supportsToolAddition("claude-fable-5"), true);
+  // The measured failure.
+  assert.equal(supportsToolAddition("claude-sonnet-5"), false);
+  // Everything unknown is off — a new model must not be able to break a
+  // request just by existing.
+  assert.equal(supportsToolAddition("claude-haiku-4-5"), false);
+  assert.equal(supportsToolAddition("some-future-model"), false);
+  assert.equal(supportsToolAddition(undefined), false);
+  assert.equal(supportsToolAddition(null), false);
+});
+
+test("supportsToolAddition: EXTRA override admits a candidate for the live probe, per call", () => {
+  // The override serves the throwaway acceptance-probe proxy only (it is how
+  // fable-5 earned its baseline entry on 2026-07-29); it must be read per
+  // call (a long-lived process picks up the change without a module reload)
+  // and must not disturb the baseline list.
+  const prev = process.env.CACHE_FIX_TOOL_ADDITION_EXTRA;
+  try {
+    process.env.CACHE_FIX_TOOL_ADDITION_EXTRA = "claude-candidate-x, claude-candidate-y";
+    assert.equal(supportsToolAddition("claude-candidate-x"), true);
+    assert.equal(supportsToolAddition("claude-candidate-y-20260101"), true);
+    assert.equal(supportsToolAddition("claude-sonnet-5"), false, "override must not widen beyond its prefixes");
+    delete process.env.CACHE_FIX_TOOL_ADDITION_EXTRA;
+    assert.equal(supportsToolAddition("claude-candidate-x"), false, "cleared override must clear per call");
+  } finally {
+    if (prev === undefined) delete process.env.CACHE_FIX_TOOL_ADDITION_EXTRA;
+    else process.env.CACHE_FIX_TOOL_ADDITION_EXTRA = prev;
+  }
+});
+
+test("BITE — an unsupported model gets NO tool_addition, no beta header, tools passed through", async () => {
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-sonnet" };
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      const u1 = { role: "user", content: [{ type: "text", text: "turn 1" }] };
+      const base = { system: [], messages: [u1], model: "claude-sonnet-5" };
+      await runExt({ ...base, tools: [tool("Read")] }, { headers, dir });
+      const ctx = await runExt(
+        { ...base, tools: [tool("Read"), tool("SendMessage")] },
+        { headers, dir },
+      );
+      // No injected system message anywhere in messages[].
+      const injected = (ctx.body.messages || []).filter(
+        (m) => m.role === "system" && Array.isArray(m.content) && m.content.some((b) => b.type === "tool_addition"),
+      );
+      assert.equal(injected.length, 0, "no tool_addition may reach a model that 400s on it");
+      // No beta token.
+      const beta = Object.entries(ctx.headers || {}).find(([k]) => k.toLowerCase() === "anthropic-beta");
+      assert.ok(
+        !beta || !String(beta[1]).includes("mid-conversation-tool-changes"),
+        "beta token must not be sent to an unsupported model",
+      );
+      // And no defer_loading marker smuggled onto the new tool.
+      const sm = (ctx.body.tools || []).find((t) => t.name === "SendMessage");
+      assert.ok(sm, "the new tool is still forwarded — degrade, do not drop");
+      assert.ok(!("defer_loading" in sm), "defer_loading belongs to the contract the model rejects");
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a suppressed announcement is LOUD: stderr once per model, telemetry every time", async () => {
+  // The silent version of this path is the failure mode: a new model family
+  // (documented rule is "Opus onward", so it likely supports the beta) pays
+  // a full-prefix bust per tool load with nothing anywhere saying so, until
+  // someone probes it by accident. The warning names the probe; telemetry
+  // records every occurrence for counting.
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-new-family" };
+  const warnings = [];
+  const origWrite = process.stderr.write;
+  process.stderr.write = (s, ...rest) => {
+    if (String(s).includes("not allowlisted for tool_addition")) {
+      warnings.push(String(s));
+      return true;
+    }
+    return origWrite.call(process.stderr, s, ...rest);
+  };
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      const u1 = { role: "user", content: [{ type: "text", text: "turn 1" }] };
+      const base = { system: [], messages: [u1], model: "claude-new-family-7" };
+      await runExt({ ...base, tools: [tool("Read")] }, { headers, dir });
+      await runExt({ ...base, tools: [tool("Read"), tool("SendMessage")] }, { headers, dir });
+      assert.equal(warnings.length, 1, "the first suppression must warn");
+      assert.match(warnings[0], /claude-new-family-7/);
+      assert.match(warnings[0], /probe/i, "the warning must name the way out");
+      // A second suppressed load on the same model: telemetry yes, stderr no.
+      await runExt(
+        { ...base, tools: [tool("Read"), tool("SendMessage"), tool("Monitor")] },
+        { headers, dir },
+      );
+      assert.equal(warnings.length, 1, "once per model per process");
+      const { readdir: rd, readFile: rf } = await import("node:fs/promises");
+      const snapDir = join(dir, "cache-fix-snapshots");
+      const evFile = (await rd(snapDir)).find((f) => f.endsWith("-deferred-tool-events.jsonl"));
+      assert.ok(evFile, "telemetry file must exist");
+      const events = (await rf(join(snapDir, evFile), "utf-8")).trim().split("\n").map(JSON.parse);
+      const sup = events.filter((e) => e.suppressed);
+      assert.equal(sup.length, 2, "every suppressed occurrence is recorded");
+      assert.equal(sup[0].model, "claude-new-family-7");
+      assert.equal(sup[0].injected, 0);
+    });
+  } finally {
+    process.stderr.write = origWrite;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a SUPPORTED model still gets the announcement (the gate is not a kill switch)", async () => {
+  const dir = await newTmp();
+  const headers = { "x-claude-code-session-id": "sess-opus" };
+  try {
+    await withEnvAsync({ CACHE_FIX_TOOL_REWRITE: "1" }, async () => {
+      const u1 = { role: "user", content: [{ type: "text", text: "turn 1" }] };
+      const base = { system: [], messages: [u1], model: "claude-opus-5" };
+      await runExt({ ...base, tools: [tool("Read")] }, { headers, dir });
+      const ctx = await runExt(
+        { ...base, tools: [tool("Read"), tool("SendMessage")] },
+        { headers, dir },
+      );
+      const injected = (ctx.body.messages || []).filter(
+        (m) => m.role === "system" && Array.isArray(m.content) && m.content.some((b) => b.type === "tool_addition"),
+      );
+      assert.equal(injected.length, 1, "opus must keep the mitigation");
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/test/fixtures/toolgc-1536.json
+++ b/test/fixtures/toolgc-1536.json
@@ -1,0 +1,30 @@
+{
+  "_comment": "Synthetic fixture, minimal, built from the ledger SHAPE only (measured 2026-07-27 15:36, ledger row tools:REMOVE, CronCreate removed + DeferredToolPlaceholder reordered, no ToolSearch nearby; skills-update system events in-window) per docs/directives/robustness-threat-matrix.md row 13. Session mirrors were NOT read to build this — only the shape named in the matrix row (a known tool disappearing from tools[] plus an unrelated reorder, both mid-conversation, with no addition).",
+  "prior": {
+    "model": "claude-sonnet-4-6",
+    "system": [{ "type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude." }],
+    "messages": [
+      { "role": "user", "content": [{ "type": "text", "text": "schedule a cron job" }] }
+    ],
+    "tools": [
+      { "name": "Read", "input_schema": { "type": "object", "properties": { "file_path": { "type": "string" } } } },
+      { "name": "Bash", "input_schema": { "type": "object", "properties": { "command": { "type": "string" } } } },
+      { "name": "CronCreate", "input_schema": { "type": "object", "properties": { "schedule": { "type": "string" } } } },
+      { "name": "DeferredToolPlaceholder", "input_schema": { "type": "object", "properties": {} } }
+    ]
+  },
+  "incoming": {
+    "model": "claude-sonnet-4-6",
+    "system": [{ "type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude." }],
+    "messages": [
+      { "role": "user", "content": [{ "type": "text", "text": "schedule a cron job" }] },
+      { "role": "assistant", "content": [{ "type": "text", "text": "Scheduled." }] },
+      { "role": "user", "content": [{ "type": "text", "text": "thanks, what else can you do" }] }
+    ],
+    "tools": [
+      { "name": "DeferredToolPlaceholder", "input_schema": { "type": "object", "properties": {} } },
+      { "name": "Read", "input_schema": { "type": "object", "properties": { "file_path": { "type": "string" } } } },
+      { "name": "Bash", "input_schema": { "type": "object", "properties": { "command": { "type": "string" } } } }
+    ]
+  }
+}

--- a/test/fixtures/toolload-1247.json
+++ b/test/fixtures/toolload-1247.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "Synthetic fixture, minimal, built from the ledger SHAPE only (measured 2026-07-27 12:47:56, ledger row tools[SendMessage:added], toolsMatch:false) per docs/directives/proxy-deferred-tool-rewrite.md Phase A. Session mirrors were NOT read to build this — only the shape named in the directive (a tools[] array gaining exactly one new entry, SendMessage, mid-conversation).",
+  "prior": {
+    "model": "claude-sonnet-4-6",
+    "system": [{ "type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude." }],
+    "messages": [
+      { "role": "user", "content": [{ "type": "text", "text": "start a background agent" }] }
+    ],
+    "tools": [
+      { "name": "Read", "input_schema": { "type": "object", "properties": { "file_path": { "type": "string" } } } },
+      { "name": "Bash", "input_schema": { "type": "object", "properties": { "command": { "type": "string" } } } }
+    ]
+  },
+  "incoming": {
+    "model": "claude-sonnet-4-6",
+    "system": [{ "type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude." }],
+    "messages": [
+      { "role": "user", "content": [{ "type": "text", "text": "start a background agent" }] },
+      { "role": "assistant", "content": [{ "type": "text", "text": "Starting a background agent now." }] },
+      { "role": "user", "content": [{ "type": "text", "text": "ok, keep going" }] }
+    ],
+    "tools": [
+      { "name": "Read", "input_schema": { "type": "object", "properties": { "file_path": { "type": "string" } } } },
+      { "name": "Bash", "input_schema": { "type": "object", "properties": { "command": { "type": "string" } } } },
+      {
+        "name": "SendMessage",
+        "description": "Send a message to a teammate agent.",
+        "input_schema": {
+          "type": "object",
+          "properties": { "to": { "type": "string" }, "message": { "type": "string" } }
+        }
+      }
+    ]
+  }
+}

--- a/test/session-key-invariants.test.mjs
+++ b/test/session-key-invariants.test.mjs
@@ -1,0 +1,127 @@
+// Cross-extension session-key invariants — the guard against "the lesson did
+// not travel to the sibling".
+//
+// This exact failure happened twice in one day (2026-07-28), the second time
+// costing real cache:
+//
+//   insertion-normalization keyed persisted state on (session-id,
+//   system-prompt). Every subagent of a session runs the same agent prompt,
+//   so one bucket held 39 distinct conversations and 100% of conversation
+//   switches within a bucket reset (60/60). Fixed by adding a conversation
+//   sub-key: 0 resets across 940 requests.
+//
+//   deferred-tool-rewrite had the IDENTICAL key and did not get the fix,
+//   because nothing connected the two. Its tool_addition announcement is
+//   anchored to a MESSAGE IDENTITY, so under a shared key the stored anchor
+//   belonged to another conversation's history, failed to match, and
+//   re-anchored to "after the last user message" — a different index every
+//   request. Measured: our output diverging at index 4 while CC's history was
+//   byte-identical through index 23, twice in one corpus.
+//
+// A fix applied to one consumer of a shared idea is not applied. So this file
+// does not test a list someone maintains: it DISCOVERS every exported
+// `*SessionKey` function under proxy/extensions/ and holds all of them to the
+// same invariants. A new stateful extension is covered the moment it exports
+// one, and an existing one cannot quietly regress.
+//
+// If a future extension legitimately needs a coarser key, this test failing is
+// the conversation about it — which is the point.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const EXT_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "proxy", "extensions");
+
+// prefix-diff is exempt, and the exemption is checked rather than trusted.
+// It keeps its FILE key at the session id deliberately (its design note 1: a
+// path that moves with content misses its own baseline, so a bust never gets
+// logged) and separates co-tenants INSIDE the file via tenantId. It also
+// shapes no request — it is telemetry, so a coarse key costs attribution
+// precision, not cache. The exemption is paired with an assertion that
+// tenantId still exists, so if that design ever changes this guard notices
+// instead of staying quietly satisfied.
+const SEPARATES_INSIDE_THE_FILE = new Set(["prefix-diff.mjs"]);
+
+async function discoverKeyResolvers({ all = false } = {}) {
+  const found = [];
+  for (const f of (await readdir(EXT_DIR)).sort()) {
+    if (!f.endsWith(".mjs")) continue;
+    if (!all && SEPARATES_INSIDE_THE_FILE.has(f)) continue;
+    const mod = await import(pathToFileURL(join(EXT_DIR, f)).href);
+    for (const [name, fn] of Object.entries(mod)) {
+      if (typeof fn === "function" && /SessionKey$/.test(name)) {
+        found.push({ file: f, name, fn });
+      }
+    }
+  }
+  return found;
+}
+
+const HEADERS = { "x-claude-code-session-id": "shared-session" };
+const SYSTEM = [{ type: "text", text: "You are a Claude agent." }];
+const convA = [{ role: "user", content: [{ type: "text", text: "conversation A" }] }];
+const convB = [{ role: "user", content: [{ type: "text", text: "conversation B" }] }];
+
+// The resolvers do not share a signature — insertion-normalization takes
+// (headers, messages, system), deferred-tool-rewrite takes (headers, body).
+// ARITY distinguishes them mechanically, so no name list is maintained here:
+// a name list is the same hand-maintained roster this file exists to avoid.
+function callResolver(fn, { messages, system }) {
+  return fn.length >= 3
+    ? fn(HEADERS, messages, system)
+    : fn(HEADERS, { messages, system, model: "test-model" });
+}
+
+test("every extension exporting a *SessionKey is discovered", async () => {
+  const resolvers = await discoverKeyResolvers();
+  assert.ok(resolvers.length >= 2, `expected at least the two stateful extensions, found ${resolvers.length}`);
+  const files = new Set(resolvers.map((r) => r.file));
+  // These two are the reason the file exists; losing either from discovery
+  // would silently empty the guard.
+  assert.ok(files.has("insertion-normalization.mjs"), [...files].join(","));
+  assert.ok(files.has("deferred-tool-rewrite.mjs"), [...files].join(","));
+});
+
+test("BITE — a session key must separate CONVERSATIONS, not just system prompts", async () => {
+  for (const { file, name, fn } of await discoverKeyResolvers()) {
+    const a = callResolver(fn, { messages: convA, system: SYSTEM });
+    const b = callResolver(fn, { messages: convB, system: SYSTEM });
+    assert.notEqual(
+      a,
+      b,
+      `${file}:${name} gives one key to two conversations under the same session-id and system prompt — ` +
+        `the collision that cost cache in deferred-tool-rewrite. Add conversationSubKey from message-hash.mjs.`,
+    );
+  }
+});
+
+test("a session key must separate SYSTEM PROMPTS (sidecar classes)", async () => {
+  for (const { file, name, fn } of await discoverKeyResolvers()) {
+    const main = callResolver(fn, { messages: convA, system: SYSTEM });
+    const sidecar = callResolver(fn, {
+      messages: convA,
+      system: [{ type: "text", text: "Generate a concise 5-word title." }],
+    });
+    assert.notEqual(main, sidecar, `${file}:${name} shares a key across system-prompt classes`);
+  }
+});
+
+test("a session key is STABLE for the same conversation as it grows", async () => {
+  // The other half: a key that changes every turn is not an identity either,
+  // and would abandon state on every request rather than colliding.
+  for (const { file, name, fn } of await discoverKeyResolvers()) {
+    const first = callResolver(fn, { messages: convA, system: SYSTEM });
+    const grown = callResolver(fn, {
+      messages: [...convA, { role: "assistant", content: [{ type: "text", text: "reply" }] }],
+      system: SYSTEM,
+    });
+    assert.equal(first, grown, `${file}:${name} changes key as the conversation grows — state cannot persist`);
+  }
+});
+
+// (A further case verifying prefix-diff's exemption from this invariant --
+// its own tenantId separation -- ships with the prefix-diff changes, which
+// export the function it inspects.)

--- a/tools/probe-tool-addition.mjs
+++ b/tools/probe-tool-addition.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// probe-tool-addition — measure, per model, whether the API accepts the
+// mid-conversation-tool-changes contract (tool_addition blocks).
+//
+// Exists because the allowlist in deferred-tool-rewrite.mjs is opt-in with
+// evidence required, and the evidence was collected the expensive way once:
+// the extension announced additions to every model, and on 2026-07-28 a
+// sonnet-5 dispatch died with
+//
+//     API Error: 400 tool_addition/tool_removal is not supported on this model
+//
+// after which TOOL_ADDITION_MODELS was cut to the one model with wire
+// evidence. This script is the cheap way: one minimal real request per model,
+// same auth path production uses (the CC OAuth credentials the proxy keeps
+// fresh), wire shapes IMPORTED from the extension rather than re-typed here —
+// a probe that hand-rolls the shape tests the probe author's memory, not the
+// contract (the identity-key lesson, again).
+//
+// Direct to the API, not through the proxy — deliberately. The question is a
+// property of the API endpoint per model, and the proxy would wrap the probe
+// in session state, capture records and telemetry that all describe traffic
+// no session sent. The directive's "one live request through the proxy"
+// acceptance step remains what it is: end-to-end validation of the EXTENSION,
+// done once per gate flip. This measures the MODEL support matrix.
+//
+// Three answers per model, never two:
+//   ACCEPTED  — HTTP 200 with the addition block on the wire
+//   REJECTED  — HTTP 400 naming tool_addition/tool_removal
+//   COULD NOT VERIFY — anything else (auth failure, rate limit, network,
+//               unrelated 400); reported verbatim, never classified, and the
+//               process exits non-zero so a broken probe cannot read as a
+//               clean sweep.
+//
+// KNOWN LIMIT (measured 2026-07-29): on a subscription OAuth token, this
+// direct-API probe gets HTTP 429 for EVERY big model (opus, sonnet, fable)
+// regardless of quota state — hand-built requests are refused for those
+// models; only haiku answers, because CC itself sends it free-form utility
+// traffic. For big models the working probe is a real session: start a
+// throwaway proxy with CACHE_FIX_TOOL_ADDITION_EXTRA=<model> on a spare
+// port, run `claude --model <model> -p` through it with a prompt that loads
+// a tool via ToolSearch, then verify on production's capture that the
+// injected block was forwarded byte-identically (replay the pipeline,
+// compare against the outcome record's outSha) and that an outcome record
+// exists (only written on a streamed 200). That is how fable-5 was measured.
+//
+// An ACCEPTED verdict is the evidence an allowlist entry cites (prefix +
+// probe date); nothing is edited automatically.
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+import {
+  buildToolAdditionMessage,
+  injectAdditions,
+  forwardedTools,
+  anchorHash,
+  addBetaToken,
+} from "../proxy/extensions/deferred-tool-rewrite.mjs";
+
+const API = "https://api.anthropic.com/v1/messages";
+
+// The current Claude lineup as CC sends it. Override: pass model ids as argv.
+const DEFAULT_MODELS = [
+  "claude-opus-5",
+  "claude-fable-5",
+  "claude-sonnet-5",
+  "claude-haiku-4-5-20251001",
+];
+
+async function accessToken() {
+  const raw = await readFile(join(homedir(), ".claude", ".credentials.json"), "utf-8");
+  const c = JSON.parse(raw);
+  const o = c.claudeAiOauth ?? c;
+  if (!o.accessToken) throw new Error(".credentials.json carries no accessToken");
+  if (o.expiresAt && o.expiresAt < Date.now()) {
+    throw new Error("access token expired — start a Claude Code session to refresh it");
+  }
+  return o.accessToken;
+}
+
+function probeBody(model) {
+  // Two tools: one present from the start, one "added mid-conversation" via
+  // the real builders. forwardedTools marks the added one defer_loading; the
+  // addition message is injected at its anchor exactly as onRequest does.
+  const toolA = {
+    name: "echo_base",
+    description: "Echo the input string.",
+    input_schema: { type: "object", properties: { s: { type: "string" } }, required: ["s"] },
+  };
+  const toolB = {
+    name: "echo_added",
+    description: "Echo the input string (added mid-conversation).",
+    input_schema: { type: "object", properties: { s: { type: "string" } }, required: ["s"] },
+  };
+  const user = { role: "user", content: "Reply with the single word ok. Do not use tools." };
+  const additions = [
+    {
+      names: [toolB.name],
+      anchorHash: anchorHash(user),
+      message: buildToolAdditionMessage([toolB.name]),
+    },
+  ];
+  const { messages } = injectAdditions([user], additions);
+  return {
+    model,
+    max_tokens: 16,
+    messages,
+    tools: forwardedTools([toolA, toolB], additions),
+  };
+}
+
+async function probe(model, token) {
+  const headers = {
+    "content-type": "application/json",
+    "anthropic-version": "2023-06-01",
+    "anthropic-beta": "oauth-2025-04-20",
+    authorization: `Bearer ${token}`,
+  };
+  addBetaToken(headers); // the same token the extension puts on real traffic
+  let res, text;
+  try {
+    res = await fetch(API, { method: "POST", headers, body: JSON.stringify(probeBody(model)) });
+    text = await res.text();
+  } catch (e) {
+    return { model, verdict: "COULD NOT VERIFY", detail: `network: ${e?.message ?? e}` };
+  }
+  if (res.status === 200) return { model, verdict: "ACCEPTED", detail: "HTTP 200" };
+  if (res.status === 400 && /tool_addition|tool_removal/.test(text)) {
+    return { model, verdict: "REJECTED", detail: text.slice(0, 200) };
+  }
+  return { model, verdict: "COULD NOT VERIFY", detail: `HTTP ${res.status}: ${text.slice(0, 300)}` };
+}
+
+const models = process.argv.slice(2).length ? process.argv.slice(2) : DEFAULT_MODELS;
+const token = await accessToken();
+let unverified = 0;
+console.log(`probing ${models.length} model(s) against ${API}\n`);
+for (const m of models) {
+  const r = await probe(m, token);
+  if (r.verdict === "COULD NOT VERIFY") unverified++;
+  console.log(`${r.verdict.padEnd(18)} ${m}`);
+  if (r.verdict !== "ACCEPTED") console.log(`                   ${r.detail}\n`);
+}
+if (unverified) {
+  console.error(`\n${unverified} model(s) COULD NOT be verified — that is not a verdict either way.`);
+  process.exit(1);
+}


### PR DESCRIPTION
> **Stacked on #272** — includes its commit (`message-hash.mjs` identity + the insertion-normalization system-prompt sub-key). Review the tip commit; will rebase once #272 lands.

## The bust class

Every ToolSearch/deferred-tool load makes Claude Code re-send a different `tools[]` array. `tools[]` heads the cache prefix, so each load re-bills the whole context. This is the class in anthropics/claude-code#81967 (there triggered by LSP add/remove — the deferred-tool path hits it far more often; at 700k context one load re-bills ~700k tokens).

The remarkable part: **the API already ships the fix.** The documented `mid-conversation-tool-changes-2026-07-01` beta lets a request announce an added tool in a `tool_addition` block at the *tail* of the conversation, leaving the prefix untouched — and Claude Code 2.1.220 carries that beta's documentation inside its own binary without using it on the wire.

## The mitigation

- `tools[]` is frozen at its first-seen form per session (keyed session + system-prompt + conversation, so subagents/sidecars never share a baseline — the keying collision was a measured bug before it was a design note).
- A mid-session addition keeps the frozen bytes; the new tool is announced via a `tool_addition` system message anchored at the tail, re-injected at a stable anchor on every subsequent request, beta header added. Removals/reorders are held byte-stable; a schema change resets honestly.
- **Opt-in per model, evidence required.** The beta is rolled out per model family; an unsupported model rejects the whole request with a 400 (measured: `claude-sonnet-5`, `claude-haiku-4-5` — haiku's error names the gating capability, "requires a model that supports mid-conversation system content"). Unknown models degrade to the status-quo bust, never a lost request, and the first suppressed announcement per model logs a warning naming the way out.
- `tools/probe-tool-addition.mjs` measures a candidate model in one real request; `CACHE_FIX_TOOL_ADDITION_EXTRA` admits a candidate on a throwaway proxy for a live probe. Allowlisted with wire evidence: `claude-opus-5`, `claude-fable-5` (capture holds the injected block; replaying the pipeline reproduces the forwarded body hash byte-for-byte; outcome record shows the API streamed a 200).

Off by default: `CACHE_FIX_TOOL_REWRITE=1`.

## Evidence

In production on this fork across multi-hundred-request sessions: additions announced with 0 re-billed prefix bytes, removals held stable (`14->13` incoming forwarded as `14->14`), 0 stability/sequence/order violations under a daily replay gate over ~2.5 GB of captures. 41 tests including bite tests for the model gate (unsupported model: no block, no beta header, no defer_loading markers — demonstrated red before the gate existed, when it killed a day of sonnet subagent dispatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)