### PR TITLE
feat(capture): pre-pipeline request capture + source/gate provenance on /health

### DIFF
--- a/proxy/extensions.json
+++ b/proxy/extensions.json
@@ -1,5 +1,6 @@
 {
   "bootstrap-defense": { "enabled": true, "order": 45 },
+  "request-capture": { "enabled": true, "order": 60 },
   "ttl-tier-detect": { "enabled": true, "order": 75 },
   "cc-version-normalize": { "enabled": true, "order": 90 },
   "fingerprint-strip": { "enabled": true, "order": 100 },

--- a/proxy/extensions/request-capture.mjs
+++ b/proxy/extensions/request-capture.mjs
@@ -1,0 +1,319 @@
+// request-capture — record full request bodies for offline replay.
+//
+// Directive: docs/directives/proxy-request-capture-replay.md (stage 1).
+// The proxy is the only component that sees every request byte-for-byte;
+// until this extension, it threw the bodies away, so every pipeline
+// change could only be validated against synthetic fixtures or live
+// traffic. Captures feed tools/replay.mjs and tools/cache-sim.mjs.
+//
+// Order 60 — after bootstrap-defense (45) and ttl-tier-detect (75 is
+// AFTER, fine: it only reads), before cc-version-normalize (90), the
+// first extension that MUTATES the body. Capture must record what CC
+// sent, not what the pipeline made of it.
+//
+// Activation: `enabled: true` in extensions.json (always loaded), runtime
+// gate CACHE_FIX_REQUEST_CAPTURE=1 (read per-call so tests can flip it).
+// Fail-open: capture failure never fails the request. CACHE_FIX_DEBUG=1
+// logs swallowed errors, same idiom as prefix-diff.
+//
+// Sensitivity: captures contain the FULL conversation content — the same
+// sensitivity as the transcripts in ~/.claude/projects/, on the same
+// machine. No new exposure class; documented in the directive.
+//
+// Retention: CACHE_FIX_CAPTURE_MAX_MB (default 2048). Checked every
+// SWEEP_EVERY appends per process; oldest capture files deleted first
+// until under the cap. The sweep is best-effort and fail-open.
+
+import { appendFile, mkdir, readdir, stat, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { claudeHome } from "../claude-home.mjs";
+import { resolveSessionId } from "./cache-telemetry.mjs";
+import { createHash } from "node:crypto";
+
+const DEFAULT_FS = { appendFile, mkdir, readdir, stat, unlink };
+const SWEEP_EVERY = 50;
+
+let _appendsSinceSweep = 0;
+// The source tree the traffic was served by, read from the environment the
+// server publishes it into. NOT module state: loadExtensions cache-busts its
+// imports, so a setter would land on a different module instance than the one
+// the pipeline runs and the field would stay null forever.
+function proxyTree() {
+  return process.env.CACHE_FIX_PROXY_TREE || null;
+}
+
+function isEnabled(env = process.env) {
+  return env.CACHE_FIX_REQUEST_CAPTURE === "1";
+}
+
+function isDebug(env = process.env) {
+  return env.CACHE_FIX_DEBUG === "1";
+}
+
+function debug(msg) {
+  if (isDebug()) process.stderr.write(`[request-capture] DEBUG: ${msg}\n`);
+}
+
+function getCaptureDir() {
+  return join(claudeHome(), "cache-fix-captures");
+}
+
+function getMaxBytes(env = process.env) {
+  const raw = parseInt(env.CACHE_FIX_CAPTURE_MAX_MB ?? "2048", 10);
+  const mb = Number.isFinite(raw) && raw > 0 ? raw : 2048;
+  return mb * 1024 * 1024;
+}
+
+// Same key derivation family as prefix-diff/insertion-normalization:
+// session-id header preferred, content-hash fallback — captures must join
+// against the existing events ledgers by key + ts.
+export function resolveCaptureKey(headers, body) {
+  const sid = headers ? resolveSessionId(headers) : null;
+  if (sid) return `s-${sid.replace(/[^A-Za-z0-9_-]/g, "_")}`;
+  const first = Array.isArray(body?.messages) ? body.messages[0] : null;
+  const h = first
+    ? createHash("sha256").update(JSON.stringify(first)).digest("hex").slice(0, 12)
+    : "empty";
+  return `c-${h}`;
+}
+
+// One NDJSON record per request. Headers are reduced to the two that
+// matter for replay fidelity (beta set: cache semantics; session-id:
+// key derivation) — full header capture would add auth material to a
+// file that must never contain it.
+export function buildCaptureRecord(ctx, now = new Date(), id = null) {
+  const headers = ctx.headers || {};
+  return {
+    ts: now.toISOString(),
+    // Join key. Until 2026-07-28 a capture line carried no identifier, so the
+    // only way to tie a recorded request to what it COST was to compare wall
+    // clocks against a separate ledger — which mis-attributed a 484k event to
+    // the wrong session twice in one evening before the error was caught.
+    id,
+    sid: resolveSessionId(headers) ?? null,
+    key: resolveCaptureKey(headers, ctx.body),
+    headers: {
+      "anthropic-beta": headers["anthropic-beta"] ?? null,
+      "session-id": headers["session-id"] ?? headers["x-session-id"] ?? null,
+    },
+    body: ctx.body,
+  };
+}
+
+// The OUTCOME of a captured request: what the API actually charged.
+//
+// A capture recorded what was SENT and never what it cost, so every
+// cache question had to be answered by inference — prefix-diff's `cause` is a
+// hypothesis about what the API keyed on, never a measurement. With
+// `cache_read_input_tokens` on the record, the matched prefix LENGTH becomes
+// observable: the cache keys on the longest identical prefix, so a read of N
+// tokens says where the match ended, and that can be compared against message
+// boundaries instead of guessed at.
+//
+// Written as a SEPARATE line rather than by amending the request line: the
+// request must reach disk immediately (a response that never arrives must not
+// lose the request from the corpus), and an append-only file cannot be
+// rewritten in place. Consumers join on `id`.
+export function buildOutcomeRecord(ctx, id, key, now = new Date()) {
+  // Usage is read from the EVENT, not from another extension's meta.
+  //
+  // The first version read `meta.cacheStats`, which cache-telemetry populates
+  // on this same frame — but cache-telemetry is order 100 and this extension
+  // is order 60, so it ran first and always saw undefined. It wrote nothing,
+  // logged nothing, and looked exactly like a feature that worked. Reading the
+  // frame directly removes the ordering dependency instead of reversing it,
+  // and a hidden coupling to another extension's side effect is worth removing
+  // on its own.
+  const u = ctx?.event?.message?.usage;
+  const cs = u
+    ? {
+        cacheRead: u.cache_read_input_tokens || 0,
+        cacheCreation: u.cache_creation_input_tokens || 0,
+        inputTokens: u.input_tokens || 0,
+        outputTokens: u.output_tokens || 0,
+        // cache_creation may carry the per-tier split alongside the scalar.
+        ephemeral1h: (u.cache_creation && u.cache_creation.ephemeral_1h_input_tokens) || 0,
+        ephemeral5m: (u.cache_creation && u.cache_creation.ephemeral_5m_input_tokens) || 0,
+      }
+    : ctx?.meta?.cacheStats;
+  if (!cs || !id) return null;
+  return {
+    ts: now.toISOString(),
+    type: "outcome",
+    id,
+    key,
+    // The upstream request-id also appears in CC's own session transcript
+    // (jsonl-session-mirror records it), so this is the field that finally
+    // joins three records that described the same event and shared no key:
+    // the cold-rewrite ledger, the capture, and CC's transcript.
+    requestId: ctx?.meta?._captureRequestId ?? null,
+    model: ctx?.event?.message?.model ?? ctx?.meta?._servedModel ?? null,
+    // Everything the API told us it charged. Recorded in full rather than
+    // reduced to one number: the tier split says which TTL the cache actually
+    // used (not a heuristic), input/output separate the prompt from the
+    // completion, and a zero cacheRead beside a large cacheCreation IS the
+    // definition of a cold rewrite — the event the whole corpus exists to
+    // explain.
+    usage: {
+      cacheRead: cs.cacheRead ?? 0,
+      cacheCreation: cs.cacheCreation ?? 0,
+      inputTokens: cs.inputTokens ?? 0,
+      outputTokens: cs.outputTokens ?? 0,
+      ephemeral1h: cs.ephemeral1h ?? 0,
+      ephemeral5m: cs.ephemeral5m ?? 0,
+    },
+    // What we actually put on the wire, so a replay can PROVE it reproduced
+    // the real request instead of assuming it. Set in server.mjs at the one
+    // point the outbound bytes exist.
+    outSha: ctx?.meta?._forwardedSha ?? null,
+    outBytes: ctx?.meta?._forwardedBytes ?? null,
+    // Wall time from request to first usage — separates "the cache was cold"
+    // from "the request was slow for another reason".
+    ms: ctx?.meta?._captureStart ? Date.now() - ctx.meta._captureStart : null,
+  };
+}
+
+// Delete oldest capture files until the directory is under maxBytes.
+// Returns the number of files deleted (for tests/telemetry).
+export async function sweepCaptureDir(dir, maxBytes, fs = DEFAULT_FS) {
+  let files;
+  try {
+    files = await fs.readdir(dir);
+  } catch {
+    return 0;
+  }
+  const entries = [];
+  for (const f of files) {
+    if (!f.endsWith("-requests.jsonl")) continue;
+    try {
+      const st = await fs.stat(join(dir, f));
+      entries.push({ f, size: st.size, mtimeMs: st.mtimeMs });
+    } catch {}
+  }
+  let total = entries.reduce((a, e) => a + e.size, 0);
+  if (total <= maxBytes) return 0;
+  entries.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  let deleted = 0;
+  for (const e of entries) {
+    if (total <= maxBytes) break;
+    try {
+      await fs.unlink(join(dir, e.f));
+      total -= e.size;
+      deleted++;
+    } catch {}
+  }
+  return deleted;
+}
+
+// One per proxy boot, written into every capture file the boot touches.
+//
+// Two things were unrecoverable from a corpus without it, and both cost time
+// on 2026-07-28:
+//
+//   RESTARTS — a restart resets module-scope state, so replaying across one
+//   without knowing where it happened silently models a different run.
+//   `--restart-at N` exists precisely for this and had to be guessed by
+//   reading journalctl and matching wall clocks.
+//
+//   THE GATE SET — a capture never recorded which mitigations were ON while it
+//   was written, so replaying yesterday's traffic under today's gates compares
+//   two different worlds and calls the difference a finding. That is the same
+//   class as the gate runner replaying extension DEFAULTS while production ran
+//   eleven gates: a verdict over the wrong configuration.
+export function buildBootRecord(now = new Date(), env = process.env, tree = null) {
+  const gates = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (k.startsWith("CACHE_FIX_") && k !== "CACHE_FIX_PROXY_TREE") gates[k] = v;
+  }
+  return {
+    ts: now.toISOString(),
+    type: "boot",
+    pid: process.pid,
+    proxyTree: tree,
+    gates,
+  };
+}
+
+let _bootWrittenFor = new Set();
+
+export default {
+  name: "request-capture",
+  description:
+    "Append full request bodies (pre-mutation) to " +
+    "~/.claude/cache-fix-captures/<key>-requests.jsonl for offline " +
+    "replay and cache simulation",
+  enabled: false, // overridden by extensions.json
+  order: 60,
+
+  async onRequest(ctx) {
+    if (!isEnabled()) return;
+    if (!ctx || !ctx.body || !Array.isArray(ctx.body.messages)) return;
+
+    try {
+      const dir = getCaptureDir();
+      // Random, not sequential: capture files rotate and several proxies may
+      // write concurrently, so a counter would collide across boots.
+      const id = randomUUID().slice(0, 12);
+      ctx.meta = ctx.meta || {};
+      ctx.meta._captureId = id;
+      ctx.meta._captureStart = Date.now();
+      const record = buildCaptureRecord(ctx, new Date(), id);
+      ctx.meta._captureKey = record.key;
+      // First write into this file from this boot: stamp the boundary and the
+      // configuration, so the corpus carries its own provenance.
+      if (!_bootWrittenFor.has(record.key)) {
+        _bootWrittenFor.add(record.key);
+        await DEFAULT_FS.mkdir(dir, { recursive: true });
+        await DEFAULT_FS.appendFile(
+          join(dir, `${record.key}-requests.jsonl`),
+          JSON.stringify(buildBootRecord(new Date(), process.env, proxyTree())) + "\n",
+        );
+      }
+      await DEFAULT_FS.mkdir(dir, { recursive: true });
+      await DEFAULT_FS.appendFile(
+        join(dir, `${record.key}-requests.jsonl`),
+        JSON.stringify(record) + "\n",
+      );
+      if (++_appendsSinceSweep >= SWEEP_EVERY) {
+        _appendsSinceSweep = 0;
+        await sweepCaptureDir(dir, getMaxBytes(), DEFAULT_FS);
+      }
+    } catch (err) {
+      debug(`capture failed: ${err?.message ?? err}`);
+    }
+  },
+
+  // Response headers carry the upstream request-id; stash it for the outcome
+  // record written once usage arrives.
+  async onResponseStart(ctx) {
+    if (!isEnabled() || !ctx?.meta) return;
+    ctx.meta._captureRequestId = ctx.headers?.["request-id"] ?? null;
+  },
+
+  // Usage arrives on the streaming `message_start` frame — the same mechanism
+  // cache-telemetry uses, and the only one that fires on the SSE path that
+  // /v1/messages actually takes. Written once per request: `message_delta`
+  // updates output tokens afterwards, but waiting for it would risk losing the
+  // record entirely on a cancelled stream, and the cache numbers (which are
+  // the point) are final at message_start.
+  async onStreamEvent(ctx) {
+    if (!isEnabled() || !ctx?.meta) return;
+    if (ctx.event?.type !== "message_start") return;
+    if (ctx.meta._captureOutcomeWritten) return;
+    try {
+      const id = ctx.meta._captureId;
+      const key = ctx.meta._captureKey;
+      if (!id || !key) return;
+        const record = buildOutcomeRecord(ctx, id, key);
+      if (!record) return;
+      ctx.meta._captureOutcomeWritten = true;
+      await DEFAULT_FS.appendFile(
+        join(getCaptureDir(), `${key}-requests.jsonl`),
+        JSON.stringify(record) + "\n",
+      );
+    } catch (err) {
+      debug(`outcome capture failed: ${err?.message ?? err}`);
+    }
+  },
+};

--- a/proxy/extensions/request-capture.mjs
+++ b/proxy/extensions/request-capture.mjs
@@ -24,14 +24,24 @@
 // SWEEP_EVERY appends per process; oldest capture files deleted first
 // until under the cap. The sweep is best-effort and fail-open.
 
-import { appendFile, mkdir, readdir, stat, unlink } from "node:fs/promises";
+import { appendFile, chmod, mkdir, readdir, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { claudeHome } from "../claude-home.mjs";
 import { resolveSessionId } from "./cache-telemetry.mjs";
 import { createHash } from "node:crypto";
+import { appendFileOwnerOnly } from "./write-owner-only.mjs";
+import { publishableGates } from "../gate-allowlist.mjs";
 
-const DEFAULT_FS = { appendFile, mkdir, readdir, stat, unlink };
+// The capture directory holds whole request and response bodies — the most
+// sensitive thing this proxy writes anywhere. 0700 so the directory listing
+// itself, which leaks session keys through filenames, is owner-only too;
+// the files inside are 0600 via appendFileOwnerOnly. Both are applied at
+// CREATE rather than chmod'ed afterwards, so there is no window in which a
+// capture file exists at the ambient umask.
+const CAPTURE_DIR_MODE = 0o700;
+
+const DEFAULT_FS = { appendFile, chmod, mkdir, readdir, stat, unlink };
 const SWEEP_EVERY = 50;
 
 let _appendsSinceSweep = 0;
@@ -222,10 +232,12 @@ export async function sweepCaptureDir(dir, maxBytes, fs = DEFAULT_FS) {
 //   class as the gate runner replaying extension DEFAULTS while production ran
 //   eleven gates: a verdict over the wrong configuration.
 export function buildBootRecord(now = new Date(), env = process.env, tree = null) {
-  const gates = {};
-  for (const [k, v] of Object.entries(env)) {
-    if (k.startsWith("CACHE_FIX_") && k !== "CACHE_FIX_PROXY_TREE") gates[k] = v;
-  }
+  // Allowlisted gate VALUES only; every other CACHE_FIX_* key is present by
+  // NAME with its value redacted. A capture file is the artifact most likely
+  // to be attached to a bug report or replayed elsewhere, and the environment
+  // holds credentials and machine paths beside the switches. PROXY_TREE is
+  // skipped because it is already a field of this record.
+  const gates = publishableGates(env, { skip: ["CACHE_FIX_PROXY_TREE"] });
   return {
     ts: now.toISOString(),
     type: "boot",
@@ -264,16 +276,18 @@ export default {
       // configuration, so the corpus carries its own provenance.
       if (!_bootWrittenFor.has(record.key)) {
         _bootWrittenFor.add(record.key);
-        await DEFAULT_FS.mkdir(dir, { recursive: true });
-        await DEFAULT_FS.appendFile(
+        await DEFAULT_FS.mkdir(dir, { recursive: true, mode: CAPTURE_DIR_MODE });
+        await appendFileOwnerOnly(
           join(dir, `${record.key}-requests.jsonl`),
           JSON.stringify(buildBootRecord(new Date(), process.env, proxyTree())) + "\n",
+          DEFAULT_FS,
         );
       }
-      await DEFAULT_FS.mkdir(dir, { recursive: true });
-      await DEFAULT_FS.appendFile(
+      await DEFAULT_FS.mkdir(dir, { recursive: true, mode: CAPTURE_DIR_MODE });
+      await appendFileOwnerOnly(
         join(dir, `${record.key}-requests.jsonl`),
         JSON.stringify(record) + "\n",
+        DEFAULT_FS,
       );
       if (++_appendsSinceSweep >= SWEEP_EVERY) {
         _appendsSinceSweep = 0;
@@ -308,9 +322,10 @@ export default {
         const record = buildOutcomeRecord(ctx, id, key);
       if (!record) return;
       ctx.meta._captureOutcomeWritten = true;
-      await DEFAULT_FS.appendFile(
+      await appendFileOwnerOnly(
         join(getCaptureDir(), `${key}-requests.jsonl`),
         JSON.stringify(record) + "\n",
+        DEFAULT_FS,
       );
     } catch (err) {
       debug(`outcome capture failed: ${err?.message ?? err}`);

--- a/proxy/extensions/write-owner-only.mjs
+++ b/proxy/extensions/write-owner-only.mjs
@@ -1,0 +1,111 @@
+import { appendFile as _appendFile, chmod as _chmod, writeFile as _writeFile } from "node:fs/promises";
+import { appendFileSync, chmodSync, writeFileSync } from "node:fs";
+
+// Owner-only (0600) writes for conversation-derived state.
+//
+// WHAT THIS GUARANTEES. Every file the proxy writes under the user's
+// Claude config root whose content is derived from live traffic —
+// message bytes, request/response bodies, system-prompt text, and the
+// stable session identifiers that link a record back to a conversation —
+// is readable and writable by its owner alone.
+//
+// WHY. Without an explicit mode these files land at the ambient umask:
+// 0664 or 0644, i.e. group- or world-readable. The threat is not a
+// remote attacker; it is that ~/.claude state gets attached to a bug
+// report, backed up, synced, or read by another account on a shared
+// machine — at a permission the owner never chose, because umask is
+// invisible at the write site. Reported as a series-wide finding across
+// three PRs writing the same shape (#272 canon content, #275 request
+// bodies, #280 system-prompt text), so it is fixed once, here.
+//
+// TWO MECHANISMS, because neither covers the other's case:
+//
+//   1. `mode` at CREATE. Node applies the `mode` option only when the
+//      write actually creates the file. Passing it means a new file is
+//      never, not even briefly, group-readable — there is no window
+//      between creation and a repair.
+//   2. A lazy chmod, once per path per process. This is what fixes files
+//      created before this module existed, and the rare umask that masks
+//      bits out of the create mode (chmod ignores umask; the `mode`
+//      option does not). It is deliberately NOT a startup sweep: a sweep
+//      would have to guess the file set and would touch state nobody
+//      writes again. Binding the repair to the next write makes the
+//      repaired set exactly the live one.
+//
+// ATOMIC WRITERS (tmp + rename) need only mechanism 1, which is why the
+// write helpers below take no repair path. The tmp file is always freshly
+// created, so it is born 0600, and the rename carries that mode onto the
+// final path — replacing a loose mode on an existing final file for free.
+// Log rotation (`rename(path, path + ".1")`) preserves mode the same way.
+
+export const OWNER_ONLY = 0o600;
+
+// Paths already repaired in this process. Bounded by the number of
+// distinct state files a single proxy process touches, which is a handful
+// per session — not the unbounded per-request growth a cache would be.
+const repaired = new Set();
+
+// Repair an existing file's mode once per path per process. Best-effort by
+// design: a chmod failure must never fail the write that triggered it —
+// the file is written either way, and losing telemetry to a permissions
+// error would be a worse outcome than a stale mode. ENOENT is the normal
+// case on first write (the file does not exist yet) and is not a problem:
+// the create mode already covered it.
+export async function ensureOwnerOnly(path, fs) {
+  if (repaired.has(path)) return;
+  repaired.add(path);
+  try {
+    await (fs?.chmod ?? _chmod)(path, OWNER_ONLY);
+  } catch {
+    // Intentionally silent — see above.
+  }
+}
+
+function repairOnceSync(path) {
+  if (repaired.has(path)) return;
+  repaired.add(path);
+  try {
+    chmodSync(path, OWNER_ONLY);
+  } catch {
+    // Intentionally silent — see above.
+  }
+}
+
+/**
+ * Write a file owner-only. Intended for the tmp half of a tmp+rename
+ * atomic write, where the target is newly created every time.
+ *
+ * `fs` is the injected filesystem seam the call sites already carry
+ * (DEFAULT_FS objects with a `writeFile`); it defaults to node's promises
+ * API for the sites that import the functions directly.
+ */
+export async function writeFileOwnerOnly(path, data, fs) {
+  const writeFn = fs?.writeFile ?? _writeFile;
+  await writeFn(path, data, { mode: OWNER_ONLY });
+}
+
+/**
+ * Append to a file owner-only, repairing a stale mode on this process's
+ * first append to the path.
+ */
+export async function appendFileOwnerOnly(path, data, fs) {
+  const appendFn = fs?.appendFile ?? _appendFile;
+  await ensureOwnerOnly(path, fs);
+  await appendFn(path, data, { mode: OWNER_ONLY });
+}
+
+/** Synchronous counterpart of `writeFileOwnerOnly`. */
+export function writeFileSyncOwnerOnly(path, data) {
+  writeFileSync(path, data, { mode: OWNER_ONLY });
+}
+
+/** Synchronous counterpart of `appendFileOwnerOnly`. */
+export function appendFileSyncOwnerOnly(path, data) {
+  repairOnceSync(path);
+  appendFileSync(path, data, { mode: OWNER_ONLY });
+}
+
+/** Test seam: forget the per-process repair memo. */
+export function _resetRepairMemo() {
+  repaired.clear();
+}

--- a/proxy/gate-allowlist.mjs
+++ b/proxy/gate-allowlist.mjs
@@ -1,0 +1,96 @@
+// Which CACHE_FIX_* values may be published, and the rule for everything else.
+//
+// TWO CONSUMERS, one definition: `/health`'s `gates` object and the capture
+// corpus's boot record. Both existed to answer one question — "which gates was
+// this proxy actually running with" — and both answered it by dumping every
+// CACHE_FIX_* variable with its VALUE. That is more than the question needs and
+// more than is safe to publish: `/health` is served to anything that can reach
+// the port, and a capture file is the artifact most likely to be attached to a
+// bug report or replayed on another machine.
+//
+// The environment is not a uniform population. Of the ~117 CACHE_FIX_* names
+// this codebase reads, the switches are inert to publish ("1", "on", a byte
+// budget) while others carry an OAuth client id, a token endpoint, a
+// credentials path, the upstream URL, a command line, and a dozen filesystem
+// paths that describe the operator's machine. A dump cannot tell them apart.
+//
+// SO THE DEFAULT IS NAME-ONLY, and that is the load-bearing decision here.
+// An allowlisted key is published as `KEY: value`. Everything else is
+// published as its NAME with a `<redacted>` marker — the reader still learns
+// that the variable is set, which is what provenance needs, and learns nothing
+// about what it is set to. A new CACHE_FIX_* variable added tomorrow is
+// therefore safe on the day it is added, without anyone remembering this file
+// exists. Redaction lists fail the other way round: they cover the hazards
+// someone enumerated and ship the unanticipated one by default.
+//
+// The allowlist below is the set whose VALUE answers the gates question — the
+// pipeline switches and the numeric budgets that change behaviour. It contains
+// no path, no URL, no command, no credential, and no free-form pattern, and a
+// key of any of those kinds must not be added to it.
+
+export const PUBLISHABLE_GATES = new Set([
+  // Pipeline switches (the production set in cache-fix-proxy.service).
+  "CACHE_FIX_FORWARD_PROXY",
+  "CACHE_FIX_INSERTION_NORMALIZE",
+  "CACHE_FIX_OUTPUT_GUARD",
+  "CACHE_FIX_PREFIXDIFF",
+  "CACHE_FIX_REQUEST_CAPTURE",
+  "CACHE_FIX_SESSION_MIRROR",
+  "CACHE_FIX_TOOL_REWRITE",
+  "CACHE_FIX_UPSTREAM_DETECTION",
+  "CACHE_FIX_UPSTREAM_ERROR_LOG",
+  "CACHE_FIX_VOLATILE_PIN",
+  // Further behaviour switches, same character.
+  "CACHE_FIX_AUTO_1M_GUARD",
+  "CACHE_FIX_BOOTSTRAP_MODE",
+  "CACHE_FIX_DEBUG",
+  "CACHE_FIX_DISABLED",
+  "CACHE_FIX_HOT_RELOAD",
+  "CACHE_FIX_IMAGE_GUARD",
+  "CACHE_FIX_IMAGE_RETRY_BREAKER",
+  "CACHE_FIX_NORMALIZE_CC_VERSION",
+  "CACHE_FIX_NORMALIZE_MICROCOMPACT",
+  "CACHE_FIX_OAUTH_REFRESH",
+  "CACHE_FIX_OVERAGE_WARNING",
+  "CACHE_FIX_READ_DEDUPE",
+  "CACHE_FIX_REQUEST_LOG",
+  "CACHE_FIX_SESSION_BUDGET",
+  "CACHE_FIX_THINKING_DISPLAY",
+  "CACHE_FIX_THINKING_RISK",
+  "CACHE_FIX_THINKING_SANITIZE",
+  "CACHE_FIX_USAGE_LOG",
+  "CACHE_FIX_WIRED_BY_LAUNCHER",
+  "CACHE_FIX_WORKFLOW_AGENT_DERIVATION",
+  // Numeric budgets and limits — a size, never an identifier.
+  "CACHE_FIX_CAPTURE_MAX_MB",
+  "CACHE_FIX_IMAGE_COUNT_MAX",
+  "CACHE_FIX_IMAGE_KEEP_LAST",
+  "CACHE_FIX_IMAGE_MAX_DIM",
+  "CACHE_FIX_IMAGE_REQUEST_SIZE_MAX",
+  "CACHE_FIX_PROXY_PORT",
+  "CACHE_FIX_PROXY_TIMEOUT",
+  "CACHE_FIX_SESSION_BUDGET_TOKENS",
+  "CACHE_FIX_TTL_MAIN",
+  "CACHE_FIX_TTL_SUBAGENT",
+]);
+
+export const REDACTED = "<redacted>";
+
+/**
+ * The publishable view of the CACHE_FIX_* environment: allowlisted keys with
+ * their values, every other CACHE_FIX_* key present by NAME with its value
+ * replaced by `REDACTED`. Sorted, so two boot records or two /health reads are
+ * comparable byte-for-byte.
+ *
+ * `skip` drops keys entirely — used for CACHE_FIX_PROXY_TREE, which the boot
+ * record already carries as its own field.
+ */
+export function publishableGates(env = process.env, { skip = [] } = {}) {
+  const skipSet = new Set(skip);
+  const out = {};
+  for (const key of Object.keys(env).sort((a, b) => a.localeCompare(b))) {
+    if (!key.startsWith("CACHE_FIX_") || skipSet.has(key)) continue;
+    out[key] = PUBLISHABLE_GATES.has(key) ? env[key] : REDACTED;
+  }
+  return out;
+}

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -9,6 +9,7 @@ import { startWatcher } from "./watcher.mjs";
 import { startOAuthRefresher, stopOAuthRefresher } from "./oauth/refresher.mjs";
 import { attachForwardProxy, handleDownloadsAbsolute } from "./forward-proxy.mjs";
 import { sourceFingerprint, PROXY_ROOT } from "./source-fingerprint.mjs";
+import { publishableGates } from "./gate-allowlist.mjs";
 
 // Debug logging — writes to ~/.claude/cache-fix-debug.log (override path with
 // CACHE_FIX_DEBUG_LOG). Self-gated on CACHE_FIX_DEBUG=1; a no-op otherwise.
@@ -597,11 +598,11 @@ export async function startProxy(options = {}) {
   // failure to read our own source must not take the proxy down — an unknown
   // fingerprint reports as null, which a checker can distinguish from a
   // mismatch.
-  _gates = Object.fromEntries(
-    Object.entries(process.env)
-      .filter(([k]) => k.startsWith("CACHE_FIX_"))
-      .sort(([a], [b]) => a.localeCompare(b)),
-  );
+  // Allowlisted gate VALUES, every other CACHE_FIX_* key by name only. /health
+  // is served to anything that can reach the port, and the environment holds an
+  // OAuth client id, a token endpoint and a dozen machine paths alongside the
+  // switches. See proxy/gate-allowlist.mjs for why the default is name-only.
+  _gates = publishableGates(process.env);
   try {
     _sourceTree = await sourceFingerprint(PROXY_ROOT);
     // Publish via the environment, NOT via a module export. loadExtensions

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -1,4 +1,5 @@
 import http from "node:http";
+import { createHash } from "node:crypto";
 import { pathToFileURL, URL } from "node:url";
 import config from "./config.mjs";
 import { forwardRequest, parseAbsoluteForm } from "./upstream.mjs";
@@ -7,6 +8,7 @@ import { loadExtensions, snapshotRegistry, runOnRequest, runOnResponseStart, run
 import { startWatcher } from "./watcher.mjs";
 import { startOAuthRefresher, stopOAuthRefresher } from "./oauth/refresher.mjs";
 import { attachForwardProxy, handleDownloadsAbsolute } from "./forward-proxy.mjs";
+import { sourceFingerprint, PROXY_ROOT } from "./source-fingerprint.mjs";
 
 // Debug logging — writes to ~/.claude/cache-fix-debug.log (override path with
 // CACHE_FIX_DEBUG_LOG). Self-gated on CACHE_FIX_DEBUG=1; a no-op otherwise.
@@ -70,15 +72,17 @@ function collectBody(req) {
 // Returns `headers`: the (possibly extension-mutated) outbound header
 // object. Extensions read/mutate `reqCtx.headers` — added, changed, AND
 // deleted keys — expecting those mutations to reach the real outbound
-// request (auto-1m-guard's strip mode is the standing example). Prior to
-// this fix only `reqCtx.body` was serialized back into `forwardBody`;
-// `reqCtx.headers` was built for extensions to read/mutate but the mutated
-// object was discarded — forwardRequest still read the ORIGINAL
-// `clientReq.headers`, so header mutations never reached the wire.
-// Returning the object itself (not a copy) is what makes deletions visible
-// to the caller too: `{ ...x }` followed by `delete copy.k` naturally drops
-// `k` from the copy, so no special-casing is needed for add/change/delete —
-// plain object semantics carry all three.
+// request (auto-1m-guard's strip mode, deferred-tool-rewrite's beta-token
+// addition). Prior to this fix only `reqCtx.body` was serialized back into
+// `forwardBody`; `reqCtx.headers` was built for extensions to read/mutate
+// but the mutated object was discarded — forwardRequest still read the
+// ORIGINAL `clientReq.headers`, so header mutations never reached the wire
+// (see docs/audits/restart-state-audit.md-adjacent gap notes in
+// deferred-tool-rewrite.mjs's file header). Returning the object here (not
+// a copy) is what makes deletions visible to the caller too: `{ ...x }`
+// followed by `delete copy.k` naturally drops `k` from the copy, so no
+// special-casing is needed for add/change/delete — plain object semantics
+// carry all three.
 async function preForward(clientReq, clientRes, _abortController, extSnapshot, routeName, baseMeta = {}) {
   const rawBody = await collectBody(clientReq);
 
@@ -112,6 +116,20 @@ async function preForward(clientReq, clientRes, _abortController, extSnapshot, r
 
     if (parsed) {
       forwardBody = Buffer.from(JSON.stringify(reqCtx.body));
+      // Fingerprint of what we ACTUALLY send. Captures are recorded
+      // pre-pipeline — that is what makes attribution possible — so nothing
+      // anywhere records our own output. tools/replay.mjs RECONSTRUCTS it by
+      // re-running the pipeline and then assumes the reconstruction is
+      // faithful; nothing has ever checked that assumption, and every verdict
+      // the gate produces rests on it.
+      //
+      // Recorded here rather than in an extension because this is the single
+      // point where the outbound bytes exist, after every extension has run.
+      // A hash, not the body: the corpus already grows quadratically, and the
+      // question is only ever "did the replay reproduce this", which equality
+      // answers.
+      meta._forwardedSha = createHash("sha256").update(forwardBody).digest("hex").slice(0, 16);
+      meta._forwardedBytes = forwardBody.length;
     }
     headers = reqCtx.headers;
   }
@@ -325,6 +343,13 @@ async function handleBootstrap(clientReq, clientRes) {
 // reverse-mode semantics, and a closed forward instance retires its vote
 // instead of haunting later reverse-only instances in the same process.
 let _forwardActive = 0;
+// sha256 over the proxy source tree as loaded at startup; null when it could
+// not be computed. Set once by startProxy, never after — the point is that it
+// describes the code THIS process is running, not the code on disk now.
+let _sourceTree = null;
+// Every CACHE_FIX_* variable this process was started with, snapshotted once
+// for the same reason: it describes what is SERVING, not what is declared.
+let _gates = {};
 
 function handleHealth(_req, res) {
   // Surface extension-load failures so callers (operators, monitoring) see
@@ -355,6 +380,26 @@ function handleHealth(_req, res) {
     version: config.version,
     forward_proxy: _forwardActive > 0,
     https_proxy: (_forwardActive > 0 && config.httpsProxy) || null,
+    // Content fingerprint of the source this process LOADED. Hot-reload is
+    // off, so after an edit without a restart this stays at the old value
+    // while the working tree moves on — which is precisely the drift an
+    // external checker needs to see, and cannot infer from mtimes without
+    // false-firing on every touch that changes no bytes.
+    proxy_tree: _sourceTree,
+    // The gate set this process is ACTUALLY running, snapshotted at startup.
+    //
+    // Same argument as proxy_tree, one layer over: checking the unit file
+    // answers "what is declared", not "what is serving". Edit the unit and
+    // skip the restart and the two diverge silently — every extension reads
+    // its gate from process.env, which is fixed for the life of the process.
+    //
+    // It also gives the offline gate (tools/gate-live.mjs) something better
+    // than the unit to replay against: on 2026-07-28 the gate ran with
+    // extension DEFAULTS while production ran 11 gates, so CACHE_FIX_TOOL_REWRITE
+    // was off in every verification run and on in every served request. The
+    // sweep reported 0 violations; the same corpus under the real gate set
+    // reported 2.
+    gates: _gates,
   }));
 }
 
@@ -544,6 +589,32 @@ export async function startProxy(options = {}) {
   // wedge mitigation), so we require the exact disable token there.
   const hotReloadOptIn = process.env.CACHE_FIX_HOT_RELOAD === "on";
   const watch = options.watch !== false && hotReloadOptIn;
+
+  // Fingerprint the source we are ABOUT TO RUN, before serving anything, so
+  // /health can answer "which bytes is this process actually running" instead
+  // of leaving an external checker to guess from mtimes. Computed here rather
+  // than at module load: this is the moment the answer becomes true, and a
+  // failure to read our own source must not take the proxy down — an unknown
+  // fingerprint reports as null, which a checker can distinguish from a
+  // mismatch.
+  _gates = Object.fromEntries(
+    Object.entries(process.env)
+      .filter(([k]) => k.startsWith("CACHE_FIX_"))
+      .sort(([a], [b]) => a.localeCompare(b)),
+  );
+  try {
+    _sourceTree = await sourceFingerprint(PROXY_ROOT);
+    // Publish via the environment, NOT via a module export. loadExtensions
+    // cache-busts its imports (pipeline.mjs `_loadCounter`), so the module
+    // instance the pipeline runs is not the one a dynamic import here would
+    // return — module-scope state does not cross that boundary, and a setter
+    // called on the wrong instance leaves the field silently null. Extensions
+    // already read their gates from process.env for the same reason.
+    if (_sourceTree) process.env.CACHE_FIX_PROXY_TREE = _sourceTree;
+  } catch (err) {
+    process.stderr.write(`[cache-fix] source fingerprint unavailable: ${err?.message ?? err}\n`);
+    _sourceTree = null;
+  }
 
   // Boot banner on stderr so the EFFECTIVE hot-reload mode is visible in the
   // supervisor's log (journalctl --user / ~/Library/Logs/) without being

--- a/proxy/source-fingerprint.mjs
+++ b/proxy/source-fingerprint.mjs
@@ -1,0 +1,80 @@
+// Fingerprint of the proxy's own source tree, computed once at startup and
+// reported on /health as `proxy_tree`.
+//
+// Why this exists. Hot-reload is off, so the running process keeps whatever
+// code it loaded at start; edit proxy/ without restarting and the repo checks
+// pass while the traffic is served by something else. The dotfiles doctor
+// asked that question by comparing the newest MTIME under proxy/ against the
+// unit's start time, with a comment declaring the label to be the whole truth
+// because "what the process holds in memory is not hashable".
+//
+// It is not the whole truth, and 2026-07-28 showed how: restoring a file from
+// a backup after a bite test moved its mtime while leaving the bytes
+// identical, and doctor reported "still running old code" about a proxy that
+// was running exactly the code on disk. A checker that fires on a non-defect
+// trains its reader to ignore it — the same fault, in the same repo, that the
+// mtime comment was written to avoid.
+//
+// What the process holds is not hashable, but what it LOADED is: it can
+// fingerprint its own source at startup and publish the result. Then doctor
+// compares content to content, and mtime churn is silent by construction.
+//
+// The algorithm is deliberately dull, because a second implementation would
+// have to match it: every regular file under the root except node_modules and
+// dot-directories, relative POSIX paths sorted byte-wise, each contributing
+// `path\n<sha256 of contents>\n` to one running hash. Nothing here depends on
+// filesystem order, mtimes, or inode numbers.
+//
+// There is no second implementation: doctor shells out to this file rather
+// than mirroring it in Python. Two implementations of one hash is exactly the
+// kind of duplication that drifts silently and reports a mismatch nobody can
+// explain.
+
+import { createHash } from "node:crypto";
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative, sep, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SKIP_DIRS = new Set(["node_modules"]);
+
+async function collect(root, dir, out) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    if (e.name.startsWith(".")) continue;
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (SKIP_DIRS.has(e.name)) continue;
+      await collect(root, full, out);
+    } else if (e.isFile()) {
+      out.push(relative(root, full).split(sep).join("/"));
+    }
+  }
+  return out;
+}
+
+export async function sourceFingerprint(root) {
+  const files = (await collect(root, root, [])).sort();
+  const h = createHash("sha256");
+  for (const rel of files) {
+    const bytes = await readFile(join(root, rel));
+    h.update(rel);
+    h.update("\n");
+    h.update(createHash("sha256").update(bytes).digest("hex"));
+    h.update("\n");
+  }
+  return h.digest("hex").slice(0, 12);
+}
+
+export const PROXY_ROOT = dirname(fileURLToPath(import.meta.url));
+
+// `node proxy/source-fingerprint.mjs [root]` — the form doctor calls.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const root = process.argv[2] ?? PROXY_ROOT;
+  sourceFingerprint(root).then(
+    (fp) => process.stdout.write(fp + "\n"),
+    (err) => {
+      process.stderr.write(`source-fingerprint failed: ${err?.message ?? err}\n`);
+      process.exit(1);
+    },
+  );
+}

--- a/test/capture-hardening.test.mjs
+++ b/test/capture-hardening.test.mjs
@@ -1,0 +1,139 @@
+// #275 round 2: the capture corpus is owner-only, and neither /health nor the
+// boot record publishes an unrecognised CACHE_FIX_* value.
+//
+// Both halves are silent failures by nature. A capture file at 0644 works
+// exactly as well as one at 0600, and a boot record carrying an OAuth client
+// id parses exactly as well as one without — so nothing about the running
+// system says anything is wrong. Only an assertion does.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, statSync, writeFileSync, chmodSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import ext, { buildBootRecord } from "../proxy/extensions/request-capture.mjs";
+import { publishableGates, PUBLISHABLE_GATES, REDACTED } from "../proxy/gate-allowlist.mjs";
+import { appendFileOwnerOnly } from "../proxy/extensions/write-owner-only.mjs";
+
+const mode = (p) => statSync(p).mode & 0o777;
+
+async function withTemp(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "capture-hardening-"));
+  try { return await fn(dir); } finally { rmSync(dir, { recursive: true, force: true }); }
+}
+
+// --- part 1: modes -----------------------------------------------------------
+
+test("a capture file is created 0600, not at the ambient umask", async () => {
+  await withTemp(async (dir) => {
+    const f = join(dir, "s-000000000000-requests.jsonl");
+    await appendFileOwnerOnly(f, "{}\n");
+    assert.equal(mode(f), 0o600, "a capture file must never be group- or world-readable");
+  });
+});
+
+test("a pre-existing loose capture file is repaired on the next append", async () => {
+  await withTemp(async (dir) => {
+    // A file written before this hardening existed — the real migration case.
+    const f = join(dir, "s-111111111111-requests.jsonl");
+    writeFileSync(f, "{}\n");
+    chmodSync(f, 0o644);
+    assert.equal(mode(f), 0o644, "arrange: the file starts group-readable");
+    await appendFileOwnerOnly(f, "{}\n");
+    assert.equal(mode(f), 0o600, "the next append must repair the mode");
+  });
+});
+
+// The two tests above exercise the HELPER. This one exercises the extension's
+// own write path, which is the thing that can regress: someone reverting the
+// call site back to a bare appendFile leaves the helper perfectly correct and
+// every capture file group-readable again. Drives ext.onRequest end to end and
+// stats what actually landed on disk.
+test("request-capture's own write path lands the dir 0700 and the file 0600", async () => {
+  await withTemp(async (dir) => {
+    const prevConfig = process.env.CLAUDE_CONFIG_DIR;
+    const prevFlag = process.env.CACHE_FIX_REQUEST_CAPTURE;
+    process.env.CLAUDE_CONFIG_DIR = dir;
+    process.env.CACHE_FIX_REQUEST_CAPTURE = "1";
+    try {
+      await ext.onRequest({
+        body: { model: "claude-opus-5", messages: [{ role: "user", content: "hi" }] },
+        headers: { "x-session-id": "abc-123" },
+        meta: { route: "messages" },
+      });
+      const captureDir = join(dir, "cache-fix-captures");
+      assert.equal(mode(captureDir), 0o700,
+        "the directory listing leaks session keys through filenames — it is owner-only too");
+      const files = readdirSync(captureDir);
+      assert.equal(files.length, 1, `expected one capture file, got ${JSON.stringify(files)}`);
+      assert.equal(mode(join(captureDir, files[0])), 0o600,
+        "the capture file holds whole request bodies — it must never land at the ambient umask");
+    } finally {
+      if (prevConfig === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+      else process.env.CLAUDE_CONFIG_DIR = prevConfig;
+      if (prevFlag === undefined) delete process.env.CACHE_FIX_REQUEST_CAPTURE;
+      else process.env.CACHE_FIX_REQUEST_CAPTURE = prevFlag;
+    }
+  });
+});
+
+// --- part 2: the gate allowlist ---------------------------------------------
+
+test("an unrecognised CACHE_FIX_* key is published by NAME, never by value", () => {
+  const secret = "https://token.example.invalid/oauth/v2/token";
+  const env = {
+    CACHE_FIX_TOOL_REWRITE: "1",
+    CACHE_FIX_OAUTH_TOKEN_URL: secret,
+    CACHE_FIX_SOMETHING_INVENTED_TOMORROW: "s3cr3t",
+    PATH: "/usr/bin",
+  };
+  const gates = publishableGates(env);
+
+  assert.equal(gates.CACHE_FIX_TOOL_REWRITE, "1", "an allowlisted gate keeps its value");
+  assert.equal(gates.CACHE_FIX_OAUTH_TOKEN_URL, REDACTED);
+  assert.equal(gates.CACHE_FIX_SOMETHING_INVENTED_TOMORROW, REDACTED,
+    "a key nobody has seen before must be safe on the day it is added");
+  assert.ok("CACHE_FIX_OAUTH_TOKEN_URL" in gates,
+    "the NAME still appears — provenance needs to know the variable is set");
+  assert.ok(!("PATH" in gates), "non-CACHE_FIX_ variables are not this object's business");
+
+  // The whole point, stated as one assertion: the secret is nowhere in it.
+  assert.ok(!JSON.stringify(gates).includes(secret));
+  assert.ok(!JSON.stringify(gates).includes("s3cr3t"));
+});
+
+test("the allowlist contains no path, URL, command or credential key", () => {
+  // The allowlist is hand-maintained, so this pins the RULE that governs
+  // adding to it rather than the current membership: a key whose value names
+  // a place on the operator's machine or a credential is not a gate.
+  // Suffix-based, and the distinction is real in this codebase: `*_LOG` is an
+  // on/off switch ("write the usage log?") while `*_LOG_PATH` names where it
+  // goes. Only the latter is a location.
+  const forbidden = /(_(PATH|DIR|URL|CMD|FILE|CRED|SCOPE|UPSTREAM|SENTINEL|PATTERN|PREFIX|REPLACEMENT|KEYS|PLAN)|_CLIENT_ID|_LOG_PATH|_STATE)$/;
+  const offenders = [...PUBLISHABLE_GATES].filter((k) => forbidden.test(k));
+  assert.deepEqual(offenders, [],
+    `these allowlisted keys name a location or a secret rather than a gate:\n${offenders.join("\n")}`);
+});
+
+test("the boot record redacts the same way, and drops the tree it already carries", () => {
+  const rec = buildBootRecord(new Date(), {
+    CACHE_FIX_INSERTION_NORMALIZE: "1",
+    CACHE_FIX_OAUTH_CRED_PATH: "/home/someone/.claude/.credentials.json",
+    CACHE_FIX_PROXY_TREE: "deadbeef",
+  }, "deadbeef");
+
+  assert.equal(rec.gates.CACHE_FIX_INSERTION_NORMALIZE, "1");
+  assert.equal(rec.gates.CACHE_FIX_OAUTH_CRED_PATH, REDACTED);
+  assert.ok(!JSON.stringify(rec.gates).includes("/home/someone"),
+    "a capture file must not carry the operator's filesystem layout");
+  assert.ok(!("CACHE_FIX_PROXY_TREE" in rec.gates),
+    "the tree is already a field of this record — it is not a gate");
+  assert.equal(rec.proxyTree, "deadbeef");
+});
+
+test("gate objects are key-sorted, so two boot records are comparable byte-for-byte", () => {
+  const a = publishableGates({ CACHE_FIX_VOLATILE_PIN: "1", CACHE_FIX_DEBUG: "1" });
+  const b = publishableGates({ CACHE_FIX_DEBUG: "1", CACHE_FIX_VOLATILE_PIN: "1" });
+  assert.equal(JSON.stringify(a), JSON.stringify(b));
+});

--- a/test/request-capture.test.mjs
+++ b/test/request-capture.test.mjs
@@ -1,0 +1,180 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import ext, {
+  resolveCaptureKey,
+  buildCaptureRecord,
+  sweepCaptureDir,
+  buildOutcomeRecord,
+} from "../proxy/extensions/request-capture.mjs";
+
+function makeCtx(overrides = {}) {
+  return {
+    body: {
+      model: "claude-opus-5",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      ...overrides.body,
+    },
+    headers: {
+      "anthropic-beta": "context-1m-2025-08-07",
+      "x-session-id": "abc-123",
+      authorization: "Bearer SECRET",
+      ...overrides.headers,
+    },
+    meta: { route: "messages" },
+  };
+}
+
+test("request-capture: disabled by default (no env flag) — onRequest is a no-op", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "capture-test-"));
+  const prevConfig = process.env.CLAUDE_CONFIG_DIR;
+  const prevFlag = process.env.CACHE_FIX_REQUEST_CAPTURE;
+  process.env.CLAUDE_CONFIG_DIR = dir;
+  delete process.env.CACHE_FIX_REQUEST_CAPTURE;
+  try {
+    await ext.onRequest(makeCtx());
+    const entries = await readdir(dir);
+    assert.deepEqual(entries, [], "no capture dir should be created when disabled");
+  } finally {
+    if (prevConfig === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = prevConfig;
+    if (prevFlag !== undefined) process.env.CACHE_FIX_REQUEST_CAPTURE = prevFlag;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("request-capture: enabled — appends one full-body NDJSON record per request", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "capture-test-"));
+  const prevConfig = process.env.CLAUDE_CONFIG_DIR;
+  const prevFlag = process.env.CACHE_FIX_REQUEST_CAPTURE;
+  process.env.CLAUDE_CONFIG_DIR = dir;
+  process.env.CACHE_FIX_REQUEST_CAPTURE = "1";
+  try {
+    const ctx = makeCtx();
+    await ext.onRequest(ctx);
+    await ext.onRequest(ctx);
+    const captureDir = join(dir, "cache-fix-captures");
+    const files = await readdir(captureDir);
+    assert.equal(files.length, 1);
+    assert.match(files[0], /^s-abc-123-requests\.jsonl$/);
+    const all = (await readFile(join(captureDir, files[0]), "utf-8"))
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+    // The first write of a boot stamps a provenance record — the restart
+    // boundary and the gate set the traffic was captured under. It carries no
+    // body and is not a request.
+    const boots = all.filter((r) => r.type === "boot");
+    assert.equal(boots.length, 1, "one boot record per file per proxy boot");
+    assert.ok(boots[0].gates, "the boot record names the gates in force");
+    const lines = all.filter((r) => !r.type);
+    assert.equal(lines.length, 2);
+    const rec = lines[0];
+    assert.equal(rec.body.model, "claude-opus-5");
+    assert.deepEqual(rec.body.messages, ctx.body.messages, "body captured verbatim");
+    assert.equal(rec.headers["anthropic-beta"], "context-1m-2025-08-07");
+    assert.ok(rec.id, "every request record carries a join id");
+  } finally {
+    if (prevConfig === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = prevConfig;
+    if (prevFlag === undefined) delete process.env.CACHE_FIX_REQUEST_CAPTURE;
+    else process.env.CACHE_FIX_REQUEST_CAPTURE = prevFlag;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("request-capture: record never contains auth material", () => {
+  const rec = buildCaptureRecord(makeCtx());
+  const flat = JSON.stringify(rec);
+  assert.doesNotMatch(flat, /SECRET/, "authorization header must not be captured");
+  assert.equal(Object.keys(rec.headers).length, 2, "only beta + session-id headers");
+});
+
+test("resolveCaptureKey: session header preferred, content-hash fallback", () => {
+  const withSid = resolveCaptureKey({ "x-session-id": "abc" }, { messages: [] });
+  assert.equal(withSid, "s-abc");
+  const noSid = resolveCaptureKey(
+    {},
+    { messages: [{ role: "user", content: "x" }] },
+  );
+  assert.match(noSid, /^c-[0-9a-f]{12}$/);
+  const empty = resolveCaptureKey({}, { messages: [] });
+  assert.equal(empty, "c-empty");
+});
+
+test("sweepCaptureDir: deletes oldest files first until under the cap", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "capture-sweep-"));
+  try {
+    // Three 100-byte files with distinct mtimes (writes are sequential).
+    for (const name of ["a", "b", "c"]) {
+      await writeFile(join(dir, `s-${name}-requests.jsonl`), "x".repeat(100));
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const deleted = await sweepCaptureDir(dir, 150);
+    assert.equal(deleted, 2, "two oldest deleted to get 300 bytes under 150");
+    const left = await readdir(dir);
+    assert.deepEqual(left, ["s-c-requests.jsonl"], "newest survives");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("sweepCaptureDir: no-op under the cap and on missing dir", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "capture-sweep-"));
+  try {
+    await writeFile(join(dir, "s-a-requests.jsonl"), "x".repeat(50));
+    assert.equal(await sweepCaptureDir(dir, 1000), 0);
+    assert.equal(await sweepCaptureDir(join(dir, "does-not-exist"), 1000), 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- Outcome records: what the API actually charged ---
+//
+// A capture recorded what was SENT and never what it cost, so every cache
+// question was answered by inference. prefix-diff's `cause` is a hypothesis
+// about what the API keyed on, not a measurement, and correlating a bust to a
+// request meant comparing wall clocks against a separate ledger — which
+// mis-attributed a 484k event to the wrong session twice in one evening.
+
+test("outcome record carries the full usage the API reported", () => {
+  const ctx = {
+    meta: {
+      cacheStats: { cacheRead: 1000, cacheCreation: 484000, inputTokens: 5, outputTokens: 20, ephemeral1h: 484000, ephemeral5m: 0 },
+      _servedModel: "claude-opus-5",
+      _captureRequestId: "req_abc",
+      _captureStart: Date.now() - 100,
+    },
+  };
+  const r = buildOutcomeRecord(ctx, "cap123", "s-key");
+  assert.equal(r.type, "outcome");
+  assert.equal(r.id, "cap123", "the join key back to the request record");
+  assert.equal(r.requestId, "req_abc", "joins to CC's own transcript");
+  // A zero read beside a large creation IS a cold rewrite — the event the
+  // corpus exists to explain, now observable rather than inferred.
+  assert.equal(r.usage.cacheCreation, 484000);
+  assert.equal(r.usage.cacheRead, 1000);
+  assert.equal(r.usage.outputTokens, 20);
+  assert.equal(r.usage.ephemeral1h, 484000, "tier split says which TTL the cache actually used");
+  assert.ok(r.ms >= 100);
+});
+
+test("BITE — no usage means NO record, never a zeroed guess", () => {
+  // cache-telemetry populates meta.cacheStats. If it is off, or the stream was
+  // cancelled before message_start, there is nothing to report — and emitting
+  // zeros would put a fabricated "cold rewrite" into the corpus.
+  assert.equal(buildOutcomeRecord({ meta: {} }, "cap123", "s-key"), null);
+  assert.equal(buildOutcomeRecord({ meta: { cacheStats: { cacheRead: 1 } } }, null, "s-key"), null,
+    "no capture id means the record could never be joined — do not write it");
+});
+
+test("request records carry a join id", () => {
+  const ctx = { headers: { "session-id": "s1" }, body: { messages: [{ role: "user", content: "hi" }] } };
+  const r = buildCaptureRecord(ctx, new Date(), "cap999");
+  assert.equal(r.id, "cap999");
+  assert.ok(r.body, "the request record still carries the body it always did");
+});

--- a/test/source-fingerprint.test.mjs
+++ b/test/source-fingerprint.test.mjs
@@ -1,0 +1,121 @@
+// source-fingerprint — the content answer to "is the running proxy stale?"
+//
+// The check this replaces compared the newest MTIME under proxy/ against the
+// service start time, and its comment declared that a defensible exception:
+// "what the process holds in memory is not hashable, so here the label is the
+// whole truth". On 2026-07-28 it reported "still running old code" because a
+// bite test restored a file from a backup — same bytes, new mtime. The label
+// was not the whole truth, and the false alarm is the expensive half: it
+// trains its reader to discount the warning that will one day be real.
+//
+// So the properties below are the whole point, not incidental:
+//   - identical bytes at a different mtime  -> SAME fingerprint
+//   - one changed byte anywhere             -> DIFFERENT fingerprint
+// The rest pins the details a second reader might otherwise assume.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { sourceFingerprint } from "../proxy/source-fingerprint.mjs";
+
+async function tree(spec) {
+  const root = await mkdtemp(join(tmpdir(), "cache-fix-fp-"));
+  for (const [rel, content] of Object.entries(spec)) {
+    const full = join(root, rel);
+    await mkdir(join(full, ".."), { recursive: true });
+    await writeFile(full, content);
+  }
+  return root;
+}
+
+test("fingerprint: identical content is identical regardless of MTIME", async () => {
+  // The exact false positive that motivated the replacement.
+  const root = await tree({ "a.mjs": "export const x = 1;\n", "sub/b.mjs": "// b\n" });
+  try {
+    const before = await sourceFingerprint(root);
+
+    // Rewrite both files with the SAME bytes and push their mtimes far into
+    // the future — what `cp`, `git checkout` and a backup restore all do.
+    await writeFile(join(root, "a.mjs"), "export const x = 1;\n");
+    await writeFile(join(root, "sub/b.mjs"), "// b\n");
+    const future = new Date(Date.now() + 86_400_000);
+    await utimes(join(root, "a.mjs"), future, future);
+    await utimes(join(root, "sub/b.mjs"), future, future);
+
+    assert.equal(await sourceFingerprint(root), before, "touching bytes-identical files must be silent");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("fingerprint: BITE — a single changed byte is caught", async () => {
+  const root = await tree({ "a.mjs": "export const x = 1;\n", "sub/b.mjs": "// b\n" });
+  try {
+    const before = await sourceFingerprint(root);
+    await writeFile(join(root, "sub/b.mjs"), "// c\n");
+    assert.notEqual(await sourceFingerprint(root), before);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("fingerprint: BITE — an added or removed file is caught", async () => {
+  const root = await tree({ "a.mjs": "x\n" });
+  try {
+    const before = await sourceFingerprint(root);
+    await writeFile(join(root, "new.mjs"), "y\n");
+    const added = await sourceFingerprint(root);
+    assert.notEqual(added, before, "a new extension file must change the fingerprint");
+    await rm(join(root, "new.mjs"));
+    assert.equal(await sourceFingerprint(root), before, "removing it must restore the old value");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// Content is hashed per PATH, so moving a file is a change even though the
+// bytes in the tree are unchanged — an extension that moves between
+// directories is loaded differently, or not at all.
+test("fingerprint: renaming a file changes the fingerprint even though bytes are unchanged", async () => {
+  const root = await tree({ "a.mjs": "same\n" });
+  try {
+    const before = await sourceFingerprint(root);
+    await rm(join(root, "a.mjs"));
+    await writeFile(join(root, "b.mjs"), "same\n");
+    assert.notEqual(await sourceFingerprint(root), before);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("fingerprint: node_modules and dot-directories are excluded", async () => {
+  const root = await tree({ "a.mjs": "x\n" });
+  try {
+    const before = await sourceFingerprint(root);
+    await mkdir(join(root, "node_modules/pkg"), { recursive: true });
+    await writeFile(join(root, "node_modules/pkg/index.js"), "vendored\n");
+    await mkdir(join(root, ".cache"), { recursive: true });
+    await writeFile(join(root, ".cache/junk"), "junk\n");
+    assert.equal(
+      await sourceFingerprint(root),
+      before,
+      "dependency and cache churn must not read as a proxy source change",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("fingerprint: stable across calls, and a hex digest", async () => {
+  const root = await tree({ "a.mjs": "x\n", "z/y.mjs": "z\n" });
+  try {
+    const fp = await sourceFingerprint(root);
+    assert.equal(fp, await sourceFingerprint(root));
+    assert.match(fp, /^[0-9a-f]{12}$/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
> **Stacked on #274** (header forwarding fix — this branch includes its commit). Review the tip commit.

## Why

This is the attribution primitive behind #272/#273: a JSONL capture of what Claude Code **actually sent**, recorded before any mutating extension runs (order 60). A divergence present in the raw capture is CC's; one absent is ours. Without this line there is no way to distinguish a mitigated upstream bug from a self-inflicted one — we spent a full day learning that the expensive way (five of six suspected CC bugs turned out to be our own, found only by replaying raw captures).

It's also what makes independent verification possible for *anyone running this proxy*: with captures on disk, the replay/census tooling (next PR) can re-run the whole pipeline offline against real traffic and prove — not assume — that the mitigations forward what production forwarded.

## What

Three record types share one capture file per session:

- **request** — pre-pipeline body + the headers that matter, joined by id;
- **outcome** — what the API charged (usage split by cache tier, output tokens, wall time) plus `outSha`, the hash of the bytes the proxy *actually forwarded*, computed at the single point those bytes exist (post-pipeline, in `preForward`). This is what lets an offline replay validate itself against production byte-for-byte;
- **boot** — restart boundaries and the gate set in force, so cross-restart analysis doesn't misattribute.

`/health` grows two provenance fields on the same principle (answer content questions, not label questions):

- `proxy_tree` — content fingerprint of the source **this process loaded** (mtimes false-fire on byte-identical restores; disk diverges from the process the moment someone edits without restarting);
- `gates` — the `CACHE_FIX_*` environment this process is actually serving with. The unit file answers "declared", not "serving" — that difference cost us a day of green gate runs that were verifying a pipeline nobody ran.

Size-capped (`CACHE_FIX_CAPTURE_MAX_MB`, oldest-file rotation). Off by default: `CACHE_FIX_REQUEST_CAPTURE=1`. Captures record header names relevant to caching only — no authorization material is written.

## Evidence

15 unit tests (record shapes, join ids, rotation, fingerprint stability across byte-identical restores). In production on our machines for two days at ~2.5 GB/day of captures; the outcome-record `outSha` is what proved the replay faithful (109/109 reconstructions matched the wire on a fresh session) and what proved fable-5's `tool_addition` support in #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)