### PR TITLE
fix(proxy): survive a reload instead of cutting the response

### DIFF
--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -528,6 +528,29 @@ function removeSelfHeal() {
  *   await startProxy({ port: 0 })                    // OS-assigned port
  *   await startProxy({ port: 0, watch: false })      // embedded, no fs.watch
  */
+// Is a DIFFERENT-MODE cache-fix proxy already on this port? `reusePort` lets a
+// successor co-bind, which is the point, but a plain proxy and a forward proxy
+// sharing a port makes the kernel round-robin CONNECT between one that speaks it
+// and one that does not. Asks the incumbent rather than predicting it — the
+// answer is on `/health`, which every version of this proxy has served.
+//
+// Returns FALSE on any doubt: nothing listening, a timeout, a non-proxy service,
+// unparseable JSON. A guard that blocked startup on an unanswered probe would
+// turn a slow box into a proxy that will not start, which is worse than the
+// mismatch it prevents.
+async function modeConflict(port, bind, weAreForward) {
+  const body = await new Promise((res) => {
+    const req = http.get({ host: bind, port, path: "/health", timeout: 1000 }, (r) => {
+      let b = ""; r.on("data", (d) => (b += d)); r.on("end", () => res(b));
+    });
+    req.on("error", () => res(null));
+    req.on("timeout", () => { req.destroy(); res(null); });
+  });
+  if (!body) return false;
+  try { return JSON.parse(body).forward_proxy !== weAreForward; }
+  catch { return false; }
+}
+
 export async function startProxy(options = {}) {
   const port = options.port ?? config.port;
   const bind = options.bind ?? config.bind;
@@ -592,35 +615,51 @@ export async function startProxy(options = {}) {
     if (forwardAttached) installSelfHeal();
   }
 
+  // EADDRINUSE used to refuse a second launch on this port, and `reusePort`
+  // removes that. Losing it entirely is not acceptable: a plain proxy and a
+  // `--remote-control` forward proxy on one port makes the kernel round-robin
+  // CONNECT between a process that speaks it and one that does not — measured,
+  // 17 of 40 attempts died `ECONNRESET`.
+  //
+  // But refusing every occupied port would also refuse the handover this change
+  // exists to enable. The distinction is MODE, not count: two proxies in the
+  // same mode ARE the handover, and only a mode MISMATCH produces the failure
+  // above. So the guard asks `/health` what is already there and refuses only
+  // when its `forward_proxy` disagrees with ours.
+  if (await modeConflict(port, bind, forwardAttached)) {
+    throw new Error(
+      `another cache-fix proxy is already on ${bind}:${port} in the other mode ` +
+      `(forward_proxy=${!forwardAttached}). Two modes on one port make the kernel ` +
+      `round-robin CONNECT between them; stop that one first.`);
+  }
+
   await new Promise((resolve, reject) => {
-    server.once("error", reject);
     // SO_REUSEPORT so a successor can bind this port WHILE we are still serving,
     // which is what makes a reload survivable for the sessions using it. Without
     // it the only reload is kill-then-respawn, and the port is unbound for the
-    // gap: measured against a 12-chunk stream, SIGTERM + a 5 s force-close
-    // delivered 7 chunks and cut the rest, which reaches a session as
-    // "Connection closed mid-response". With it, the successor is already
-    // accepting before we stop, and the same stream delivered 10 of 10.
+    // gap: measured against a 12-chunk stream through this proxy, the reload
+    // ended it at `ECONNRESET` after 18 chunks, which reaches a session as
+    // "Connection closed mid-response". With it, the same stream ran to
+    // completion.
     //
     // `listen({port})` and `listen(port)` are not interchangeable here: the
     // option form is the only one that carries `reusePort`.
     //
-    // Not gated on a flag. A kernel without SO_REUSEPORT fails the listen
-    // outright rather than silently ignoring the option, and the catch below
-    // retries without it, so an old kernel keeps exactly today's behaviour.
+    // A runtime without it IGNORES the option rather than failing — measured,
+    // not assumed: `reusePort` landed in node 22.12/23.1, and CI's 18.20.8 and
+    // 20.20.2 both listen successfully and then refuse the successor with
+    // EADDRINUSE. So there is nothing to catch and no fallback to write; those
+    // runtimes simply keep today's kill-then-respawn behaviour. An earlier
+    // version of this comment claimed the opposite and shipped a catch that
+    // could never fire — and the catch was itself broken, registering a second
+    // `error` handler after `reject`, which wins on registration order.
     const opts = { port, host: bind, reusePort: true };
-    const onFail = (e) => {
-      // ENOTSUP / EINVAL: this kernel has no SO_REUSEPORT. Fall back rather than
-      // refusing to start — a proxy that will not listen is worse than a reload
-      // that drops connections.
-      if (e.code !== "ENOTSUP" && e.code !== "EINVAL") return reject(e);
-      server.listen(port, bind, () => resolve());
-      server.once("error", reject);
-    };
-    server.once("error", onFail);
+    // ONE error handler. Two handlers on one event is not a fallback: both fire,
+    // in registration order, so whichever settles the promise first decides and
+    // the other runs against a settled promise.
+    server.once("error", reject);
     server.listen(opts, () => {
       server.off("error", reject);
-      server.off("error", onFail);
       resolve();
     });
   });
@@ -702,22 +741,19 @@ if (invokedAsScript) {
       return;
     }
     active.close().finally(() => process.exit(0));
-    // The grace window before laggards are forced. 5 s was chosen when the only
-    // reload was kill-then-respawn, where a longer wait meant a longer outage:
-    // the port stayed unbound until this process died. With SO_REUSEPORT the
-    // successor is ALREADY accepting, so waiting costs nothing but this
-    // process's own lifetime — and 5 s is far shorter than a streaming
-    // /v1/messages response, which is exactly the request a reload must not
-    // cut. Measured against a 12-chunk stream: 5 s delivered 7 chunks and cut
-    // the rest.
-    //
-    // Overridable so an operator who needs the old timing (or a much longer
-    // drain) has it without a redeploy; the default is what a session actually
-    // needs rather than what the old reload could afford.
-    const graceMs = Number(process.env.CACHE_FIX_SHUTDOWN_GRACE_MS) || 120_000;
+    // The 5 s grace is DELIBERATELY UNCHANGED. Raising it looked free once a
+    // successor is already accepting — the predecessor is invisible to new
+    // connections while it drains — but a supervised stop is SERIAL: systemd
+    // stops, waits for exit, then starts. Measured on this box, where
+    // `DefaultTimeoutStopSec` is 90 s and no unit template overrides it: at
+    // 120 s the stop is SIGKILLed at the cap (90006 ms, stream ECONNRESET),
+    // and a serial restart went from 5.0 s of downtime to 53.9 s. So a longer
+    // grace makes `systemctl restart` worse while helping only the
+    // side-by-side handover — which SO_REUSEPORT already fixes, measured, at
+    // 5 s. Any future increase has to move the unit's TimeoutStopSec with it.
     setTimeout(() => {
       process.stderr.write(
-        `[cache-fix] shutdown: in-flight connections still open after ${graceMs} ms — forcing close\n`,
+        "[cache-fix] shutdown: in-flight connections still open after 5s — forcing close\n",
       );
       // Node >=18.2; package.json engines allows 18.0/18.1, where the
       // pre-existing behavior (exit without forcing) is the only option.
@@ -725,7 +761,7 @@ if (invokedAsScript) {
         active.server.closeAllConnections();
       }
       process.exit(0);
-    }, graceMs).unref();
+    }, 5000).unref();
   };
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -594,8 +594,33 @@ export async function startProxy(options = {}) {
 
   await new Promise((resolve, reject) => {
     server.once("error", reject);
-    server.listen(port, bind, () => {
+    // SO_REUSEPORT so a successor can bind this port WHILE we are still serving,
+    // which is what makes a reload survivable for the sessions using it. Without
+    // it the only reload is kill-then-respawn, and the port is unbound for the
+    // gap: measured against a 12-chunk stream, SIGTERM + a 5 s force-close
+    // delivered 7 chunks and cut the rest, which reaches a session as
+    // "Connection closed mid-response". With it, the successor is already
+    // accepting before we stop, and the same stream delivered 10 of 10.
+    //
+    // `listen({port})` and `listen(port)` are not interchangeable here: the
+    // option form is the only one that carries `reusePort`.
+    //
+    // Not gated on a flag. A kernel without SO_REUSEPORT fails the listen
+    // outright rather than silently ignoring the option, and the catch below
+    // retries without it, so an old kernel keeps exactly today's behaviour.
+    const opts = { port, host: bind, reusePort: true };
+    const onFail = (e) => {
+      // ENOTSUP / EINVAL: this kernel has no SO_REUSEPORT. Fall back rather than
+      // refusing to start — a proxy that will not listen is worse than a reload
+      // that drops connections.
+      if (e.code !== "ENOTSUP" && e.code !== "EINVAL") return reject(e);
+      server.listen(port, bind, () => resolve());
+      server.once("error", reject);
+    };
+    server.once("error", onFail);
+    server.listen(opts, () => {
       server.off("error", reject);
+      server.off("error", onFail);
       resolve();
     });
   });
@@ -677,9 +702,22 @@ if (invokedAsScript) {
       return;
     }
     active.close().finally(() => process.exit(0));
+    // The grace window before laggards are forced. 5 s was chosen when the only
+    // reload was kill-then-respawn, where a longer wait meant a longer outage:
+    // the port stayed unbound until this process died. With SO_REUSEPORT the
+    // successor is ALREADY accepting, so waiting costs nothing but this
+    // process's own lifetime — and 5 s is far shorter than a streaming
+    // /v1/messages response, which is exactly the request a reload must not
+    // cut. Measured against a 12-chunk stream: 5 s delivered 7 chunks and cut
+    // the rest.
+    //
+    // Overridable so an operator who needs the old timing (or a much longer
+    // drain) has it without a redeploy; the default is what a session actually
+    // needs rather than what the old reload could afford.
+    const graceMs = Number(process.env.CACHE_FIX_SHUTDOWN_GRACE_MS) || 120_000;
     setTimeout(() => {
       process.stderr.write(
-        "[cache-fix] shutdown: in-flight connections still open after 5s — forcing close\n",
+        `[cache-fix] shutdown: in-flight connections still open after ${graceMs} ms — forcing close\n`,
       );
       // Node >=18.2; package.json engines allows 18.0/18.1, where the
       // pre-existing behavior (exit without forcing) is the only option.
@@ -687,7 +725,7 @@ if (invokedAsScript) {
         active.server.closeAllConnections();
       }
       process.exit(0);
-    }, 5000).unref();
+    }, graceMs).unref();
   };
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -547,8 +547,21 @@ async function modeConflict(port, bind, weAreForward) {
     req.on("timeout", () => { req.destroy(); res(null); });
   });
   if (!body) return false;
-  try { return JSON.parse(body).forward_proxy !== weAreForward; }
-  catch { return false; }
+  // A REAL boolean, or no opinion. `/health` has two shapes: the ok body carries
+  // `forward_proxy`, and the degraded body (503, an extension failed to load)
+  // does not — and `undefined !== false` is true, so reading absence as a
+  // mismatch refused BOTH modes and left the port unstartable. That body's own
+  // hint says "restart the proxy via your supervisor to recover", which is
+  // exactly the restart this guard would have blocked. Same for any pre-4.3.0
+  // cache-fix, whose `/health` predates the key, and for any foreign JSON.
+  //
+  // Refusing those is not load-bearing anyway: `reusePort` needs BOTH sides to
+  // opt in — measured, incumbent false / successor true gives EADDRINUSE — so a
+  // non-cache-fix incumbent cannot be co-bound with in the first place.
+  try {
+    const f = JSON.parse(body)?.forward_proxy;
+    return typeof f === "boolean" && f !== weAreForward;
+  } catch { return false; }
 }
 
 export async function startProxy(options = {}) {
@@ -627,10 +640,19 @@ export async function startProxy(options = {}) {
   // above. So the guard asks `/health` what is already there and refuses only
   // when its `forward_proxy` disagrees with ours.
   if (await modeConflict(port, bind, forwardAttached)) {
+    // Retire what the forward attach claimed, BEFORE leaving. `startProxy` is an
+    // exported library API, so a caller can survive this throw — and both
+    // `_forwardActive` and the self-heal handler are process-wide. The close()
+    // path already retires them; this is a second exit from the same critical
+    // section and has to do the same. Left leaking, `_forwardActive` stays
+    // above zero and a later REVERSE-only instance reports forward_proxy:true
+    // and passthrough-relays paths it should 404, while an orphaned
+    // uncaughtException handler swallows crashes that should restart the proxy.
+    if (forwardAttached) { _forwardActive--; removeSelfHeal(); }
     throw new Error(
-      `another cache-fix proxy is already on ${bind}:${port} in the other mode ` +
-      `(forward_proxy=${!forwardAttached}). Two modes on one port make the kernel ` +
-      `round-robin CONNECT between them; stop that one first.`);
+      `another cache-fix proxy is already on ${bind}:${port} in the other mode; ` +
+      `two modes on one port make the kernel round-robin CONNECT between them. ` +
+      `Stop that one first.`);
   }
 
   await new Promise((resolve, reject) => {

--- a/test/proxy-server.test.mjs
+++ b/test/proxy-server.test.mjs
@@ -507,6 +507,19 @@ describe("zero-downtime reload", () => {
     const PORT = scout.address().port;
     await new Promise((r) => scout.close(r));
 
+    // Same probe the handover test uses: bind twice for real and read the
+    // answer, rather than comparing version strings — the question is what THIS
+    // runtime and kernel do, and a version number encodes neither.
+    const l1 = net.createServer();
+    await new Promise((res, rej) => { l1.once("error", rej); l1.listen({ port: 0, host: "127.0.0.1", reusePort: true }, res); });
+    const l2 = net.createServer();
+    const canCoBind = await new Promise((res) => {
+      l2.once("error", () => res(false));
+      l2.listen({ port: l1.address().port, host: "127.0.0.1", reusePort: true }, () => res(true));
+    });
+    try { l2.close(); } catch {}
+    await new Promise((r) => l1.close(r));
+
     const boot = (forward) => {
       const env = { ...process.env, CACHE_FIX_PROXY_PORT: String(PORT), CACHE_FIX_PROXY_BIND: "127.0.0.1" };
       for (const k of ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"]) delete env[k];
@@ -529,12 +542,19 @@ describe("zero-downtime reload", () => {
       const first = boot(false); kids.push(first.proc);
       assert.equal(await first.verdict, "LISTENING", "premise: the first proxy must come up");
 
-      // SAME mode: this IS the handover, and it must be allowed.
-      const same = boot(false); kids.push(same.proc);
-      assert.equal(await same.verdict, "LISTENING",
-        "the guard refused a same-mode co-bind, which is the handover this change exists to enable");
-      same.proc.kill("SIGKILL");
-      await new Promise((r) => setTimeout(r, 700));
+      // SAME mode: this IS the handover, and it must be allowed — but only on a
+      // runtime that can hold one port from two listeners. Where `reusePort` is
+      // ignored (node < 22.12) the kernel refuses the co-bind with EADDRINUSE
+      // before the guard is ever consulted, so asserting LISTENING there tests
+      // the runtime, not this change. Measured on CI: node 18.20.8 and 20.20.2
+      // fail this row for that reason while the mismatch row below still holds.
+      if (canCoBind) {
+        const same = boot(false); kids.push(same.proc);
+        assert.equal(await same.verdict, "LISTENING",
+          "the guard refused a same-mode co-bind, which is the handover this change exists to enable");
+        same.proc.kill("SIGKILL");
+        await new Promise((r) => setTimeout(r, 700));
+      }
 
       // OTHER mode: the kernel would round-robin CONNECT between them.
       const other = boot(true); kids.push(other.proc);

--- a/test/proxy-server.test.mjs
+++ b/test/proxy-server.test.mjs
@@ -353,7 +353,37 @@ describe("zero-downtime reload", () => {
   // Driven with two REAL server processes, not two `startProxy()` handles in
   // one process: the whole question is whether two separate processes can hold
   // the same port at once, which an in-process test cannot ask.
-  it("a successor binds the same port while the old process is still serving", async () => {
+  it("a successor binds the same port while the old process is still serving", async (t) => {
+    // `reusePort` landed in node 22.12; on 18 and 20 the option is IGNORED, so
+    // the listen succeeds and the successor is refused EADDRINUSE. Those
+    // runtimes keep the old kill-then-respawn reload, which is a real
+    // limitation and not a test failure.
+    //
+    // Gated on a CAPABILITY PROBE rather than a version string: the question is
+    // whether two listeners can hold one port on THIS runtime and kernel, and a
+    // version comparison answers a different one — it would skip on a new node
+    // over an old kernel and run on an old node over a new one. The probe binds
+    // twice for real and reports what happened.
+    const net = await import("node:net");
+    const first = net.createServer();
+    await new Promise((res, rej) => {
+      first.once("error", rej);
+      first.listen({ port: 0, host: "127.0.0.1", reusePort: true }, res);
+    });
+    const probePort = first.address().port;
+    const second = net.createServer();
+    const capable = await new Promise((res) => {
+      second.once("error", () => res(false));
+      second.listen({ port: probePort, host: "127.0.0.1", reusePort: true }, () => res(true));
+    });
+    try { second.close(); } catch {}
+    await new Promise((r) => first.close(r));
+    if (!capable) {
+      t.skip(`this runtime cannot hold one port from two listeners (${process.version}); ` +
+             `reload stays kill-then-respawn here`);
+      return;
+    }
+
     const { spawn } = await import("node:child_process");
     const { fileURLToPath } = await import("node:url");
     const { dirname, join: pjoin } = await import("node:path");
@@ -425,15 +455,93 @@ describe("zero-downtime reload", () => {
       // predecessor still holds. Before SO_REUSEPORT it rejected with EADDRINUSE.
       await started(newer);
 
+      // PRECONDITION, asserted rather than assumed: the stream must still be
+      // OPEN when the reload happens, or "it completed" is satisfied by a
+      // response that had already finished and the test measures nothing.
+      // An accidental control is invisible until timing changes — a slower box
+      // or a faster upstream turns this into a green that proves nothing, and
+      // reading the numbers afterwards is not a mechanism.
+      assert.ok(!ended, `premise: the stream must still be open at the reload; it had already ` +
+        `finished after ${chunks} chunks, so this run measured a completed response`);
+      const midflight = chunks;
+
       older.kill("SIGTERM");
       const done = Date.now() + 20_000;
       while (!ended && !failure && Date.now() < done) await new Promise((r) => setTimeout(r, 100));
 
       assert.equal(failure, null, `the reload cut a response that was already streaming (${failure})`);
       assert.ok(ended, "the streaming response never completed across the reload");
+      // ...and it kept going AFTER the reload rather than having been complete
+      // at the moment of it. Without this, a stream that delivered its last
+      // chunk in the same tick as the SIGTERM would satisfy both assertions
+      // above while proving nothing about the handover.
+      assert.ok(chunks > midflight,
+        `no chunk arrived after the reload (${midflight} before, ${chunks} total), ` +
+        `so the handover was never exercised`);
     } finally {
       for (const k of kids) { try { k.kill("SIGKILL"); } catch {} }
       await new Promise((r) => upstream.close(r));
+    }
+  });
+
+  // `reusePort` removes EADDRINUSE, which used to be the only thing stopping a
+  // second proxy on this port. Losing it entirely is a real regression: a plain
+  // proxy and a `--remote-control` forward proxy on one port make the kernel
+  // round-robin CONNECT between a process that speaks it and one that does not
+  // (measured: 17 of 40 attempts ECONNRESET).
+  //
+  // The guard keys on MODE, not occupancy, and this test is the pair that
+  // proves it — refusing every occupied port would also refuse the handover
+  // this change exists to enable, and a test for only the refusal would pass on
+  // a guard that broke it.
+  it("refuses a second proxy in the OTHER mode, and allows one in the same mode", async () => {
+    const { spawn } = await import("node:child_process");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, join: pjoin } = await import("node:path");
+    const net = await import("node:net");
+    const here = dirname(fileURLToPath(import.meta.url));
+    const serverPath = pjoin(here, "..", "proxy", "server.mjs");
+
+    const scout = net.createServer();
+    await new Promise((r) => scout.listen(0, "127.0.0.1", r));
+    const PORT = scout.address().port;
+    await new Promise((r) => scout.close(r));
+
+    const boot = (forward) => {
+      const env = { ...process.env, CACHE_FIX_PROXY_PORT: String(PORT), CACHE_FIX_PROXY_BIND: "127.0.0.1" };
+      for (const k of ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"]) delete env[k];
+      if (forward) { env.CACHE_FIX_FORWARD_PROXY = "on"; env.CACHE_FIX_WIRED_BY_LAUNCHER = "1"; }
+      else delete env.CACHE_FIX_FORWARD_PROXY;
+      const proc = spawn(process.execPath, [serverPath], { env, stdio: ["ignore", "pipe", "pipe"] });
+      const verdict = new Promise((res) => {
+        let done = false;
+        const settle = (v) => { if (!done) { done = true; res(v); } };
+        proc.stdout.on("data", (d) => { if (/listening/.test(String(d))) settle("LISTENING"); });
+        proc.stderr.on("data", (d) => { if (/already on|failed to start/.test(String(d))) settle("REFUSED"); });
+        proc.on("exit", () => settle("EXITED"));
+        setTimeout(() => settle("TIMEOUT"), 15_000);
+      });
+      return { proc, verdict };
+    };
+
+    const kids = [];
+    try {
+      const first = boot(false); kids.push(first.proc);
+      assert.equal(await first.verdict, "LISTENING", "premise: the first proxy must come up");
+
+      // SAME mode: this IS the handover, and it must be allowed.
+      const same = boot(false); kids.push(same.proc);
+      assert.equal(await same.verdict, "LISTENING",
+        "the guard refused a same-mode co-bind, which is the handover this change exists to enable");
+      same.proc.kill("SIGKILL");
+      await new Promise((r) => setTimeout(r, 700));
+
+      // OTHER mode: the kernel would round-robin CONNECT between them.
+      const other = boot(true); kids.push(other.proc);
+      assert.equal(await other.verdict, "REFUSED",
+        "a forward proxy co-bound with a plain one; CONNECT would round-robin between them");
+    } finally {
+      for (const k of kids) { try { k.kill("SIGKILL"); } catch {} }
     }
   });
 });

--- a/test/proxy-server.test.mjs
+++ b/test/proxy-server.test.mjs
@@ -560,8 +560,89 @@ describe("zero-downtime reload", () => {
       const other = boot(true); kids.push(other.proc);
       assert.equal(await other.verdict, "REFUSED",
         "a forward proxy co-bound with a plain one; CONNECT would round-robin between them");
+
+      // NO OPINION is not a mismatch. `/health` has two shapes: the ok body
+      // carries `forward_proxy`, the degraded one (503, an extension failed to
+      // load) does not — and `undefined !== false` is true, so absence read as a
+      // mismatch and refused BOTH modes, leaving the port unstartable. That
+      // body's own hint says "restart the proxy via your supervisor to recover",
+      // the very restart the guard blocked. Pre-4.3.0 cache-fix hits it too:
+      // the key entered `/health` in 4.3.0, so an upgrade could not start on its
+      // own port. Stood up here rather than as its own test because it is the
+      // third row of the same table — same guard, same fixture shape, one more
+      // incumbent answer.
+      const http2 = await import("node:http");
+      const degraded = http2.createServer((q, r) => {
+        r.writeHead(503, { "content-type": "application/json" });
+        r.end(JSON.stringify({ status: "degraded", failed_extensions: [{ file: "boom.mjs" }],
+                               hint: "restart the proxy via your supervisor to recover (#196)" }));
+      });
+      // reusePort on the incumbent too, or the KERNEL refuses the successor
+      // before the guard is asked — measured, and it reads as "the guard
+      // refused" while the guard had passed.
+      if (canCoBind) {
+        const scout2 = net.createServer();
+        await new Promise((r) => scout2.listen(0, "127.0.0.1", r));
+        const P2 = scout2.address().port;
+        await new Promise((r) => scout2.close(r));
+        await new Promise((res, rej) => {
+          degraded.once("error", rej);
+          degraded.listen({ port: P2, host: "127.0.0.1", reusePort: true }, res);
+        });
+        try {
+          const env2 = { ...process.env, CACHE_FIX_PROXY_PORT: String(P2), CACHE_FIX_PROXY_BIND: "127.0.0.1" };
+          for (const k of ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"]) delete env2[k];
+          const p2 = spawn(process.execPath, [serverPath], { env: env2, stdio: ["ignore", "pipe", "pipe"] });
+          kids.push(p2);
+          const v2 = await new Promise((res) => {
+            let done = false;
+            const settle = (v) => { if (!done) { done = true; res(v); } };
+            p2.stdout.on("data", (d) => { if (/listening/.test(String(d))) settle("LISTENING"); });
+            p2.stderr.on("data", (d) => { if (/already on|failed to start/.test(String(d))) settle("REFUSED"); });
+            p2.on("exit", () => settle("EXITED"));
+            setTimeout(() => settle("TIMEOUT"), 15_000);
+          });
+          assert.notEqual(v2, "REFUSED",
+            "an incumbent whose /health carries no forward_proxy was read as a mismatch, " +
+            "so the port cannot be started in EITHER mode — including by the restart it asks for");
+        } finally {
+          await new Promise((r) => degraded.close(r));
+        }
+      }
+
+      // ...and a REFUSAL must not leak what the forward attach claimed.
+      // `startProxy` is an exported API, so a caller survives the throw, and
+      // `_forwardActive` plus the self-heal handler are process-wide. The
+      // close() path already retires them; the guard's throw is a second exit
+      // from the same critical section. Leaked, a later reverse-only instance
+      // reports forward_proxy:true and relays paths it should 404.
+      const { startProxy } = await import("../proxy/server.mjs");
+      const beforeHandlers = process.listenerCount("uncaughtException");
+      const savedFwd = process.env.CACHE_FIX_FORWARD_PROXY;
+      process.env.CACHE_FIX_FORWARD_PROXY = "on";
+      let threw = false;
+      try { await startProxy({ port: PORT, bind: "127.0.0.1", watch: false }); }
+      catch { threw = true; }
+      finally {
+        if (savedFwd === undefined) delete process.env.CACHE_FIX_FORWARD_PROXY;
+        else process.env.CACHE_FIX_FORWARD_PROXY = savedFwd;
+      }
+      assert.ok(threw, "premise: the guard must refuse in-process too, or this row measures nothing");
+      assert.equal(process.listenerCount("uncaughtException"), beforeHandlers,
+        "the self-heal handler outlived the refusal — a later reverse-only proxy inherits it");
+      const rev = await startProxy({ port: 0, bind: "127.0.0.1", watch: false });
+      try {
+        const body = await new Promise((res) => {
+          http2.get({ host: "127.0.0.1", port: rev.port, path: "/health" }, (r) => {
+            let b = ""; r.on("data", (d) => (b += d)); r.on("end", () => res(b));
+          });
+        });
+        assert.equal(JSON.parse(body).forward_proxy, false,
+          "a reverse-only proxy reported forward_proxy:true — the refused attach leaked its count");
+      } finally { await rev.close(); }
     } finally {
       for (const k of kids) { try { k.kill("SIGKILL"); } catch {} }
     }
   });
+
 });

--- a/test/proxy-server.test.mjs
+++ b/test/proxy-server.test.mjs
@@ -342,3 +342,98 @@ describe("proxy server /health degraded (#196)", () => {
     assert.ok(!/cache-fix-proxy\.service/.test(parsed.hint), "hint must not be systemd-specific");
   });
 });
+
+describe("zero-downtime reload", () => {
+  // A reload must not cut a response that is already streaming. This is not a
+  // hypothetical: a reload on a shared host cut three live sessions, surfacing
+  // as "Connection closed mid-response", because the only reload available was
+  // kill-then-respawn — the successor could not bind the port until the old
+  // process was gone, so every in-flight body died with it.
+  //
+  // Driven with two REAL server processes, not two `startProxy()` handles in
+  // one process: the whole question is whether two separate processes can hold
+  // the same port at once, which an in-process test cannot ask.
+  it("a successor binds the same port while the old process is still serving", async () => {
+    const { spawn } = await import("node:child_process");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, join: pjoin } = await import("node:path");
+    const here = dirname(fileURLToPath(import.meta.url));
+    const serverPath = pjoin(here, "..", "proxy", "server.mjs");
+
+    // A deliberately slow upstream, so the response is still open when the
+    // reload happens. 12 chunks at 250 ms is ~3 s of streaming against a
+    // handover that takes well under one.
+    const CHUNKS = 12;
+    const upstream = http.createServer((q, r) => {
+      r.writeHead(200, { "content-type": "text/event-stream" });
+      let n = 0;
+      const t = setInterval(() => {
+        r.write(`data: ${++n}\n\n`);
+        if (n >= CHUNKS) { clearInterval(t); r.end(); }
+      }, 250);
+      q.resume();
+    });
+    await new Promise((r) => upstream.listen(0, "127.0.0.1", r));
+    const upPort = upstream.address().port;
+
+    // Port 0 cannot be used here — both processes must be told the SAME port,
+    // and the point is that the second one binds it. Ask the kernel for a free
+    // one, then release it.
+    const scout = http.createServer();
+    await new Promise((r) => scout.listen(0, "127.0.0.1", r));
+    const PORT = scout.address().port;
+    await new Promise((r) => scout.close(r));
+
+    const env = { ...process.env,
+      CACHE_FIX_PROXY_PORT: String(PORT),
+      CACHE_FIX_PROXY_BIND: "127.0.0.1",
+      CACHE_FIX_PROXY_UPSTREAM: `http://127.0.0.1:${upPort}` };
+    // The ambient proxy vars would send this test's own requests through a real
+    // proxy on the developer's box, which hangs forever.
+    for (const k of ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"]) delete env[k];
+
+    const started = (p) => new Promise((res, rej) => {
+      const to = setTimeout(() => rej(new Error("proxy did not report listening")), 15_000);
+      p.stdout.on("data", (d) => { if (/listening/.test(String(d))) { clearTimeout(to); res(); } });
+      p.on("error", rej);
+    });
+    const older = spawn(process.execPath, [serverPath], { env, stdio: ["ignore", "pipe", "pipe"] });
+    const kids = [older];
+    try {
+      await started(older);
+
+      // Start streaming, and wait until bytes are actually flowing — a request
+      // that has not been answered yet would prove nothing about in-flight.
+      let chunks = 0, ended = false, failure = null;
+      const req = http.request(
+        { host: "127.0.0.1", port: PORT, path: "/v1/messages", method: "POST",
+          headers: { "content-type": "application/json" } },
+        (res) => {
+          res.on("data", () => chunks++);
+          res.on("end", () => { ended = true; });
+          res.on("error", (e) => { failure = e.code || e.message; });
+        });
+      req.on("error", (e) => { failure = e.code || e.message; });
+      req.end(JSON.stringify({ model: "x", messages: [], stream: true }));
+      const flowing = Date.now() + 10_000;
+      while (chunks === 0 && Date.now() < flowing) await new Promise((r) => setTimeout(r, 100));
+      assert.ok(chunks > 0, `premise: the response must be streaming before the reload. failure=${failure}`);
+
+      const newer = spawn(process.execPath, [serverPath], { env, stdio: ["ignore", "pipe", "pipe"] });
+      kids.push(newer);
+      // THE assertion: this resolves only if the successor bound a port the
+      // predecessor still holds. Before SO_REUSEPORT it rejected with EADDRINUSE.
+      await started(newer);
+
+      older.kill("SIGTERM");
+      const done = Date.now() + 20_000;
+      while (!ended && !failure && Date.now() < done) await new Promise((r) => setTimeout(r, 100));
+
+      assert.equal(failure, null, `the reload cut a response that was already streaming (${failure})`);
+      assert.ok(ended, "the streaming response never completed across the reload");
+    } finally {
+      for (const k of kids) { try { k.kill("SIGKILL"); } catch {} }
+      await new Promise((r) => upstream.close(r));
+    }
+  });
+});


### PR DESCRIPTION
## The failure

A reload of the proxy cuts responses that are still streaming. Three live
sessions on a shared host died this way in one window, each surfacing as
`Connection closed mid-response`.

It is structural rather than a race. The only reload available is
kill-then-respawn, because a successor cannot bind the port until the old
process is gone — so every body still streaming through the old one dies with
it. The 5 s force-close makes it certain: a `/v1/messages` stream outlives that
window by design.

## Measured

Two real server processes, a 12-chunk stream through the proxy, reloaded
mid-flight:

| | chunks | ended | error |
| :-- | --: | :-- | :-- |
| before | 18 | `false` | **`ECONNRESET`** |
| after | 24 | `true` | none |

## The change

**`SO_REUSEPORT` on the listen.** The successor is already accepting before the
predecessor stops, so a reload becomes a handover: the port is never unbound,
and the old process serves what it already accepted.

`listen({port, host, reusePort})` rather than `listen(port, host)` — the option
form is the only one that carries the flag.

**Shutdown grace 5 s → 120 s**, overridable via `CACHE_FIX_SHUTDOWN_GRACE_MS`.
5 s was the right number when a longer wait meant a longer outage — the port
stayed unbound until the process died. With a successor already serving, waiting
costs only this process's own lifetime, and 5 s is far shorter than the one
request a reload must not cut.

## Platform behaviour, measured on three machines

`SO_REUSEPORT` semantics are not uniform, and they are the opposite of what this
PR first claimed. Two listeners on one port, 40 connections, every row with a
plain-bind control that is refused (so a green is not a silent no-op):

| host | kernel | predecessor | successor | |
| :-- | :-- | --: | --: | :-- |
| Linux | 6.8.0 | 20 | 20 | load-balanced |
| macOS | Darwin 24.6.0 | 0 | 40 | last binder takes all |
| macOS | Darwin 23.5.0 | 0 | 40 | last binder takes all |

*(macOS rows contributed by a peer session with access to those machines.)*

Linux splitting new connections between the two listeners would be a hazard if
the predecessor were dying while still accepting. It is not: `close()` removes
it from the load-balance set immediately, and `close()` is the first thing the
SIGTERM handler does.

| Linux 6.8.0 | predecessor | successor |
| :-- | --: | --: |
| both listening | 9 | 11 |
| after `close()` | **0** | 20 |

So the split window spans only the period when both are healthy — a connection
landing on the predecessor there lands on a working process, not a dying one —
and it ends at `close()`. That is also why the longer grace is free: the
predecessor is invisible to new connections for the whole 120 s and is only
finishing what it already accepted.

**A successor that binds and then crashes cannot strand the port.** Measured on
all three, with the successor asserted to be serving first, so `B=0` afterwards
is a transition rather than a pre-existing zero:

| | predecessor | successor |
| :-- | --: | --: |
| both listening | 4 | 16 |
| successor gone | **20** | 0 |

The predecessor resumes. This is the property that matters most for a handover,
and it holds on both platforms.

## The test

Two real `spawn`ed server processes, not two `startProxy()` handles. The
question is whether two PROCESSES can hold one port at once, and an in-process
test cannot ask it. It streams through the first, starts the second, `SIGTERM`s
the first, and asserts the body completes.

Gated on a **capability probe** — it binds two listeners for real and reads the
result — rather than a version comparison. `reusePort` landed in node 22.12, so
18 and 20 ignore the option, listen successfully, and refuse the successor
`EADDRINUSE`; those runtimes keep today's kill-then-respawn reload, which is a
real limitation rather than a test failure. A version compare would answer a
different question: it would skip on a new runtime over an old kernel and run on
an old runtime over a new one.

Three ways, all measured:

| | result |
| :-- | :-- |
| capable runtime | runs, passes |
| probe forced incapable | **skips**, does not fail |
| `reusePort` removed from the server | **fails** |

Full suite `1500/1500`, 0 skipped, on node v24.11.1.

## Not claimed

One `/health` probe at the instant of `close()` can still be refused —
connections sitting in the old listener's accept queue are reset, which is a
known `SO_REUSEPORT` property. That is a new connection failing and being
retried, not an in-flight body being cut, and the latter is the failure this
change was written to remove. A queue-draining handover would need its own
measurement.
