### PR TITLE
currentdate-normalize: mask CC's daily date injection so midnight stops busting the prefix

### DIFF
--- a/proxy/extensions/currentdate-normalize.mjs
+++ b/proxy/extensions/currentdate-normalize.mjs
@@ -1,0 +1,130 @@
+// currentdate-normalize — mask CC's daily current-date injection so the
+// calendar rolling over mid-session does not invalidate the prefix.
+//
+// CC stamps the date into the claudeMd system-reminder block:
+//
+//     # currentDate
+//     Today's date is 2026-08-16.
+//
+// It sits deep inside the first user message's injected claudeMd block —
+// measured ~30k characters into `messages[0].content[3]` on one capture. When
+// the calendar day rolls over mid-session that value advances by one, and
+// everything from byte 0 through the first cache_control marker invalidates:
+// a full cold write, once per midnight, for every session still running.
+// Measured at ~386k tokens on the session that motivated it (2026-04-23
+// 00:34:50).
+//
+// It is a *scheduled* cache bust — the one class you can predict to the minute
+// — and it scales with how long sessions live rather than with what they do.
+//
+// The fix is to write a canonical placeholder in place of the value. The model
+// still sees the `# currentDate` header, so the signal is visibly abstracted
+// rather than missing, and CC still delivers the real rollover separately via
+// its own "The date has changed" system-reminder when it actually happens.
+//
+// The placeholder keeps the YYYY-MM-DD shape so anything downstream that
+// parses that format keeps parsing.
+//
+// Order 310: beside identity-normalization (300), which stabilizes the same
+// class of volatile per-turn field inside otherwise-stable reminder blocks, and
+// before the cache_control mutators.
+//
+// Gate: CACHE_FIX_NORMALIZE_CURRENTDATE=0 to disable. Default on — the
+// alternative is a scheduled full cold write per session per day.
+
+const PLACEHOLDER = "0000-00-00";
+
+// Deliberately NOT anchored on the `# currentDate` header above it: CC has
+// been observed emitting the line both with and without that header across
+// claudeMd shapes. The sentence is specific enough that matching it anywhere is
+// safe — content that coincidentally contains it benefits from the same
+// stabilization.
+//
+// The negative lookahead keeps the transform IDEMPOTENT: running twice
+// produces the same bytes and the same count as running once, which matters
+// because a proxy may see the same body more than once (retries, replays).
+const DATE_LINE = /(Today's date is )(?!0000-00-00\.)\d{4}-\d{2}-\d{2}(\.)/g;
+
+function envDisabled() {
+  return process.env.CACHE_FIX_NORMALIZE_CURRENTDATE === "0";
+}
+
+// Pure: returns { text, count }. count is the number of dates masked.
+export function maskCurrentDate(text) {
+  if (typeof text !== "string" || !text.includes("Today's date is ")) {
+    return { text, count: 0 };
+  }
+  let count = 0;
+  const out = text.replace(DATE_LINE, (_m, head, tail) => {
+    count += 1;
+    return `${head}${PLACEHOLDER}${tail}`;
+  });
+  return { text: out, count };
+}
+
+// Walk every text-bearing block of a message list and mask in place.
+// Returns the number of blocks changed.
+export function normalizeMessages(messages) {
+  if (!Array.isArray(messages)) return 0;
+  let applied = 0;
+  for (const m of messages) {
+    if (!m || typeof m !== "object") continue;
+    if (typeof m.content === "string") {
+      const r = maskCurrentDate(m.content);
+      if (r.count) {
+        m.content = r.text;
+        applied += 1;
+      }
+      continue;
+    }
+    if (!Array.isArray(m.content)) continue;
+    for (const b of m.content) {
+      if (!b || typeof b !== "object" || typeof b.text !== "string") continue;
+      const r = maskCurrentDate(b.text);
+      if (r.count) {
+        b.text = r.text;
+        applied += 1;
+      }
+    }
+  }
+  return applied;
+}
+
+export default {
+  name: "currentdate-normalize",
+  description:
+    "Mask CC's 'Today's date is YYYY-MM-DD.' injection to a canonical placeholder so the calendar rolling " +
+    "over mid-session does not invalidate the whole prefix. Disable with CACHE_FIX_NORMALIZE_CURRENTDATE=0.",
+  order: 310,
+
+  async onRequest(ctx) {
+    if (envDisabled()) return;
+    const body = ctx.body;
+    if (!body) return;
+
+    let applied = normalizeMessages(body.messages);
+
+    // The same line has been observed in top-level system blocks; masking it
+    // there too costs one walk and keeps the two locations consistent.
+    if (Array.isArray(body.system)) {
+      for (const b of body.system) {
+        if (!b || typeof b !== "object" || typeof b.text !== "string") continue;
+        const r = maskCurrentDate(b.text);
+        if (r.count) {
+          b.text = r.text;
+          applied += 1;
+        }
+      }
+    } else if (typeof body.system === "string") {
+      const r = maskCurrentDate(body.system);
+      if (r.count) {
+        body.system = r.text;
+        applied += 1;
+      }
+    }
+
+    if (applied > 0) {
+      ctx.meta._currentDateNormalize = { currentdate_blocks_masked: applied };
+    }
+  },
+};

--- a/test/proxy-currentdate-normalize.test.mjs
+++ b/test/proxy-currentdate-normalize.test.mjs
@@ -1,0 +1,146 @@
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import ext, { maskCurrentDate, normalizeMessages } from "../proxy/extensions/currentdate-normalize.mjs";
+
+const LINE = "Today's date is 2026-08-16.";
+const MASKED = "Today's date is 0000-00-00.";
+const CLAUDEMD = `<system-reminder>\n# currentDate\n${LINE}\n</system-reminder>`;
+
+let origEnv;
+beforeEach(() => {
+  origEnv = process.env.CACHE_FIX_NORMALIZE_CURRENTDATE;
+});
+afterEach(() => {
+  if (origEnv === undefined) delete process.env.CACHE_FIX_NORMALIZE_CURRENTDATE;
+  else process.env.CACHE_FIX_NORMALIZE_CURRENTDATE = origEnv;
+});
+
+const block = (text) => ({ role: "user", content: [{ type: "text", text }] });
+const mkCtx = (body) => ({ headers: {}, meta: {}, body });
+
+// --- the mask ----------------------------------------------------------------
+
+test("masks the date and leaves everything around it alone", () => {
+  const r = maskCurrentDate(CLAUDEMD);
+  assert.equal(r.count, 1);
+  assert.ok(r.text.includes(MASKED));
+  assert.ok(r.text.includes("# currentDate"), "the header must survive — the signal is abstracted, not removed");
+  assert.ok(!r.text.includes("2026-08-16"));
+});
+
+test("IDEMPOTENT — running twice is byte-identical and counts once", () => {
+  // A proxy can see the same body more than once (retries, replays). A
+  // non-idempotent mask would keep reporting work and, worse, could differ
+  // between two emissions of the same body.
+  const once = maskCurrentDate(CLAUDEMD);
+  const twice = maskCurrentDate(once.text);
+  assert.equal(twice.count, 0, "second pass must find nothing");
+  assert.equal(twice.text, once.text);
+});
+
+test("masks every occurrence in one string", () => {
+  const r = maskCurrentDate(`${LINE}\n...\nToday's date is 2025-01-02.`);
+  assert.equal(r.count, 2);
+  assert.ok(!/20\d\d-\d\d-\d\d/.test(r.text.replace(/0000-00-00/g, "")));
+});
+
+test("does not require the # currentDate header", () => {
+  // CC emits the line both with and without the markdown header across
+  // claudeMd shapes, so anchoring on the header would miss half the cases.
+  assert.equal(maskCurrentDate(LINE).count, 1);
+});
+
+test("leaves unrelated dates and prose alone", () => {
+  for (const s of [
+    "The release was on 2026-08-16.",
+    "Today's date is unknown.",
+    "Todays date is 2026-08-16.",
+    "Today's date is 2026-8-16.",
+    "",
+  ]) {
+    assert.equal(maskCurrentDate(s).count, 0, s);
+  }
+  assert.equal(maskCurrentDate(null).count, 0);
+  assert.equal(maskCurrentDate(42).count, 0);
+});
+
+// --- the walk ----------------------------------------------------------------
+
+test("normalizeMessages handles block content and string content", () => {
+  const msgs = [block(CLAUDEMD), { role: "user", content: LINE }];
+  assert.equal(normalizeMessages(msgs), 2);
+  assert.ok(msgs[0].content[0].text.includes(MASKED));
+  assert.equal(msgs[1].content, MASKED);
+});
+
+test("normalizeMessages tolerates junk", () => {
+  assert.equal(normalizeMessages(null), 0);
+  assert.equal(normalizeMessages("nope"), 0);
+  assert.equal(normalizeMessages([null, 7, {}, { content: 3 }, { content: [null, { text: 1 }] }]), 0);
+});
+
+// --- onRequest ---------------------------------------------------------------
+
+test("THE DEFECT — midnight no longer moves the prefix", async () => {
+  // The same session serialized either side of a calendar rollover. Before the
+  // mask these bodies differ at the claudeMd block, which sits ahead of the
+  // first cache_control marker — so everything from byte 0 invalidates.
+  const before = mkCtx({ messages: [block(`# currentDate\n${LINE}`), block("real content")] });
+  const after = mkCtx({ messages: [block("# currentDate\nToday's date is 2026-08-17."), block("real content")] });
+
+  assert.notEqual(
+    JSON.stringify(before.body.messages),
+    JSON.stringify(after.body.messages),
+    "premise: the rollover really does change the bytes",
+  );
+
+  await ext.onRequest(before);
+  await ext.onRequest(after);
+
+  assert.equal(
+    JSON.stringify(before.body.messages),
+    JSON.stringify(after.body.messages),
+    "after masking, the two sides of midnight must be byte-identical",
+  );
+});
+
+test("annotates only when it changed something", async () => {
+  const hit = mkCtx({ messages: [block(CLAUDEMD)] });
+  await ext.onRequest(hit);
+  assert.equal(hit.meta._currentDateNormalize.currentdate_blocks_masked, 1);
+
+  const miss = mkCtx({ messages: [block("nothing to see")] });
+  await ext.onRequest(miss);
+  assert.equal(miss.meta._currentDateNormalize, undefined);
+});
+
+test("also masks a top-level system block", async () => {
+  const ctx = mkCtx({ messages: [], system: [{ type: "text", text: CLAUDEMD }] });
+  await ext.onRequest(ctx);
+  assert.ok(ctx.body.system[0].text.includes(MASKED));
+
+  const asString = mkCtx({ messages: [], system: LINE });
+  await ext.onRequest(asString);
+  assert.equal(asString.body.system, MASKED);
+});
+
+test("CACHE_FIX_NORMALIZE_CURRENTDATE=0 disables it", async () => {
+  process.env.CACHE_FIX_NORMALIZE_CURRENTDATE = "0";
+  const ctx = mkCtx({ messages: [block(CLAUDEMD)] });
+  await ext.onRequest(ctx);
+  assert.ok(ctx.body.messages[0].content[0].text.includes("2026-08-16"));
+});
+
+test("a malformed body is left alone", async () => {
+  for (const body of [undefined, null, {}, { messages: "nope" }]) {
+    const ctx = { headers: {}, meta: {}, body };
+    await ext.onRequest(ctx);
+    assert.equal(ctx.meta._currentDateNormalize, undefined);
+  }
+});
+
+test("registration: declares its own order", () => {
+  assert.equal(ext.name, "currentdate-normalize");
+  assert.equal(ext.order, 310, "beside identity-normalization (300), before the cache_control mutators");
+  assert.equal(typeof ext.onRequest, "function");
+});


### PR DESCRIPTION
## The defect

CC stamps the date into the claudeMd system-reminder block:

```
# currentDate
Today's date is 2026-08-16.
```

It sits deep inside the first user message's injected claudeMd block —
measured ~30k characters into `messages[0].content[3]`. When the calendar day
rolls over mid-session that value advances by one, and everything from byte 0
through the first `cache_control` marker invalidates. A full cold write, once
per midnight, for every session still running. **~386k tokens** on the session
that motivated it (2026-04-23 00:34:50).

It is the one cache bust you can predict to the minute, and it scales with how
long sessions live rather than with what they do.

## Approach

Write a canonical `0000-00-00` placeholder in place of the value.

- The model still sees the `# currentDate` header, so the signal reads as
  *abstracted* rather than missing.
- CC still delivers the real rollover separately through its own
  "The date has changed" system-reminder when it actually happens, so nothing
  the model needs is lost — only the byte that changes on a timer.
- The placeholder keeps the `YYYY-MM-DD` shape so anything downstream that
  parses that format keeps parsing.

## Notes

- **Idempotent by construction.** The pattern carries a negative lookahead on
  the placeholder, so a second pass finds nothing and produces identical bytes.
  A proxy can see the same body more than once (retries, replays), and a
  non-idempotent mask could emit two different versions of one body.
- **Not anchored on `# currentDate`.** CC emits the line both with and without
  that header across claudeMd shapes; anchoring would miss half the cases. The
  sentence is specific enough to match anywhere — the tests pin that
  `Todays date is …`, `Today's date is unknown.`, `2026-8-16` and a bare
  `The release was on 2026-08-16.` are all left alone.
- **Order 310**, beside `identity-normalization` (300), which stabilizes the
  same class of volatile per-turn field, and before the cache_control mutators.
- Also masks the line in a top-level `system` block, where it has been observed
  as well.

## Verification

The headline test replays one session serialized either side of a rollover:
the two bodies differ before the mask (asserted, so the premise cannot rot) and
are byte-identical after. `node --test` → 13/13. Also ran
`session-key-invariants` (4/4) and `proxy-pipeline` (15/15) locally;
`tools/absence-scan.mjs` clean over both files. Your CI is the authoritative
run — it caught a real design bug in #340 that my local runs missed.

## Load-bearing?

**Yes** — it rewrites bytes inside the cached prefix.

— Claude Opus 5, working with @deafsquad