### PR TITLE
fix(proxy): a lost stdout/stderr reader must not wedge the proxy

### DIFF
--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -544,20 +544,52 @@ let _selfHealHandlers = null;
 function installSelfHeal() {
   _selfHealRefs++;
   if (_selfHealHandlers) return;
+  // AN EPIPE ON STDIO MUST NOT REACH uncaughtException, because the handlers
+  // below answer uncaughtException BY WRITING TO STDERR — so a dead stderr
+  // makes them re-enter themselves for ever.
+  //
+  // A try/catch around the write cannot cover it: a write to a pipe whose last
+  // reader is gone does not throw synchronously, it surfaces as an
+  // asynchronous 'error' event, and with no listener Node promotes that to
+  // uncaughtException. Both halves are needed, hence both guards here.
+  //
+  // Measured on a live proxy whose `| tee` was killed out from under it: 100%
+  // CPU, 22 minutes of CPU time burned, 18 connections accepted and none
+  // answered — while /health still returned 200 with every self-reported field
+  // green. `sample` showed the cycle: TriggerUncaughtException ->
+  // ReportMessage -> ErrorStackGetter -> FormatStackTrace ->
+  // PrepareStackTraceCallback -> the next stderr write -> EPIPE.
+  //
+  // Losing a log reader is ordinary — a closed terminal, a rotated file, a
+  // killed `tee`. It must cost the log line and nothing else.
+  const safeWrite = (text) => {
+    try { process.stderr.write(text); } catch { /* no reader left; keep serving */ }
+  };
+  const onStreamError = (err) => {
+    if (err && (err.code === "EPIPE" || err.code === "ERR_STREAM_DESTROYED")) return;
+    safeWrite(`[cache-fix] stdio error (proxy stays up): ${(err && err.code) || err}\n`);
+  };
+  process.stdout.on("error", onStreamError);
+  process.stderr.on("error", onStreamError);
   const onException = (err) => {
-    process.stderr.write(`[cache-fix] self-heal: uncaughtException swallowed (proxy stays up): ${err && err.stack || err}\n`);
+    safeWrite(`[cache-fix] self-heal: uncaughtException swallowed (proxy stays up): ${err && err.stack || err}\n`);
   };
   const onRejection = (reason) => {
-    process.stderr.write(`[cache-fix] self-heal: unhandledRejection swallowed (proxy stays up): ${reason && reason.stack || reason}\n`);
+    safeWrite(`[cache-fix] self-heal: unhandledRejection swallowed (proxy stays up): ${reason && reason.stack || reason}\n`);
   };
   process.on("uncaughtException", onException);
   process.on("unhandledRejection", onRejection);
-  _selfHealHandlers = { onException, onRejection };
+  _selfHealHandlers = { onException, onRejection, onStreamError };
 }
 function removeSelfHeal() {
   if (!_selfHealHandlers || --_selfHealRefs > 0) return;
   process.off("uncaughtException", _selfHealHandlers.onException);
   process.off("unhandledRejection", _selfHealHandlers.onRejection);
+  // The stdio listeners go too, for the same reason the two above do: a host
+  // process that ran forward mode earlier must get Node's default behaviour
+  // back, not keep an EPIPE swallower installed by a proxy that has closed.
+  process.stdout.off("error", _selfHealHandlers.onStreamError);
+  process.stderr.off("error", _selfHealHandlers.onStreamError);
   _selfHealHandlers = null;
 }
 

--- a/test/fixtures/stdio-epipe-child.mjs
+++ b/test/fixtures/stdio-epipe-child.mjs
@@ -1,0 +1,23 @@
+// Child for proxy-stdio-epipe.test.mjs.
+//
+// Starts the proxy in forward mode — which is what installs the process-wide
+// self-heal handlers — then throws from a CHECK-PHASE callback on command. That
+// is the exact shape production hit: an uncaught exception raised at a moment
+// when stderr has no reader left.
+//
+// The throw is triggered from stdin rather than a timer so the parent can break
+// the stderr pipe FIRST. A race here would make the test pass for the wrong
+// reason: a throw that lands while stderr is still readable never reaches the
+// defect.
+process.env.CACHE_FIX_FORWARD_PROXY = "on";
+
+const port = Number(process.argv[2]);
+const { startProxy } = await import("../../proxy/server.mjs");
+await startProxy({ port, bind: "127.0.0.1", watch: false });
+
+process.stdout.write(`listening ${port}\n`);
+
+process.stdin.on("data", () => {
+  setImmediate(() => { throw new Error("stdio-epipe probe"); });
+});
+process.stdin.resume();

--- a/test/proxy-stdio-epipe.test.mjs
+++ b/test/proxy-stdio-epipe.test.mjs
@@ -1,0 +1,114 @@
+// A LOST LOG READER MUST NOT WEDGE THE PROXY.
+//
+// Measured outage 2026-08-13 on a live 9901: a leftover `... | tee file` wrapper
+// was killed, which removed the ONLY READER of the pipe the proxy holds as
+// stdout/stderr. The next stderr write raised EPIPE, and because that arrives as
+// an asynchronous 'error' event on the stream — not a synchronous throw — it
+// became an uncaughtException. The self-heal handler then formatted err.stack
+// and wrote it to the SAME broken stderr, which raised EPIPE again. `sample`
+// caught the loop verbatim:
+//
+//   TriggerUncaughtException -> MessageHandler::ReportMessage
+//     -> ErrorStackGetter -> GetFormattedStack -> FormatStackTrace
+//       -> node::PrepareStackTraceCallback -> v8::Function::Call -> ...
+//
+// 100% CPU for 22 minutes of CPU time, 18 connections accepted and none
+// answered, while /health still returned 200. The mechanism that exists to keep
+// the proxy up is what took it down.
+//
+// The existing say() helper does not cover this: try/catch around .write()
+// catches a synchronous throw, and an EPIPE on a pipe is not one.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import net from "node:net";
+import { execFileSync, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const childPath = join(here, "fixtures", "stdio-epipe-child.mjs");
+
+async function freePort() {
+  const s = net.createServer();
+  await new Promise((r) => s.listen(0, "127.0.0.1", r));
+  const p = s.address().port;
+  await new Promise((r) => s.close(r));
+  return p;
+}
+
+// Cumulative CPU seconds. A wedged proxy spins; a healthy one is ~0. Parsed for
+// both shapes `ps` uses: MM:SS.ss (macOS) and MM:SS / HH:MM:SS (Linux).
+function cpuSeconds(pid) {
+  let t;
+  try {
+    t = execFileSync("ps", ["-p", String(pid), "-o", "time="],
+                     { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  } catch { return null; }
+  if (!t) return null;
+  const parts = t.split(":").map(Number);
+  if (parts.some(Number.isNaN)) return null;
+  return parts.reduce((acc, n) => acc * 60 + n, 0);
+}
+
+const get = (port, path) => new Promise((resolve) => {
+  const req = http.get({ host: "127.0.0.1", port, path, timeout: 3000 },
+    (res) => { res.resume(); res.on("end", () => resolve(res.statusCode)); });
+  req.on("timeout", () => { req.destroy(); resolve("timeout"); });
+  req.on("error", (e) => resolve(e.code || "error"));
+});
+
+describe("stdio EPIPE", () => {
+  it("keeps serving after its stdout/stderr reader goes away", async () => {
+    const port = await freePort();
+    const env = { ...process.env };
+    // An ambient proxy would send this test's own request somewhere real.
+    for (const k of ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy",
+                     "ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy"]) delete env[k];
+
+    const child = spawn(process.execPath, [childPath, String(port)],
+                        { env, stdio: ["pipe", "pipe", "pipe"] });
+    try {
+      await new Promise((res, rej) => {
+        const to = setTimeout(() => rej(new Error("child never reported listening")), 20_000);
+        child.stdout.on("data", (d) => {
+          if (/listening/.test(String(d))) { clearTimeout(to); res(); }
+        });
+        child.on("error", rej);
+        child.on("exit", (c) => rej(new Error(`child exited early, code=${c}`)));
+      });
+
+      // PRECONDITION, asserted rather than assumed: it must be serving BEFORE
+      // the pipe breaks, or a later failure says nothing about this defect.
+      assert.notEqual(await get(port, "/health"), "timeout",
+                      "premise: the proxy must answer before the reader is removed");
+
+      // Remove the only reader of the child's stdout and stderr. This is the
+      // production event (a killed `tee`), not a simulation of it.
+      child.stdout.destroy();
+      child.stderr.destroy();
+
+      // Now raise an uncaught exception from a check-phase callback, which is
+      // where the real one came from.
+      child.stdin.write("throw\n");
+
+      // Give the loop a chance to establish itself. In the RED state the child
+      // is pegged at 100% CPU by now.
+      await new Promise((r) => setTimeout(r, 1500));
+      const cpuBefore = cpuSeconds(child.pid);
+
+      // THE ASSERTION THAT MATTERS: it still answers.
+      assert.equal(await get(port, "/health"), 200,
+                   "the proxy must still serve after losing its log reader");
+
+      await new Promise((r) => setTimeout(r, 1500));
+      const cpuAfter = cpuSeconds(child.pid);
+      if (cpuBefore !== null && cpuAfter !== null) {
+        assert.ok(cpuAfter - cpuBefore < 0.5,
+          `the proxy must not spin: burned ${(cpuAfter - cpuBefore).toFixed(2)}s of CPU in 1.5s wall`);
+      }
+    } finally {
+      child.kill("SIGKILL");
+    }
+  });
+});


### PR DESCRIPTION
## What broke

A live proxy stopped carrying traffic for 27 minutes. It was not down — it was **pegged at 100% CPU, accepting connections and answering none**, while `/health` kept returning `200` in 0.35s with every self-reported field green (`https_proxy=127.0.0.1:8118`, `https_proxy_measured=true`).

The trigger was ordinary: a leftover `... | tee <file>` wrapper was killed. That `tee` was the only reader of the pipe the proxy holds as stdout/stderr.

```
pipe holders after the tee died:  holder fd1, holder fd2, proxy fd2
                                  -> writers only, zero readers
```

## Why one dead log reader takes the proxy down

`sample` on the wedged process, verbatim shape:

```
TriggerUncaughtException
  -> MessageHandler::ReportMessage
    -> ErrorStackGetter -> GetFormattedStack -> FormatStackTrace
      -> node::PrepareStackTraceCallback -> v8::Function::Call -> ...
```

The cycle:

1. a write to the reader-less pipe raises `EPIPE`
2. `EPIPE` on a stream arrives as an **asynchronous `'error'` event**, not a synchronous throw, and with no listener Node promotes it to `uncaughtException`
3. `installSelfHeal`'s handler answers `uncaughtException` by formatting `err.stack` and **writing it to that same dead stderr**
4. → 1

The mechanism that exists to keep the proxy up is what takes it down. A `try/catch` around the write cannot help, because step 2 is not a throw.

Measured: 22 minutes of CPU time burned, 18 connections accepted, none answered.

## The fix

- `'error'` listeners on `process.stdout` / `process.stderr` that swallow `EPIPE` and `ERR_STREAM_DESTROYED`, so the async half never reaches `uncaughtException`.
- The self-heal handlers' own logging goes through a guarded write, so a log line can never become the next uncaught exception. Both halves are needed: the guard covers a synchronous throw on a destroyed stream, the listeners cover the asynchronous event.
- Both listeners are removed in `removeSelfHeal`, matching what that function already does for the other two — an embedded host process that ran forward mode earlier must get Node's default behaviour back, not keep an EPIPE swallower installed by a proxy that has closed.

Losing a log reader is ordinary — a closed terminal, a rotated file, a killed `tee`. It should cost the log line and nothing else.

## Tests

`test/proxy-stdio-epipe.test.mjs` reproduces the outage rather than simulating it: it removes the only reader of a child proxy's stdio, raises an uncaught exception from a check-phase callback (where the real one came from), then asserts the proxy still serves and does not spin.

- Full suite on this commit: **1783 tests, 1782 pass, 0 fail, 1 skipped**.
- Mutation-checked: deleting the two listeners fails the test with `burned 2.00s of CPU in 1.5s wall`; restoring them passes. Both directions run and recorded.
- Note the `/health` assertion inside the test **passes even in the broken state** — independently reproducing the field observation that `/health` is not a liveness signal for this failure.

## Non-Functional Requirements

- **Size/complexity budget** — ~20 lines of production code in one existing function, plus one test and one fixture. Landed at 38 added lines in `proxy/server.mjs`.
- **Threat model** — unchanged. No new inputs, no new network surface, no credential handling. The listeners only discard error objects for two error codes and log the rest.
- **Maintainability constraints** — no new abstraction, no new module, no config knob. `safeWrite` is a 1-line local closure with 3 call sites in the same function; inlining it three times would be worse.
- **Performance/reliability** — this is the reliability fix. Two listeners on process stdio, no per-request cost.
- **Load-bearing?** — **yes.** It changes process-wide uncaught-exception behaviour for the forward-proxy path.

## Note for reviewers

Branched from `upstream/main` and self-contained on it. An earlier draft routed the handlers through a `say()` helper — that helper does not exist on `main` (it lives on another of our branches), and the resulting `ReferenceError: say is not defined` inside the `uncaughtException` handler killed the proxy outright. Caught by the test before commit; the landed version depends on nothing outside this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
