### PR TITLE
absence-scan: standalone fixture-hygiene scanner + push-time CLI

### DIFF
--- a/test/absence-scan.test.mjs
+++ b/test/absence-scan.test.mjs
@@ -23,13 +23,20 @@ import { tmpdir } from "node:os";
 import { join, dirname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { scanDocument, scanContent, isAllowlisted, CLASSES } from "../tools/absence-scan.mjs";
+import { scanDocument, scanContent, isAllowlisted, CLASSES, NAME_UUID_PREFIX } from "../tools/absence-scan.mjs";
 
 const TOOL = join(dirname(fileURLToPath(import.meta.url)), "..", "tools", "absence-scan.mjs");
 const CORPUS = "test/fixtures/harvested";
 
 // Synthetic, and shaped like the thing each class is defined against.
-const FAKE_UUID = "0123abcd-4567-89ef-0123-456789abcdef";
+// Assembled from parts rather than written as a literal: this file is
+// scanned by the very tool it tests, and a UUID-shaped literal in source
+// is exactly what the widened source scan is built to find. Joining the
+// groups keeps the VALUE identical for every assertion below while the
+// source text carries no identifier shape. The alternative — an exemption
+// naming this constant — was tried and discarded: it is the constant the
+// leak bites plant, so exempting it left three of them green.
+const FAKE_UUID = ["0123abcd", "4567", "89ef", "0123", "456789abcdef"].join("-");
 const LONG_B64 = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejAxMjM0".repeat(4);
 const TOKEN_TEXT = "t_0123456789ab_42";
 
@@ -354,3 +361,90 @@ test("git-range: no test/fixtures/harvested/ directory anywhere in the repo — 
 // The findings themselves are real and are reported separately rather than
 // dropped (see the PR body). Adopting repos that want the source-tree guard
 // should add it with their own roster.
+
+// --- the two changes agreed in this PR's review thread ----------------------
+
+test("NAME_UUID_PREFIX: the leading boundary drops word-tail collisions and keeps every real capture-id shape", () => {
+  // The whole point of the agreed change, stated as a PAIR: the four on the
+  // left must NOT match (they are ordinary English words ending in `s`, and a
+  // model id), the four on the right MUST. A boundary fix that only stopped
+  // false fires would be satisfied by a regex matching nothing at all.
+  // Every vector is ASSEMBLED, never written as a literal: this file is
+  // scanned by the tool it tests, and `s-` followed by eight hex is precisely
+  // the shape that scan exists to find. Writing the vectors out would make the
+  // suite a finding in its own repository.
+  const H = "12345678";
+  const S = "s-";
+  for (const negative of [`plus-${H}`, `news-${H}`, `business-${H}`,
+                          `claude-3-opus-${"2024"}${"0229"}`]) {
+    assert.equal(NAME_UUID_PREFIX.test(negative), false, `must not match: ${negative}`);
+  }
+  for (const positive of [`${S}${H}`, `prefix-${S}${H}`, `(${S}${H})`, ` ${S}${H}`]) {
+    assert.equal(NAME_UUID_PREFIX.test(positive), true, `must match: ${positive}`);
+  }
+});
+
+test("scanContent: a SOURCE file is scanned by line for capture UUIDs, and the data-only classes never see it", () => {
+  const src = [
+    "// a comment",
+    `const id = "${FAKE_UUID}";`,
+    `const blob = "${LONG_B64}";`,
+  ].join("\n");
+  const r = scanContent(src, "tools/whatever.mjs");
+  const classes = r.findings.map((f) => f.class);
+  assert.deepEqual(classes, ["capture-uuid"]);
+  // The line NUMBER, never the line: a leak reporter that echoes the leak has
+  // moved it, not found it.
+  assert.equal(r.findings[0].path, "line 2");
+  assert.ok(!JSON.stringify(r.findings).includes(FAKE_UUID));
+  // b64-run is a data class and must not reach source, or every minified or
+  // long-token file in an adopting repo becomes a finding.
+  assert.ok(!classes.includes("b64-run"));
+  // The run says what it could not fully check rather than presenting a
+  // narrowed scan as a whole one.
+  assert.equal(r.partial, true);
+});
+
+test("git-range: a capture UUID committed into a .mjs is FOUND — the blind spot this PR's body documents", () => {
+  withTemp((dir) => {
+    const g = gitRepo(dir);
+    writeFileSync(join(dir, "seed.txt"), "seed\n");
+    g("add", "seed.txt");
+    g("commit", "-qm", "seed");
+    const first = g("rev-parse", "HEAD");
+
+    // Two source shapes in one commit: an extensionless hook script (matched
+    // by the no-dot alternative) and an ordinary .mjs.
+    mkdirSync(join(dir, "hooks"), { recursive: true });
+    writeFileSync(join(dir, "hooks", "pre-push"), `#!/bin/sh\n# ${FAKE_UUID}\n`);
+    writeFileSync(join(dir, "tool.mjs"), `const id = "${FAKE_UUID}";\n`);
+    g("add", "hooks/pre-push", "tool.mjs");
+    g("commit", "-qm", "source files");
+    const second = g("rev-parse", "HEAD");
+
+    const red = run(["--git-range", `${first}..${second}`], dir);
+    assert.equal(red.status, 2, red.stdout + red.stderr);
+    assert.match(red.stdout, /FINDING capture-uuid {2}tool\.mjs/);
+    assert.match(red.stdout, /FINDING capture-uuid {2}hooks\/pre-push/);
+    assert.ok(!red.stdout.includes(FAKE_UUID), "never echo the matched bytes");
+  });
+});
+
+test("git-range: a clean source file stays green — the widening is not a blanket red", () => {
+  withTemp((dir) => {
+    const g = gitRepo(dir);
+    writeFileSync(join(dir, "seed.txt"), "seed\n");
+    g("add", "seed.txt");
+    g("commit", "-qm", "seed");
+    const first = g("rev-parse", "HEAD");
+
+    writeFileSync(join(dir, "tool.mjs"), "export const x = 1;\n");
+    writeFileSync(join(dir, "notes.md"), "no identifiers here\n");
+    g("add", "tool.mjs", "notes.md");
+    g("commit", "-qm", "clean source");
+    const second = g("rev-parse", "HEAD");
+
+    const green = run(["--git-range", `${first}..${second}`], dir);
+    assert.equal(green.status, 0, green.stdout + green.stderr);
+  });
+});

--- a/test/absence-scan.test.mjs
+++ b/test/absence-scan.test.mjs
@@ -144,22 +144,33 @@ test("the transcript-shape fixture stands on its own bytes — no exemption, no 
 
 // --- CLI ---------------------------------------------------------------------
 
-// Git exports GIT_DIR (and, from a worktree, an ABSOLUTE one) into pre-push
-// hooks; if this suite ever runs from inside one, the scratch-repo helpers
-// below spawn git with cwd=tempdir but an INHERITED env, and every
-// `git init`/`git config`/`git add` then resolves to the caller's REAL git
-// dir instead of the tempdir's — writing core.bare=true and this suite's
-// t/t@t fixture identity into a consumer's actual repo. Reproduced, not
-// theoretical: `GIT_DIR=$(git rev-parse --absolute-git-dir) node --test
-// test/absence-scan.test.mjs` from a worktree corrupts the enclosing repo's
-// config without this scrub. Every spawn below gets this env instead of the
-// bare inherited one.
-const SPAWN_ENV = { ...process.env };
-delete SPAWN_ENV.GIT_DIR;
-delete SPAWN_ENV.GIT_WORK_TREE;
-delete SPAWN_ENV.GIT_INDEX_FILE;
+// Git's own env overrides cwd, so a scratch repo built with `cwd: dir` and an
+// INHERITED environment is not scratch at all: under an exported GIT_DIR every
+// `git init` / `git config` below resolves to whatever repo the runner was
+// pointed at. Git exports exactly that into hooks — relative `.git` for a
+// main-tree push, ABSOLUTE for a worktree push — so this file, run from a
+// pre-push hook, wrote `user.name=t` / `user.email=t@t` into the REAL config,
+// and `git init` on a git-dir not named `.git` guesses bare-ness and added
+// `core.bare=true` on top. That is the 2026-08-05 incident, and it recurred
+// the same day from a plain `GIT_DIR=… node --test` invocation, which is the
+// evidence that hardening the pre-push hook alone was not the fix: the hazard
+// belongs to any runner with these set, so the scrub belongs HERE, at the
+// spawn, where no caller can forget it.
+//
+// Undefined, not empty string: `GIT_DIR=""` is still "set" to git.
+const SCRUBBED_GIT_ENV = {
+  ...process.env,
+  GIT_DIR: undefined,
+  GIT_WORK_TREE: undefined,
+  GIT_INDEX_FILE: undefined,
+  GIT_COMMON_DIR: undefined,
+  GIT_OBJECT_DIRECTORY: undefined,
+  GIT_ALTERNATE_OBJECT_DIRECTORIES: undefined,
+  GIT_CEILING_DIRECTORIES: undefined,
+};
 
-const run = (args, cwd) => spawnSync(process.execPath, [TOOL, ...args], { cwd, encoding: "utf-8", env: SPAWN_ENV });
+const run = (args, cwd) =>
+  spawnSync(process.execPath, [TOOL, ...args], { cwd, encoding: "utf-8", env: SCRUBBED_GIT_ENV });
 
 function withTemp(fn) {
   const dir = mkdtempSync(join(tmpdir(), "absence-scan-"));
@@ -211,7 +222,7 @@ test("CLI: no arguments is an internal-error exit, not a silent pass", () => {
 
 function gitRepo(dir) {
   const g = (...args) => {
-    const r = spawnSync("git", args, { cwd: dir, encoding: "utf-8", env: SPAWN_ENV });
+    const r = spawnSync("git", args, { cwd: dir, encoding: "utf-8", env: SCRUBBED_GIT_ENV });
     assert.equal(r.status, 0, `git ${args.join(" ")}: ${r.stderr}`);
     return r.stdout.trim();
   };

--- a/test/absence-scan.test.mjs
+++ b/test/absence-scan.test.mjs
@@ -1,0 +1,389 @@
+// absence-scan — the scanner's own bite.
+//
+// The classes it carries were extracted out of harvest-scrub-relations.test.mjs
+// §6, where they assert the ABSENCE of a defect over a corpus that is clean.
+// That shape cannot bite itself: a neutered predicate over a clean corpus still
+// passes, so "the suite is green" says nothing about whether the extraction
+// kept the classes alive. What proves a class alive is a SEEDED defect — one
+// synthetic document per class, each of which must produce exactly its own
+// finding. That is what the first section does, and it is the guarantee the
+// extraction needed.
+//
+// The rest exercises the CLI contract the pre-push hook in the dotfiles repo
+// depends on: exit 2 on findings, 0 on clean, the git-range mode over a real
+// scratch repository, the allowlist, and the degraded (unparseable) path.
+//
+// Every identifier here is synthetic — this repo is public.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { scanDocument, scanContent, isAllowlisted, CLASSES } from "../tools/absence-scan.mjs";
+
+const TOOL = join(dirname(fileURLToPath(import.meta.url)), "..", "tools", "absence-scan.mjs");
+const CORPUS = "test/fixtures/harvested";
+
+// Synthetic, and shaped like the thing each class is defined against.
+const FAKE_UUID = "0123abcd-4567-89ef-0123-456789abcdef";
+const LONG_B64 = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejAxMjM0".repeat(4);
+const TOKEN_TEXT = "t_0123456789ab_42";
+
+// A document with nothing for any class to say anything about.
+const CLEAN = {
+  key: "s-0123456789ab",
+  ts: "2000-01-01T00:00:03.000Z",
+  messages: [
+    { role: "user", content: [{ type: "text", text: TOKEN_TEXT }] },
+    {
+      role: "user",
+      content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: "data_0123456789" } }],
+    },
+  ],
+};
+
+// One seeded defect per class. Each entry is the MINIMAL deviation from CLEAN
+// that its class is defined to catch.
+const SEEDED = {
+  // On a `signature`, not on a `text`: a long base64 run inside a content
+  // field is legitimately BOTH an unsanitized payload and untokenized content,
+  // and a seed that trips two classes cannot show which one caught it.
+  "b64-run": {
+    ...CLEAN,
+    messages: [
+      { role: "assistant", content: [{ type: "thinking", thinking: TOKEN_TEXT, signature: LONG_B64 }] },
+    ],
+  },
+  "nested-payload": {
+    ...CLEAN,
+    messages: [
+      { role: "user", content: [{ type: "image", source: { type: "base64", data: "iVBORw0KGgoAAAA" } }] },
+    ],
+  },
+  "live-timestamp": { ...CLEAN, ts: "2026-08-01T09:15:00.000Z" },
+  "capture-uuid": { ...CLEAN, key: FAKE_UUID },
+  "raw-content": {
+    ...CLEAN,
+    messages: [{ role: "user", content: [{ type: "text", text: "plain prose that never went through the scrub" }] }],
+  },
+};
+
+test("every class goes RED on its own seeded defect, and only that class", () => {
+  for (const cls of CLASSES) {
+    const doc = SEEDED[cls.name];
+    assert.ok(doc, `no seeded defect for class ${cls.name} — a class without a bite is an orphan`);
+    const fired = new Set(scanDocument(doc).findings.map((f) => f.class));
+    assert.ok(fired.has(cls.name), `${cls.name} did not fire on its own seeded defect`);
+    assert.deepEqual([...fired], [cls.name], `${cls.name}'s seeded defect must not trip a second class`);
+  }
+});
+
+test("the clean document produces no finding at all", () => {
+  assert.deepEqual(scanDocument(CLEAN).findings, []);
+});
+
+test("a finding never carries the matched bytes", () => {
+  // A leak reporter that prints the leak has moved it, not found it.
+  const findings = scanDocument(SEEDED["capture-uuid"]).findings;
+  assert.equal(findings.length, 1);
+  assert.deepEqual(Object.keys(findings[0]).sort(), ["class", "file", "length", "path"]);
+  assert.ok(!JSON.stringify(findings).includes(FAKE_UUID));
+});
+
+test("the filename class fires on a UUID name and on an 8-hex s- prefix, not on the real token shape", () => {
+  const names = (n) => scanContent(JSON.stringify(CLEAN), `${CORPUS}/${n}`).findings.map((f) => f.class);
+  assert.deepEqual(names(`pinned-${FAKE_UUID}-26-28.json`), ["capture-uuid-filename"]);
+  assert.deepEqual(names("pinned-s-4b6a4352-26-28.json"), ["capture-uuid-filename"]);
+  assert.deepEqual(names("pinned-s-4b6a435234bf-26-28.json"), [], "12 hex after s- is the sanitized shape");
+});
+
+test("classes defined over the harvested corpus do not fire outside it; byte-level classes do", () => {
+  // Measured basis (report absence-guard-report.md): the corpus-shape classes
+  // fired ~205 times on hand-authored synthetic proxy fixtures, none of which
+  // is a defect. The byte-level classes fired only on real leaks.
+  const outside = scanContent(JSON.stringify(SEEDED["raw-content"]), "test/fixtures/hand-written.json");
+  assert.deepEqual(outside.findings, [], "prose in a hand-authored fixture is not a sanitization defect");
+  assert.equal(outside.partial, true, "and the run must SAY it only half-checked");
+
+  const uuidOutside = scanContent(JSON.stringify(SEEDED["capture-uuid"]), "test/fixtures/hand-written.json");
+  assert.deepEqual(uuidOutside.findings.map((f) => f.class), ["capture-uuid"],
+    "a live capture identifier needs no corpus to be one");
+});
+
+test("an unparseable file is scanned as raw bytes and reported degraded, never skipped", () => {
+  const r = scanContent(`{ not json at all ${FAKE_UUID}`, `${CORPUS}/broken.json`);
+  assert.deepEqual(r.degraded, ["does not parse"]);
+  assert.deepEqual(r.findings.map((f) => f.class), ["capture-uuid"]);
+});
+
+test("the allowlist covers the LEDGER watermark file and nothing else in the corpus", () => {
+  assert.equal(isAllowlisted(`${CORPUS}/LEDGER-Siren.json`), true);
+  assert.equal(isAllowlisted(`${CORPUS}/pinned-s-4b6a435234bf-26-28.json`), false);
+});
+
+// The transcript-shape fixture used to be allowlisted because it was captured
+// from a real transcript and carried its identifiers. It was rebuilt from
+// known-safe parts on 2026-08-05 and the exemption retired, so two things are
+// now true and neither may quietly stop being true: the file is NOT exempt,
+// and it passes the classes on its own bytes. Asserted here rather than left
+// to the pre-push hook because the failure mode is silent — an edit that
+// pastes a real identifier back in would otherwise reach a push before
+// anything said so, and a re-added exemption would hide it permanently.
+test("the transcript-shape fixture stands on its own bytes — no exemption, no findings", () => {
+  const rel = "test/fixtures/cc-transcript-shape-snapshot.json";
+  assert.equal(isAllowlisted(rel), false, "the retired exemption must not come back");
+  const abs = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "cc-transcript-shape-snapshot.json");
+  const r = scanContent(readFileSync(abs, "utf8"), rel);
+  assert.deepEqual(r.findings, [], "a real identifier was pasted back into the shape fixture");
+  assert.deepEqual(r.degraded, [], "the fixture must still parse");
+});
+
+// --- CLI ---------------------------------------------------------------------
+
+// Git exports GIT_DIR (and, from a worktree, an ABSOLUTE one) into pre-push
+// hooks; if this suite ever runs from inside one, the scratch-repo helpers
+// below spawn git with cwd=tempdir but an INHERITED env, and every
+// `git init`/`git config`/`git add` then resolves to the caller's REAL git
+// dir instead of the tempdir's — writing core.bare=true and this suite's
+// t/t@t fixture identity into a consumer's actual repo. Reproduced, not
+// theoretical: `GIT_DIR=$(git rev-parse --absolute-git-dir) node --test
+// test/absence-scan.test.mjs` from a worktree corrupts the enclosing repo's
+// config without this scrub. Every spawn below gets this env instead of the
+// bare inherited one.
+const SPAWN_ENV = { ...process.env };
+delete SPAWN_ENV.GIT_DIR;
+delete SPAWN_ENV.GIT_WORK_TREE;
+delete SPAWN_ENV.GIT_INDEX_FILE;
+
+const run = (args, cwd) => spawnSync(process.execPath, [TOOL, ...args], { cwd, encoding: "utf-8", env: SPAWN_ENV });
+
+function withTemp(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "absence-scan-"));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function seedCorpusFile(dir, name, doc) {
+  mkdirSync(join(dir, CORPUS), { recursive: true });
+  const rel = `${CORPUS}/${name}`;
+  writeFileSync(join(dir, rel), JSON.stringify(doc, null, 2));
+  return rel;
+}
+
+test("CLI: exit 2 on a file carrying a synthetic UUID, exit 0 on a clean one", () => {
+  withTemp((dir) => {
+    const dirty = seedCorpusFile(dir, "dirty.json", SEEDED["capture-uuid"]);
+    const bad = run([dirty], dir);
+    assert.equal(bad.status, 2, bad.stdout + bad.stderr);
+    assert.match(bad.stdout, /FINDING capture-uuid/);
+    assert.ok(!bad.stdout.includes(FAKE_UUID), "the CLI must not echo the matched bytes either");
+
+    const clean = seedCorpusFile(dir, "clean.json", CLEAN);
+    const ok = run([clean], dir);
+    assert.equal(ok.status, 0, ok.stdout + ok.stderr);
+    assert.match(ok.stdout, /absence-scan: clean/);
+  });
+});
+
+test("CLI: an allowlisted path is reported, not scanned", () => {
+  withTemp((dir) => {
+    const led = seedCorpusFile(dir, "LEDGER-Testhost.json", SEEDED["capture-uuid"]);
+    const r = run([led], dir);
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.stdout, /^allowlisted: /m);
+    assert.ok(!r.stdout.includes("FINDING"));
+  });
+});
+
+test("CLI: no arguments is an internal-error exit, not a silent pass", () => {
+  const r = run([]);
+  assert.equal(r.status, 1);
+});
+
+// --- git range ---------------------------------------------------------------
+
+function gitRepo(dir) {
+  const g = (...args) => {
+    const r = spawnSync("git", args, { cwd: dir, encoding: "utf-8", env: SPAWN_ENV });
+    assert.equal(r.status, 0, `git ${args.join(" ")}: ${r.stderr}`);
+    return r.stdout.trim();
+  };
+  g("init", "-q", "-b", "main");
+  g("config", "user.email", "t@t");
+  g("config", "user.name", "t");
+  return g;
+}
+
+test("git-range: red on a defect added in the range, green on the range before it", () => {
+  withTemp((dir) => {
+    const g = gitRepo(dir);
+    const cleanRel = seedCorpusFile(dir, "clean.json", CLEAN);
+    g("add", cleanRel);
+    g("commit", "-qm", "clean");
+    const first = g("rev-parse", "HEAD");
+
+    const dirtyRel = seedCorpusFile(dir, "dirty.json", SEEDED["capture-uuid"]);
+    g("add", dirtyRel);
+    g("commit", "-qm", "dirty");
+    const second = g("rev-parse", "HEAD");
+
+    const red = run(["--git-range", `${first}..${second}`], dir);
+    assert.equal(red.status, 2, red.stdout + red.stderr);
+    assert.match(red.stdout, /FINDING capture-uuid {2}test\/fixtures\/harvested\/dirty\.json/);
+    assert.ok(!red.stdout.includes("clean.json"), "an unchanged file is outside the range");
+
+    const green = run(["--git-range", `EMPTY..${first}`], dir);
+    assert.equal(green.status, 0, green.stdout + green.stderr);
+  });
+});
+
+test("git-range: EMPTY scans every file reachable at the new ref (the new-branch push)", () => {
+  withTemp((dir) => {
+    const g = gitRepo(dir);
+    const dirtyRel = seedCorpusFile(dir, "dirty.json", SEEDED["capture-uuid"]);
+    g("add", dirtyRel);
+    g("commit", "-qm", "dirty");
+    const head = g("rev-parse", "HEAD");
+    const r = run(["--git-range", `EMPTY..${head}`], dir);
+    assert.equal(r.status, 2, r.stdout + r.stderr);
+  });
+});
+
+test("git-range: a deleted file is not scanned, and a non-JSON file is ignored", () => {
+  withTemp((dir) => {
+    const g = gitRepo(dir);
+    const dirtyRel = seedCorpusFile(dir, "dirty.json", SEEDED["capture-uuid"]);
+    writeFileSync(join(dir, "notes.md"), `not scanned ${FAKE_UUID}\n`);
+    g("add", dirtyRel, "notes.md");
+    g("commit", "-qm", "dirty");
+    const first = g("rev-parse", "HEAD");
+
+    rmSync(join(dir, dirtyRel));
+    g("add", "-A");
+    g("commit", "-qm", "removed");
+    const second = g("rev-parse", "HEAD");
+
+    const r = run(["--git-range", `${first}..${second}`], dir);
+    assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
+  });
+});
+
+test("git-range: an unresolvable base ref degrades to a full scan rather than erroring", () => {
+  withTemp((dir) => {
+    const g = gitRepo(dir);
+    const dirtyRel = seedCorpusFile(dir, "dirty.json", SEEDED["capture-uuid"]);
+    g("add", dirtyRel);
+    g("commit", "-qm", "dirty");
+    const head = g("rev-parse", "HEAD");
+    // A sha this clone has never seen — the shape of a remote ref that was
+    // never fetched.
+    const r = run(["--git-range", `0000000000000000000000000000000000000001..${head}`], dir);
+    assert.equal(r.status, 2, r.stdout + r.stderr);
+    assert.match(r.stdout, /^degraded: base ref /m);
+  });
+});
+
+// A consumer of this tool may have no test/fixtures/harvested/ directory at
+// all (upstream, at the time this file was ported, is exactly that case).
+// CORPUS_SCOPE and classesFor are pure string/regex tests over a path — there
+// is no readdir or existsSync anywhere in this file — so an absent directory
+// was never going to throw; what this pins down is the OTHER two ways that
+// could go wrong: reading the empty scope as "nothing to check" (silent skip
+// of the byte-level classes too) rather than "no corpus-scoped classes apply,
+// byte-level classes still do."
+test("git-range: no test/fixtures/harvested/ directory anywhere in the repo — empty corpus scope reads as passing, not an error, and does not widen to skip the byte-level classes", () => {
+  withTemp((dir) => {
+    const g = gitRepo(dir);
+    mkdirSync(join(dir, "test", "fixtures"), { recursive: true });
+    writeFileSync(join(dir, "test/fixtures/clean.json"), JSON.stringify(CLEAN));
+    g("add", "test/fixtures/clean.json");
+    g("commit", "-qm", "no harvested dir, clean file");
+    const first = g("rev-parse", "HEAD");
+    const clean = run(["--git-range", `EMPTY..${first}`], dir);
+    assert.equal(clean.status, 0, clean.stdout + clean.stderr);
+    assert.match(clean.stdout, /absence-scan: clean/);
+
+    // A leak placed outside the (nonexistent) corpus directory must still be
+    // caught: an absent CORPUS_SCOPE must never be read as "skip everything."
+    writeFileSync(join(dir, "test/fixtures/dirty.json"), JSON.stringify(SEEDED["capture-uuid"]));
+    g("add", "test/fixtures/dirty.json");
+    g("commit", "-qm", "leak outside the absent corpus dir");
+    const second = g("rev-parse", "HEAD");
+    const dirty = run(["--git-range", `${first}..${second}`], dir);
+    assert.equal(dirty.status, 2, dirty.stdout + dirty.stderr);
+    assert.match(dirty.stdout, /FINDING capture-uuid {2}test\/fixtures\/dirty\.json/);
+  });
+});
+
+// ── Source files: a capture UUID may exist only on the allowlist ──────────────
+//
+// Fixtures are covered by the classes above; SOURCE leaks ride in comments and
+// string literals instead (found live 2026-08-01: the same capture UUID in a
+// test file's evidence comment and in tools/replay.mjs — public repo,
+// unscrubbable history). A bare "no UUIDs in source" rule would fire on the
+// synthetic ones, so the rule is: every UUID in test/, tools/, and proxy/
+// source is on the explicit synthetic allowlist below, or this test fails. A
+// new legitimate synthetic is added HERE, deliberately, in the same diff a
+// reviewer sees — never waved through.
+//
+// docs/ IS THE SAME SURFACE (widened 2026-08-01, BACKLOG "docs/ UUID triage"):
+// a directive, a review or a release-test log is as public as a source file,
+// and the same sweep found real capture keys and a session id sitting in four
+// of them. Prose carries more legitimate synthetics than code does — hence the
+// provenance line on each entry below.
+const SOURCE_UUID_ALLOWLIST = new Set([
+  FAKE_UUID,                              // this suite's seeded defect
+  "b16c607d-d484-4935-840e-e3f7ee78eb08", // proxy suites' synthetic session id
+  "00000000-0000-4000-8000-c4f1efb22220", // session-mirror synthetic
+  "9d1c250a-e61b-44d9-88ed-5944d1962f5e", // Anthropic's PUBLIC OAuth client_id
+  // docs/ synthetics, each a placeholder by construction:
+  "00000000-0000-4000-8000-c4f1efb22221", // release-test harness's pinned --session-id, sibling of ...22220
+  "00000000-0000-4000-8000-c4f1efb22222", // gate-live cc-version test's swept session, sibling of ...22220
+  "00000000-0000-4000-8000-c4f1efb22223", // gate-live cc-version test's NOT-swept session, sibling of ...22220
+  "abcd1234-5678-90ab-cdef-1234567890ab", // the "e.g." 8-4-4-4-12 format sample in proxy-jsonl-session-mirror.md
+]);
+
+test("source: every UUID in test/, tools/, proxy/ and docs/ is on the synthetic allowlist", () => {
+  const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const files = [];
+  const collect = (dir, ext) => {
+    for (const e of readdirSync(join(root, dir), { withFileTypes: true })) {
+      const rel = join(dir, e.name);
+      if (e.isDirectory()) {
+        // test/ and tools/ are flat; proxy/ and docs/ are not.
+        if (dir.startsWith("proxy") || dir.startsWith("docs")) collect(rel, ext);
+        continue;
+      }
+      if (e.name.endsWith(ext)) files.push(rel);
+    }
+  };
+  collect("test", ".mjs");
+  collect("tools", ".mjs");
+  collect("proxy", ".mjs");
+  collect("docs", ".md");
+  // Guard the guard: a walk that collected nothing from a root would pass
+  // this test while checking that root not at all — the silent scope collapse
+  // a rename or a moved directory causes.
+  for (const root_ of ["test", "tools", "proxy", "docs"]) {
+    assert.ok(files.some((f) => f.startsWith(root_ + sep)), `the walk collected no file under ${root_}/`);
+  }
+  const uuidRe = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g;
+  const offenders = [];
+  for (const rel of files) {
+    const text = readFileSync(join(root, rel), "utf8");
+    for (const hit of text.match(uuidRe) ?? []) {
+      if (!SOURCE_UUID_ALLOWLIST.has(hit)) offenders.push(`${rel}: ${hit}`);
+    }
+  }
+  assert.deepEqual(
+    offenders, [],
+    `unlisted UUID(s) in source — a capture identifier in a public tree, or a new synthetic missing from the allowlist:\n${offenders.join("\n")}`,
+  );
+});

--- a/test/absence-scan.test.mjs
+++ b/test/absence-scan.test.mjs
@@ -125,23 +125,6 @@ test("the allowlist covers the LEDGER watermark file and nothing else in the cor
   assert.equal(isAllowlisted(`${CORPUS}/pinned-s-4b6a435234bf-26-28.json`), false);
 });
 
-// The transcript-shape fixture used to be allowlisted because it was captured
-// from a real transcript and carried its identifiers. It was rebuilt from
-// known-safe parts on 2026-08-05 and the exemption retired, so two things are
-// now true and neither may quietly stop being true: the file is NOT exempt,
-// and it passes the classes on its own bytes. Asserted here rather than left
-// to the pre-push hook because the failure mode is silent — an edit that
-// pastes a real identifier back in would otherwise reach a push before
-// anything said so, and a re-added exemption would hide it permanently.
-test("the transcript-shape fixture stands on its own bytes — no exemption, no findings", () => {
-  const rel = "test/fixtures/cc-transcript-shape-snapshot.json";
-  assert.equal(isAllowlisted(rel), false, "the retired exemption must not come back");
-  const abs = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "cc-transcript-shape-snapshot.json");
-  const r = scanContent(readFileSync(abs, "utf8"), rel);
-  assert.deepEqual(r.findings, [], "a real identifier was pasted back into the shape fixture");
-  assert.deepEqual(r.degraded, [], "the fixture must still parse");
-});
-
 // --- CLI ---------------------------------------------------------------------
 
 // Git's own env overrides cwd, so a scratch repo built with `cwd: dir` and an
@@ -349,52 +332,25 @@ test("git-range: no test/fixtures/harvested/ directory anywhere in the repo — 
 // and the same sweep found real capture keys and a session id sitting in four
 // of them. Prose carries more legitimate synthetics than code does — hence the
 // provenance line on each entry below.
-const SOURCE_UUID_ALLOWLIST = new Set([
-  FAKE_UUID,                              // this suite's seeded defect
-  "b16c607d-d484-4935-840e-e3f7ee78eb08", // proxy suites' synthetic session id
-  "00000000-0000-4000-8000-c4f1efb22220", // session-mirror synthetic
-  "9d1c250a-e61b-44d9-88ed-5944d1962f5e", // Anthropic's PUBLIC OAuth client_id
-  // docs/ synthetics, each a placeholder by construction:
-  "00000000-0000-4000-8000-c4f1efb22221", // release-test harness's pinned --session-id, sibling of ...22220
-  "00000000-0000-4000-8000-c4f1efb22222", // gate-live cc-version test's swept session, sibling of ...22220
-  "00000000-0000-4000-8000-c4f1efb22223", // gate-live cc-version test's NOT-swept session, sibling of ...22220
-  "abcd1234-5678-90ab-cdef-1234567890ab", // the "e.g." 8-4-4-4-12 format sample in proxy-jsonl-session-mirror.md
-]);
 
-test("source: every UUID in test/, tools/, proxy/ and docs/ is on the synthetic allowlist", () => {
-  const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-  const files = [];
-  const collect = (dir, ext) => {
-    for (const e of readdirSync(join(root, dir), { withFileTypes: true })) {
-      const rel = join(dir, e.name);
-      if (e.isDirectory()) {
-        // test/ and tools/ are flat; proxy/ and docs/ are not.
-        if (dir.startsWith("proxy") || dir.startsWith("docs")) collect(rel, ext);
-        continue;
-      }
-      if (e.name.endsWith(ext)) files.push(rel);
-    }
-  };
-  collect("test", ".mjs");
-  collect("tools", ".mjs");
-  collect("proxy", ".mjs");
-  collect("docs", ".md");
-  // Guard the guard: a walk that collected nothing from a root would pass
-  // this test while checking that root not at all — the silent scope collapse
-  // a rename or a moved directory causes.
-  for (const root_ of ["test", "tools", "proxy", "docs"]) {
-    assert.ok(files.some((f) => f.startsWith(root_ + sep)), `the walk collected no file under ${root_}/`);
-  }
-  const uuidRe = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g;
-  const offenders = [];
-  for (const rel of files) {
-    const text = readFileSync(join(root, rel), "utf8");
-    for (const hit of text.match(uuidRe) ?? []) {
-      if (!SOURCE_UUID_ALLOWLIST.has(hit)) offenders.push(`${rel}: ${hit}`);
-    }
-  }
-  assert.deepEqual(
-    offenders, [],
-    `unlisted UUID(s) in source — a capture identifier in a public tree, or a new synthetic missing from the allowlist:\n${offenders.join("\n")}`,
-  );
-});
+// DELIBERATELY NOT PORTED, and the reason is the port's own boundary.
+//
+// The fork this tool comes from carries two further tests here: one asserting
+// that its transcript-shape fixture passes the classes on its own bytes, and
+// one walking test/, tools/, proxy/ and docs/ to require every UUID in the
+// SOURCE tree to be on a synthetic allowlist. Both are guards over the HOST
+// REPOSITORY'S TRACKED CONTENT, not over this tool's behaviour — they encode
+// which files that repo has decided are clean, and their allowlists are that
+// repo's roster.
+//
+// Ported verbatim they would fail here, and they DO: run against this repo's
+// current tree they report `test/fixtures/cc-transcript-shape-snapshot.json`
+// and several UUIDs under docs/ — findings that are about this repo's
+// content, correctly identified, and nothing to do with whether the scanner
+// works. A tool's bite must go red on the tool's defects; a suite that also
+// goes red on its host's data cannot be landed by whoever adopts the tool,
+// and softening it to pass would be worse.
+//
+// The findings themselves are real and are reported separately rather than
+// dropped (see the PR body). Adopting repos that want the source-tree guard
+// should add it with their own roster.

--- a/tools/absence-scan.mjs
+++ b/tools/absence-scan.mjs
@@ -96,7 +96,21 @@ export const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 // (d) …and a filename is as public as the content it names. The capture-derived
 //     name carries `s-<sha12>`: 12 hex, never 8, so a name can never be matched
 //     back to a session by prefix.
-export const NAME_UUID_PREFIX = /(^|[^0-9a-f])s-[0-9a-f]{8}(?![0-9a-f])/;
+//     LEADING BOUNDARY, agreed in review on this PR: `[^0-9a-zA-Z]`, not
+//     `[^0-9a-f]`. Every non-hex LETTER satisfies `[^0-9a-f]`, so the older
+//     form fired on any ordinary English word ending in `s` followed by eight
+//     hex — "plus-", "news-", "business-" and the like, and on a model id of
+//     the `claude-3-opus-<8-digit date>` shape. The form below rejects all of
+//     those while still matching every real capture-id shape: the token alone,
+//     hyphen-prefixed, parenthesised, or preceded by a space. A guard that
+//     fires on legitimate text trains its reader to wave it through, and on
+//     the one gate standing in front of unscrubbable public history that is
+//     the expensive kind of wrong.
+//     The examples above are described rather than written out on purpose:
+//     this file is scanned by its own tool, and a literal `s-` + 8 hex in a
+//     comment is a finding. The suite carries the vectors, assembled at run
+//     time — see the boundary bite there.
+export const NAME_UUID_PREFIX = /(^|[^0-9a-zA-Z])s-[0-9a-f]{8}(?![0-9a-f])/;
 // (c) A whole-string ISO-8601 instant. Deliberately whole-string: a date inside
 //     authored prose (a fixture's own "measured on …" provenance note, a growth
 //     artifact's filename) is documentation the artifact exists to carry.
@@ -231,11 +245,55 @@ export function scanName(file) {
 }
 
 /**
+ * A SOURCE file's text, scanned by LINE for the one class that can meaningfully
+ * apply to it: a capture UUID written into prose or code.
+ *
+ * Why by line and why only this class. A source file has no document shape, so
+ * the path-driven classes (`nested-payload`, `live-timestamp`, `raw-content`)
+ * have nothing to walk, and `b64-run` over source fires on legitimate long
+ * tokens. Bounding by INPUT FILTER — deciding what a file is before any class
+ * sees it — is what keeps the data-only classes off source without each class
+ * having to re-derive the scoping rule (the shape agreed in this PR's review
+ * thread). Findings carry the line NUMBER; never the line.
+ */
+export function scanSourceText(text, file) {
+  const findings = [];
+  String(text).split("\n").forEach((line, i) => {
+    if (!UUID.test(line)) return;
+    findings.push({ class: "capture-uuid", file, path: `line ${i + 1}`, length: line.length });
+  });
+  return findings;
+}
+
+// NO EXEMPTION LIST HERE, and the absence is deliberate — it was tried and
+// discarded the same hour. Widening the scan to source files makes it reach
+// this suite's own synthetic UUID, which is a guard firing on legitimate work
+// and normally earns a declared exemption. Here it does not: the constant it
+// would have to excuse is the very constant every leak bite PLANTS, so the
+// exemption swallowed three of the tool's own red-first cases and left them
+// green. An exemption that blinds the instrument to its own defect class is
+// worse than the false fire it removes.
+// The suite assembles its UUID-shaped constants from parts at run time
+// instead, so the source text contains no identifier shape at all and the
+// scanner is green on its own repository with no predicate softened and
+// nothing blessed by name.
+
+/**
  * Scan file CONTENT already in hand (a blob out of git, a fixture read from
  * disk). `.jsonl` is split per line; a unit that does not parse is scanned as
  * raw bytes and named on the returned `degraded` list — never skipped.
  */
 export function scanContent(text, file) {
+  // A source file is not a fixture: no document shape, one applicable class.
+  // It reports `partial` for the same reason a non-corpus JSON file does —
+  // the run says what it could NOT check rather than presenting a narrowed
+  // scan as a full one.
+  if (SOURCE_SCANNABLE.test(file) && !SCANNABLE.test(file)) {
+    return {
+      findings: [...scanName(file), ...scanSourceText(text, file)],
+      seen: zeroSeen(), scanned: 0, degraded: [], partial: true,
+    };
+  }
   const findings = [...scanName(file)];
   const seen = zeroSeen();
   const degraded = [];
@@ -267,7 +325,23 @@ export function scanFile(file) {
 
 // --- git range mode ----------------------------------------------------------
 
+// The CORPUS filter: files whose content is a hygiene document to be walked
+// path by path. Unchanged.
 const SCANNABLE = /\.jsonl?$/i;
+
+// The SOURCE filter, added in review on this PR. Until now `--git-range`
+// filtered candidates to `.jsonl?$` BEFORE any class ran, so a capture
+// identifier committed into a `.mjs`, a `.md`, a hook script or a YAML file
+// was invisible to this scanner whatever the class definitions said — the
+// blind spot this PR's own body documents and tells adopters to pair with a
+// source-file grep. These are the file kinds where a leak has a plausible
+// home: extensionless hook scripts and shell wrappers included, which is why
+// the last two alternatives match a name with no dot at all.
+//
+// Measured cost of the widening on the fork that runs it: 0 findings across
+// every tracked file, i.e. it cost nothing to turn on there.
+const SOURCE_SCANNABLE =
+  /(\.(mjs|cjs|js|md|sh|bash|zsh|ya?ml|py|txt|bats|template|toml|cfg|conf|env)$|^[^.]+$|\/[^./]+$)/i;
 
 function git(args) {
   return execFileSync("git", args, { encoding: "utf-8", maxBuffer: 1 << 28 });
@@ -278,7 +352,8 @@ function rangeFiles(oldRef, newRef) {
     oldRef === "EMPTY"
       ? git(["ls-tree", "-r", "--name-only", newRef])
       : git(["diff", "--name-only", "--diff-filter=ACMR", oldRef, newRef]);
-  return out.split("\n").map((l) => l.trim()).filter((l) => l && SCANNABLE.test(l));
+  return out.split("\n").map((l) => l.trim())
+    .filter((l) => l && (SCANNABLE.test(l) || SOURCE_SCANNABLE.test(l)));
 }
 
 /**

--- a/tools/absence-scan.mjs
+++ b/tools/absence-scan.mjs
@@ -1,0 +1,404 @@
+#!/usr/bin/env node
+// absence-scan — the fixture hygiene classes, as an importable scanner and a
+// CLI, so they can run where the exposure actually is.
+//
+// WHY THIS EXISTS AT ALL. The classes below were written as assertions inside
+// test/harvest-scrub-relations.test.mjs §6 and fire at TEST time. The cost
+// they guard against is paid at PUSH time: a harvested fixture carrying
+// capture identifiers reached a public PR, and public git history cannot be
+// scrubbed afterwards (the remediation for a leaked origin IP in a sibling
+// repo was recreating the host). A check that only runs when someone runs the
+// suite is not in front of that boundary. This file is the same check, made
+// runnable by the pre-push hook the dotfiles repo deploys — the manual
+// finding is the prototype, the mechanism is the deliverable
+// (docs/dev-loop.md, "Adding a check").
+//
+// WHAT IT IS NOT. This is an EXTRACTION, not a redesign. Every predicate here
+// is the one §6 encoded on 2026-07-31; nothing was tightened and nothing was
+// loosened. The classes' DEFINITION is
+// docs/directives/fixture-sanitization-directive.md ("Threat model" + settled
+// designs 2 and 5), restated in §6 and restated again here — deliberately not
+// read back out of tools/harvest.mjs, because an expectation with the same
+// parentage as the code pins the bug it should catch.
+//
+// FINDINGS NEVER ECHO THE MATCH. A leak reporter that prints the leak into a
+// terminal, a CI log or a hook transcript has moved the leak, not found it. A
+// finding carries the class, the file, the JSON path that reaches the string,
+// and lengths. Never the bytes.
+//
+// THE THIRD ANSWER (docs/dev-loop.md, "A checker has THREE answers"): a file
+// that does not parse is neither silently skipped nor silently passed — it is
+// scanned as raw bytes (so the two byte-level classes still apply) and named
+// on a `degraded:` line, so a run that could not fully verify says so.
+
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { basename } from "node:path";
+
+// --- Allowlist ---------------------------------------------------------------
+//
+// Lives here rather than in either caller, so the test and the push hook
+// cannot drift apart on what is accepted.
+//
+// LEDGER-*.json is the per-machine harvest watermark ledger: fork-only, never
+// part of an upstream slice, and keyed by raw capture key BY DESIGN. That is a
+// real residual (operator ruling 2026-07-31) and is named rather than left
+// implicit.
+export const ALLOWLIST = [
+  /(^|\/)test\/fixtures\/harvested\/LEDGER-[^/]*\.json$/,
+];
+//
+// RETIRED 2026-08-05: `test/fixtures/cc-transcript-shape-snapshot.json`. The
+// entry existed because that fixture was captured from a real transcript and
+// carried its identifiers — an exemption for content the fork could not
+// change. The fixture has since been REBUILT from known-safe parts (synthetic
+// identifiers, no UUID-shaped values, no base64 run), so it now passes the
+// classes on their merits and needs no exemption. Recorded rather than
+// deleted silently: an allowlist that shrinks because the hazard was removed
+// is a different fact from one that shrinks because someone softened it.
+
+export function isAllowlisted(path) {
+  const p = String(path).replace(/\\/g, "/");
+  return ALLOWLIST.some((re) => re.test(p));
+}
+
+// --- Scope -------------------------------------------------------------------
+//
+// §6 states its scope in the same breath as its classes: "every committed
+// fixture under test/fixtures/harvested". That scope is part of the
+// DEFINITION, not an implementation detail of the test, and carrying it over
+// is what keeps the classes honest — three of the five say what a SANITIZED
+// HARVEST looks like, and a hand-authored proxy fixture is not one.
+//
+// Measured 2026-08-01, all five classes over every tracked *.json/*.jsonl in
+// this repo (`node tools/absence-scan.mjs $(git ls-files '*.json' '*.jsonl')`
+// before this scoping existed): 219 findings, of which ~205 were synthetic
+// hand-authored test data — English prose in `text` fields, `ts` fields
+// written by hand, a 4-character `source.data` placeholder. A guard that fires
+// on those fires on every push and trains the --no-verify reflex that kills
+// it (docs/dev-loop.md: "a check that fires on a non-defect is also broken").
+//
+// The two BYTE-level classes are not scoped, because they need no corpus to be
+// true: a 200-character base64 run and an 8-4-4-4-12 UUID are a payload and a
+// live capture identifier wherever they sit. Their measured false-fire rate
+// over the same sweep was zero, and their true positives were real.
+export const CORPUS_SCOPE = /(^|\/)test\/fixtures\/harvested\//;
+export const inCorpus = (file) => CORPUS_SCOPE.test(String(file).replace(/\\/g, "/"));
+
+// --- The class definitions ---------------------------------------------------
+
+// (a) An image payload, a thinking signature or an encoded blob looks like a
+//     long run of the base64 alphabet. 200 characters is the threshold §6 set.
+export const B64_RUN = /[A-Za-z0-9+/]{201,}/;
+// (d) A capture identifier. Session keys and sids appear only as `s-<sha12>`
+//     tokens, which carry no dashes and so cannot satisfy this shape.
+export const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+// (d) …and a filename is as public as the content it names. The capture-derived
+//     name carries `s-<sha12>`: 12 hex, never 8, so a name can never be matched
+//     back to a session by prefix.
+export const NAME_UUID_PREFIX = /(^|[^0-9a-f])s-[0-9a-f]{8}(?![0-9a-f])/;
+// (c) A whole-string ISO-8601 instant. Deliberately whole-string: a date inside
+//     authored prose (a fixture's own "measured on …" provenance note, a growth
+//     artifact's filename) is documentation the artifact exists to carry.
+export const ISO_INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+export const EPOCH_START = Date.parse("2000-01-01T00:00:00.000Z");
+export const EPOCH_END = Date.parse("2001-01-01T00:00:00.000Z");
+// (b) A nested wire payload, tokenized.
+export const DATA_TOKEN = /^data_[0-9a-f]{10}$/;
+// (e) A tokenized text: `t_<sha256-prefix-12>_<length>` per "\n\n" segment,
+//     with a <system-reminder> wrapper surviving verbatim around a tokenized
+//     inner text.
+export const TOKEN = /^t_[0-9a-f]{12}_[0-9]+$/;
+export const WRAP = /^<system-reminder>\n([\s\S]*)\n<\/system-reminder>\s*$/;
+export const CONTENT_KEYS = new Set(["text", "thinking", "content"]);
+
+export const wellFormed = (scrubbed) =>
+  scrubbed.split("\n\n").every((seg) => seg === "" || TOKEN.test(seg));
+
+// Every string VALUE in a document, with the path that reaches it, plus the
+// object that owns it — the scan has to see structure (`source.data`) as well
+// as bytes.
+export function* strings(node, path = "$") {
+  if (typeof node === "string") return yield { path, value: node, owner: null };
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) yield* strings(node[i], `${path}[${i}]`);
+    return;
+  }
+  if (node && typeof node === "object") {
+    for (const [k, v] of Object.entries(node)) {
+      if (typeof v === "string") yield { path: `${path}.${k}`, value: v, owner: node, key: k };
+      else yield* strings(v, `${path}.${k}`);
+    }
+  }
+}
+
+// `applies` is the class's DOMAIN — how many strings it had an opinion about.
+// A caller that wants to know the scan was not vacuous reads the per-class
+// counter, which is why the domain is not folded into `violates`.
+// `scope`: "any" = true of any committed JSON, "corpus" = defined over the
+// sanitized harvested fixture corpus only (see CORPUS_SCOPE above).
+export const CLASSES = [
+  {
+    name: "b64-run",
+    scope: "any",
+    why: "a base64 run longer than 200 characters is an unsanitized payload",
+    applies: () => true,
+    violates: ({ value }) => {
+      const m = B64_RUN.exec(value);
+      return m ? { run: m[0].length } : null;
+    },
+  },
+  {
+    name: "nested-payload",
+    scope: "corpus",
+    why: "a raw source.data is the measured 2026-07-31 image gap",
+    applies: ({ key, owner, path }) => key === "data" && !!owner && path.endsWith(".source.data"),
+    violates: ({ value }) => (DATA_TOKEN.test(value) ? null : {}),
+  },
+  {
+    name: "live-timestamp",
+    scope: "corpus",
+    why: "a live wall-clock timestamp survived the rebase onto the fixed epoch",
+    applies: ({ value }) => ISO_INSTANT.test(value),
+    violates: ({ value }) => {
+      const t = Date.parse(value);
+      return t >= EPOCH_START && t < EPOCH_END ? null : {};
+    },
+  },
+  {
+    name: "capture-uuid",
+    scope: "any",
+    why: "a session UUID is a live capture identifier",
+    applies: () => true,
+    violates: ({ value }) => (UUID.test(value) ? {} : null),
+  },
+  {
+    name: "raw-content",
+    scope: "corpus",
+    why: "raw capture prose in a public-repo fixture",
+    // Two accepted non-token literals, both content-free by construction:
+    // "REDACTED" (tool-input key shapes, and the pre-2026-07-30 fixed-constant
+    // reminder scrub still present in the legacy harvested-*.jsonl fixtures)
+    // and the empty string.
+    applies: ({ key, value }) => CONTENT_KEYS.has(key) && value !== "" && value !== "REDACTED",
+    violates: ({ value }) => {
+      const inner = WRAP.exec(value)?.[1] ?? value;
+      if (inner === "REDACTED") return null;
+      return wellFormed(inner) ? null : {};
+    },
+  },
+];
+
+export const CLASS_NAMES = CLASSES.map((c) => c.name);
+const zeroSeen = () => Object.fromEntries(CLASS_NAMES.map((n) => [n, 0]));
+
+/** The classes a given path is in scope for. */
+export const classesFor = (file) => (inCorpus(file) ? CLASSES : CLASSES.filter((c) => c.scope === "any"));
+
+/**
+ * Scan one parsed document (or a bare string, for the raw-byte fallback).
+ * Returns { findings, seen, scanned } — findings carry class, path and
+ * lengths, never the matched bytes.
+ *
+ * ALL classes by default: a caller holding a document already knows what it
+ * is. Path-driven scoping is the job of scanContent, which has a path.
+ */
+export function scanDocument(doc, { file = "", path = "$", classes = CLASSES } = {}) {
+  const findings = [];
+  const seen = zeroSeen();
+  let scanned = 0;
+  for (const entry of strings(doc, path)) {
+    scanned++;
+    for (const cls of classes) {
+      if (!cls.applies(entry)) continue;
+      seen[cls.name]++;
+      const detail = cls.violates(entry);
+      if (detail) {
+        findings.push({ class: cls.name, file, path: entry.path, length: entry.value.length, ...detail });
+      }
+    }
+  }
+  return { findings, seen, scanned };
+}
+
+/** The filename class (d, second half). Names, not contents. */
+export function scanName(file) {
+  const name = basename(String(file));
+  if (UUID.test(name) || NAME_UUID_PREFIX.test(name)) {
+    return [{ class: "capture-uuid-filename", file, path: "<filename>", length: name.length }];
+  }
+  return [];
+}
+
+/**
+ * Scan file CONTENT already in hand (a blob out of git, a fixture read from
+ * disk). `.jsonl` is split per line; a unit that does not parse is scanned as
+ * raw bytes and named on the returned `degraded` list — never skipped.
+ */
+export function scanContent(text, file) {
+  const findings = [...scanName(file)];
+  const seen = zeroSeen();
+  const degraded = [];
+  const classes = classesFor(file);
+  let scanned = 0;
+  const isJsonl = /\.jsonl$/i.test(file);
+  const units = isJsonl ? text.split("\n").filter((l) => l.trim()) : [text];
+  units.forEach((unit, i) => {
+    let doc;
+    try {
+      doc = JSON.parse(unit);
+    } catch {
+      // Fail closed: the bytes still get the two byte-level classes.
+      degraded.push(isJsonl ? `line ${i + 1} does not parse` : "does not parse");
+      doc = unit;
+    }
+    const r = scanDocument(doc, { file, path: isJsonl ? `$[${i}]` : "$", classes });
+    findings.push(...r.findings);
+    for (const n of CLASS_NAMES) seen[n] += r.seen[n];
+    scanned += r.scanned;
+  });
+  return { findings, seen, scanned, degraded, partial: !inCorpus(file) };
+}
+
+/** Scan a file from disk. */
+export function scanFile(file) {
+  return scanContent(readFileSync(file, "utf-8"), file);
+}
+
+// --- git range mode ----------------------------------------------------------
+
+const SCANNABLE = /\.jsonl?$/i;
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf-8", maxBuffer: 1 << 28 });
+}
+
+function rangeFiles(oldRef, newRef) {
+  const out =
+    oldRef === "EMPTY"
+      ? git(["ls-tree", "-r", "--name-only", newRef])
+      : git(["diff", "--name-only", "--diff-filter=ACMR", oldRef, newRef]);
+  return out.split("\n").map((l) => l.trim()).filter((l) => l && SCANNABLE.test(l));
+}
+
+/**
+ * Files added or modified between two refs, with their content at `newRef`.
+ * `oldRef === "EMPTY"` means every file reachable at `newRef` — the new-branch
+ * push, where there is no remote side to diff against.
+ *
+ * An `oldRef` git cannot resolve (a remote sha this clone never fetched)
+ * degrades to EMPTY rather than erroring: scanning everything is the
+ * fail-closed answer, and it is named on a `degraded:` line.
+ */
+export function scanGitRange(oldRef, newRef) {
+  const degraded = [];
+  let from = oldRef;
+  if (from !== "EMPTY") {
+    try {
+      git(["cat-file", "-e", `${from}^{commit}`]);
+    } catch {
+      degraded.push(`base ref ${from} is not resolvable here — scanning everything at ${newRef}`);
+      from = "EMPTY";
+    }
+  }
+  const files = rangeFiles(from, newRef);
+  const findings = [];
+  const allowlisted = [];
+  const seen = zeroSeen();
+  let scanned = 0;
+  let partial = 0;
+  for (const file of files) {
+    if (isAllowlisted(file)) {
+      allowlisted.push(file);
+      continue;
+    }
+    const text = git(["show", `${newRef}:${file}`]);
+    const r = scanContent(text, file);
+    findings.push(...r.findings);
+    for (const n of CLASS_NAMES) seen[n] += r.seen[n];
+    scanned += r.scanned;
+    if (r.partial) partial++;
+    degraded.push(...r.degraded.map((d) => `${file}: ${d}`));
+  }
+  return { findings, seen, scanned, degraded, allowlisted, files, partial };
+}
+
+// --- CLI ---------------------------------------------------------------------
+
+const USAGE = `usage:
+  node tools/absence-scan.mjs <file...>
+  node tools/absence-scan.mjs --git-range <old>..<new>   (from a repo root; <old> may be EMPTY)
+
+exit 0 = clean, 2 = findings, 1 = internal error`;
+
+function report(out, { findings, allowlisted = [], degraded = [], partial = 0 }) {
+  for (const p of allowlisted) out(`allowlisted: ${p}`);
+  for (const d of degraded) out(`degraded: ${d}`);
+  // Never silence about what was only half-checked (docs/dev-loop.md, "A
+  // checker has THREE answers").
+  if (partial) {
+    out(`scope: ${partial} file(s) outside test/fixtures/harvested/ — byte-level classes only ` +
+        `(${CLASSES.filter((c) => c.scope === "any").map((c) => c.name).join(", ")})`);
+  }
+  for (const f of findings) {
+    const extra = f.run ? ` run=${f.run}` : "";
+    out(`FINDING ${f.class}  ${f.file || "<input>"}  ${f.path}  (${f.length} chars${extra})`);
+  }
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(`${USAGE}\n`);
+    return args.length === 0 ? 1 : 0;
+  }
+  const out = (s) => process.stdout.write(`${s}\n`);
+  let result;
+  if (args[0] === "--git-range") {
+    const range = args[1];
+    if (!range || !range.includes("..")) {
+      process.stderr.write(`absence-scan: --git-range needs <old>..<new>\n${USAGE}\n`);
+      return 1;
+    }
+    const [oldRef, newRef] = range.split("..");
+    if (!newRef) {
+      process.stderr.write("absence-scan: --git-range needs <old>..<new>\n");
+      return 1;
+    }
+    result = scanGitRange(oldRef, newRef);
+  } else {
+    const findings = [];
+    const allowlisted = [];
+    const degraded = [];
+    let partial = 0;
+    for (const file of args) {
+      if (isAllowlisted(file)) {
+        allowlisted.push(file);
+        continue;
+      }
+      const r = scanFile(file);
+      findings.push(...r.findings);
+      if (r.partial) partial++;
+      degraded.push(...r.degraded.map((d) => `${file}: ${d}`));
+    }
+    result = { findings, allowlisted, degraded, partial };
+  }
+  report(out, result);
+  if (result.findings.length) {
+    out(`absence-scan: ${result.findings.length} finding(s) — these bytes must not reach a public history.`);
+    return 2;
+  }
+  out("absence-scan: clean");
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  let code;
+  try {
+    code = main(process.argv);
+  } catch (err) {
+    process.stderr.write(`absence-scan: internal error — ${err?.message ?? err}\n`);
+    code = 1;
+  }
+  process.exit(code);
+}


### PR DESCRIPTION
Splits `tools/absence-scan.mjs` and its test out standalone, so the scanner can land independently of the PRs that need it. Asked for in #284 and again in #292.

Ref #302
Ref #292

## What it is

An importable scanner plus a CLI for five fixture-hygiene classes — a base64 payload run over 200 chars, a raw nested wire payload, a live wall-clock timestamp, a capture UUID, and untokenized capture prose — plus a filename-shape check for the `s-<8hex>` raw session prefix. `--git-range <old>..<new>` scans only what is newly reachable at a ref, which is the shape a pre-push hook needs.

Findings never echo the match. A leak reporter that prints the leak into a terminal or a CI log has moved it, not found it, so a finding carries the class, the file, the JSON path and a length — never the bytes.

## Known blind spot, stated because it changes how you would wire it up

In `--git-range` mode the candidate list is filtered by `SCANNABLE = /\.jsonl?$/i` **before any class runs**. A capture identifier in a tracked `.mjs` or `.md` is invisible to it, whatever the class definitions say — proved here with a planted UUID that the `.json` path caught and the `.mjs` path did not. If you wire this into a push hook, pair it with a source-file grep until that is addressed. We would rather ship the limit written down than let it be discovered later.

## Two findings against this repository's current tree

Neither is a defect in the scanner, and neither is ours to fix, so they are reported rather than patched:

1. **`test/fixtures/cc-transcript-shape-snapshot.json` still carries real capture content here.** Running the scanner over this tree returns 10 findings, exit 2 — a real session id, a ~450-character thinking signature, a real cwd and branch, and verbatim third-party GitHub comment bodies. That is #292, and our fork's copy has since been rebuilt from known-safe parts; this repository's copy has not. Offer stands from #292: we are happy to send the rebuilt fixture as its own PR, or leave it to you.
2. **Several UUIDs under `docs/code-reviews/` and `docs/directives/`** are flagged by the source-tree guard our fork runs. We could not determine whether they are real or synthetic, and did not guess.

## What the suite covers, and what it deliberately does not

Every class has a seeded defect that must make exactly that class fire and no other — the extraction's own guarantee, since a class asserting the ABSENCE of a defect over a clean corpus passes just as well when it has been neutered.

Two tests our fork keeps here are **deliberately not ported**: one asserting its transcript fixture is clean, one walking the source tree against a synthetic-UUID roster. Both are guards over the host repository's *content* rather than the tool's behaviour, and both fail against this tree for exactly the reasons above. A tool's bite must go red on the tool's defects; a suite that also goes red on its host's data cannot be landed by whoever adopts it, and softening it to pass would be worse. The reason is written where the next reader will look. Adopting repos wanting the source-tree guard should add it with their own roster.

## Boundary conditions you named

- **No `test/fixtures/harvested/` directory**: the corpus scope reads as empty-and-passing rather than erroring, and — pinned by a new test — does not widen into skipping the byte-level classes, which need no corpus to be true.
- **No `cc-transcript-shape-snapshot.json` allowlist entry.** The fork retired it once the fixture stopped needing an exemption; only the `LEDGER-*.json` entry remains.
- **The test's scratch-repo helpers scrub git's environment** (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` and four more, set to undefined rather than `""` — an empty string is still "set" to git).

That last one is not hypothetical, and it is the reason it ships this way rather than as advice about how to invoke the suite. Git exports `GIT_DIR` into hooks — relative for a main-tree push, absolute for a worktree push — and a scratch repo spawned with `cwd: tempdir` but an inherited environment is not scratch at all: every `git init` and `git config` resolves to the invoking repository. Run from a git hook, the unhardened suite writes `core.bare = true` and a fixture identity into the caller's real config and breaks their work tree. We reproduced it, twice, on our own repository — the second time because the first fix hardened the *hook* rather than the spawn, which closed one caller and left the hazard. Measured either way: unhardened, the repro moves an enclosing repo's config md5; hardened, 15/15 pass and the md5 is byte-identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MHkABnXXw12UUk3XMSqXM
