### PR TITLE
test: take a free port instead of binding a hardcoded 9876

### DIFF
--- a/test/install-service.test.mjs
+++ b/test/install-service.test.mjs
@@ -1,3 +1,4 @@
+import { createServer } from "node:net";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, writeFile, rm, readdir, mkdir } from "node:fs/promises";
@@ -809,10 +810,26 @@ test("dispatch back-compat: --proxy-port + claude-arg passes through to wrapper 
     interceptScript,
     'process.stdout.write("INTERCEPT:" + JSON.stringify({argv: process.argv.slice(2), base: process.env.ANTHROPIC_BASE_URL}));\n',
   );
+  // This case asserts on the URL, but the wrapper really BINDS the port, so a
+  // hardcoded one fails whenever anything else on the machine already holds
+  // it — observed with a local QGIS MCP server owning 9876, which turned this
+  // into a red suite on an unrelated change. `--proxy-port 0` is not usable
+  // here because the assertion needs the number it passed in, so take a free
+  // port from the OS and use that. There is a small TOCTOU window between
+  // closing the probe socket and the wrapper binding; it is far narrower than
+  // a fixed port's collision surface.
+  const port = await new Promise((resolve, reject) => {
+    const s = createServer();
+    s.on("error", reject);
+    s.listen(0, "127.0.0.1", () => {
+      const { port: p } = s.address();
+      s.close(() => resolve(p));
+    });
+  });
   try {
     const { stdout } = await execFileP(
       process.execPath,
-      [BIN, "--proxy-port", "9876", "some-claude-arg", "--another"],
+      [BIN, "--proxy-port", String(port), "some-claude-arg", "--another"],
       {
         env: {
           ...process.env,
@@ -825,7 +842,7 @@ test("dispatch back-compat: --proxy-port + claude-arg passes through to wrapper 
     assert.ok(match, `expected wrapper-intercept JSON in stdout; got: ${JSON.stringify(stdout)}`);
     const parsed = JSON.parse(match[1]);
     assert.deepEqual(parsed.argv, ["some-claude-arg", "--another"], "wrapper-mode args must reach the claude command");
-    assert.equal(parsed.base, "http://127.0.0.1:9876", "ANTHROPIC_BASE_URL must reflect --proxy-port");
+    assert.equal(parsed.base, `http://127.0.0.1:${port}`, "ANTHROPIC_BASE_URL must reflect --proxy-port");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
`test/install-service.test.mjs`'s dispatch back-compat case binds a hardcoded `127.0.0.1:9876`. The assertion is about `ANTHROPIC_BASE_URL`, but the wrapper really *binds* the port it is handed, so the case fails for anyone whose machine already holds that one.

That is not hypothetical: a local QGIS MCP server owns 9876 here, and the suite went red on a change that had nothing to do with it — blocking a push until the port was freed by hand. A test that fails for reasons outside the diff is the kind that teaches people to discount a red suite.

## The fix

`--proxy-port 0` is not usable here, because the assertion needs the number it passed in. So the case asks the OS for a free port, closes the probe socket, and passes that number through. There is a small TOCTOU window between the close and the wrapper's own bind — far narrower than a fixed port's collision surface, and it fails rarely and randomly rather than permanently on every machine that happens to use 9876.

## Verification

A controlled pair, both arms from the same command with 9876 deliberately held by another process:

```
before (hardcoded 9876):  43 tests, 42 pass, 1 fail   <- EADDRINUSE in this case
after  (free port):       43 tests, 43 pass, 0 fail
```

One file, one case, no behaviour change to shipped code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMiYvNxKq6G9gfJMzArm4q
