### PR TITLE
absence-scan: run main() on Windows, where the entrypoint guard never matched

### DIFF
--- a/tools/absence-scan.mjs
+++ b/tools/absence-scan.mjs
@@ -34,6 +34,7 @@
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { basename } from "node:path";
+import { pathToFileURL } from "node:url";
 
 // --- Allowlist ---------------------------------------------------------------
 //
@@ -467,7 +468,12 @@ function main(argv) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Entrypoint guard. pathToFileURL, NOT `file://${argv[1]}`: on Windows
+// import.meta.url is file:///C:/... while argv[1] is C:\... with backslashes,
+// so the template form never matches and main() never runs — the CLI becomes a
+// silent exit-0 no-op, and the pre-push hook that depends on it passes
+// everything. Same helper proxy/pipeline.mjs already uses for its loader.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   let code;
   try {
     code = main(process.argv);


### PR DESCRIPTION
## What

`tools/absence-scan.mjs` never executes `main()` on Windows. The CLI exits 0
having done nothing, so the pre-push hook built on its contract passes
everything — including the bytes the scanner exists to refuse from a public
history.

```js
if (import.meta.url === `file://${process.argv[1]}`) {
```

This compares a URL against a string built from a native path. On POSIX the two
coincide. On Windows `import.meta.url` is `file:///C:/...` while
`process.argv[1]` is `C:\...` with backslashes, so the template produces
`file://C:\...` and the comparison is never true.

`pathToFileURL` is the same helper `proxy/pipeline.mjs` already uses to turn an
extension path into an import URL.

## Evidence

Measured on Windows at `8ddd4f0`, before and after the change:

| invocation | before | after |
|---|---|---|
| `node tools/absence-scan.mjs` | exit 0, no output | exit 1 + usage |
| `node tools/absence-scan.mjs <file with a UUID>` | exit 0, no output | exit 2 + `FINDING capture-uuid` |
| `node tools/absence-scan.mjs <clean file>` | exit 0, no output | exit 0 + `absence-scan: clean` |
| `node --test test/absence-scan.test.mjs` | **11 pass / 8 fail** | **19 pass / 0 fail** |

The eight failures are the existing `CLI:` and `git-range:` cases from #306.
They were already encoding the correct contract; nothing on Windows was running
it. No test was added or changed — the red-to-green is entirely your existing
suite.

Verified on a full clone (416 commits), not a shallow one: my first reading of
these failures was that `--depth 1` caused them, and that was wrong.

## Load-bearing?

**Yes** — it restores a guard whose failure mode is silent, and the thing it
guards is what reaches a public git history. Worth a human look even though the
diff is two lines.

Found while writing an unrelated extension against this repo; that work is
separate and not in this PR.

— Claude Opus 5, working with @deafsquad