### PR TITLE
harden: use bounded strlcpy/snprintf in claude-vscode-wrapper.c...

### DIFF
--- a/tools/claude-vscode-wrapper.c
+++ b/tools/claude-vscode-wrapper.c
@@ -33,7 +33,7 @@ int main(int argc, char *argv[]) {
         "%s\\npm\\node_modules\\claude-code-cache-fix\\preload.mjs", appdata);
 
     char preload_url[MAX_PATH];
-    strcpy(preload_url, preload);
+    snprintf(preload_url, sizeof(preload_url), "%s", preload);
     for (char *p = preload_url; *p; p++) {
         if (*p == '\\') *p = '/';
     }
@@ -61,7 +61,7 @@ int main(int argc, char *argv[]) {
         "%s\\npm\\node_modules\\@anthropic-ai\\claude-code\\cli.js", appdata);
 
     /* Build argv: skip argv[1] (original claude path passed by extension) */
-    char **new_argv = malloc(sizeof(char *) * (argc + 2));
+    char **new_argv = calloc((size_t)argc + 2, sizeof(char *));
     if (!new_argv) return 1;
 
     new_argv[0] = "node";


### PR DESCRIPTION
## Summary
Harden input handling in `tools/claude-vscode-wrapper.c` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | c.lang.security.insecure-use-string-copy-fn.insecure-use-string-copy-fn |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `c.lang.security.insecure-use-string-copy-fn.insecure-use-string-copy-fn` |
| **File** | `tools/claude-vscode-wrapper.c:36` |
| **Assessment** | Defensive hardening |

**Description**: Finding triggers whenever there is a strcpy or strncpy used. This is an issue because strcpy does not affirm the size of the destination array and strncpy will not automatically NULL-terminate strings. This can lead to buffer overflows, which can cause program crashes and potentially let an attacker inject code in the program. Fix this by using strcpy_s instead (although note that strcpy_s is an optional part of the C11 standard, and so may not be available).

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `tools/claude-vscode-wrapper.c`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
