### PR TITLE
fix(launcher): reap the fingerprint records the proxy leaves behind

### DIFF
--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -790,8 +790,9 @@ function publishFingerprint(port) {
 // Seven days on top, matching the scratch-CA reaper, bounds what a crashed
 // holder leaves behind on a port nobody rebinds.
 //
-// The suffix check also excludes publishFingerprint's `<record>.<pid>` temp,
-// deliberately: that name is a concurrent launcher's pending rename, not litter.
+// publishFingerprint's `<record>.<pid>` temp is spared while it is fresh -- a
+// pending rename is not litter -- and collected past the same gate, where the
+// only thing that leaves one behind is a publish that died.
 async function reapFingerprintRecords() {
   let seen = 0;
   try {
@@ -800,11 +801,18 @@ async function reapFingerprintRecords() {
       // uninterrupted pass holds the event loop between the bind and the first
       // accept — which is the delay deferring this was meant to avoid.
       if (++seen % 100 === 0) await new Promise(setImmediate);
-      if (!f.startsWith(RECORD_PREFIX) || !f.endsWith(RECORD_SUFFIX)) continue;
+      if (!f.startsWith(RECORD_PREFIX)) continue;
+      const isRecord = f.endsWith(RECORD_SUFFIX);
+      // A rename pends for microseconds, so a `<record>.<pid>` this far over the
+      // gate is a crashed publish. Nothing else collects it: the suffix test
+      // alone would skip the name forever.
+      const isTemp = !isRecord && f.includes(`${RECORD_SUFFIX}.`);
+      if (!isRecord && !isTemp) continue;
       const p = join(tmpdir(), f);
       try {
         if (Date.now() - statSync(p).mtimeMs <= REAP_AGE_MS) continue;
-        if (!(await portFree(f.slice(RECORD_PREFIX.length, -RECORD_SUFFIX.length)))) continue;
+        // Only a record answers to a port. A temp is nobody's to read.
+        if (isRecord && !(await portFree(f.slice(RECORD_PREFIX.length, -RECORD_SUFFIX.length)))) continue;
         rmSync(p);
       } catch { /* raced, gone, or refused; a survivor is disk, not correctness */ }
     }

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -784,13 +784,12 @@ function publishFingerprint(port) {
 // Seven days on top, matching the scratch-CA reaper, bounds what a crashed
 // holder leaves behind on a port nobody rebinds.
 async function reapFingerprintRecords() {
-  const recordAgeMs = 7 * 86_400_000;
   try {
     for (const f of readdirSync(tmpdir())) {
       if (!f.startsWith(RECORD_PREFIX) || !f.endsWith(".sha256")) continue;
       const p = join(tmpdir(), f);
       try {
-        if (Date.now() - statSync(p).mtimeMs <= recordAgeMs) continue;
+        if (Date.now() - statSync(p).mtimeMs <= 7 * 86_400_000) continue;
         if (!(await portFree(f.slice(RECORD_PREFIX.length, -".sha256".length)))) continue;
         rmSync(p);
       } catch { /* raced, gone, or refused; a survivor is disk, not correctness */ }
@@ -809,8 +808,8 @@ async function reapFingerprintRecords() {
 // is itself a listener while it asks, so a launcher running otherHolderOn()
 // concurrently can read it as an incumbent; that window is the bind's lifetime.
 //
-// The loop does not yield: listen and close resolve on nextTick, so the await
-// never reaches the poll phase. It runs after the bind and delays no listener.
+// Awaiting this does not yield: listen and close resolve on nextTick, so the
+// caller's loop never reaches the poll phase and holds it for the whole scan.
 function portFree(port) {
   const n = Number(port);
   if (!Number.isInteger(n) || n < 1 || n > 65535) return Promise.resolve(false);

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -809,6 +809,18 @@ async function reapFingerprintRecords() {
 // reap working on a host with no lsof — otherwise the leak fix is a silent
 // no-op exactly where nobody would look for it. A name whose port is not a
 // number is not ours to judge, so it is kept.
+//
+// It answers "is anything LISTENING", which is not the same as "is anyone using
+// this port": a holder in the bound-but-not-listening state this file creates on
+// purpose reads as free. That window is the ~80 ms before the gap relay boots,
+// and losing a record there ends in the announced exit 0 above rather than
+// anything silent.
+//
+// Serialized, and it does not yield: measured at 3,000 over-age records the loop
+// held the event loop for 176 ms. listen and close resolve on nextTick, so the
+// await never reaches the poll phase. It runs after the bind, so it delays no
+// listener — but budget roughly 60 ms per 1,000 eligible records before calling
+// it free.
 function portFree(port) {
   const n = Number(port);
   if (!Number.isInteger(n) || n < 1 || n > 65535) return Promise.resolve(false);

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -753,8 +753,15 @@ function codeFingerprint(root) {
   } catch { return ""; }
 }
 
+// ONE CONSTANT, TWO SITES: the writer here and the reaper below. Deriving the
+// reaper's prefix from this path at runtime read `lastIndexOf("/")`, which is
+// -1 on Windows — the whole absolute path became the prefix, no basename from
+// readdirSync matched, and the reaper was a silent no-op there. Same reason
+// SCRATCH_PREFIX exists rather than two matching literals.
+const RECORD_PREFIX = "cache-fix-proxy-";
+
 function fingerprintPath(port) {
-  return join(tmpdir(), `cache-fix-proxy-${port}.sha256`);
+  return join(tmpdir(), `${RECORD_PREFIX}${port}.sha256`);
 }
 
 // Temp + rename: a reader that opens this mid-write would compare against a
@@ -769,10 +776,41 @@ function publishFingerprint(port) {
   } catch { /* best effort: an unwritable tmpdir must not stop a proxy starting */ }
 }
 
+// ONE RECORD PER PORT, AND THE PORT IS EPHEMERAL, so every proxy start leaves a
+// `cache-fix-proxy-<port>.sha256` nothing removed. runningOurCode() below used
+// to call that ordinary because systemd-tmpfiles sweeps /tmp; that is a
+// deployment assumption, false in a container. Measured on one with zsh as PID
+// 1: 6,743 records, 461 a day. The cost is not the 284 KB — the scratch-CA
+// reaper walks readdirSync(tmpdir()) on every start, 117 ms at 74,493 entries,
+// and this litter is what fills it.
+//
+// SEVEN DAYS, matching the scratch reaper, because nothing republishes a
+// record: publishFingerprint has one call site, the spawn path, so an
+// unrestarted holder's mtime is its launch time. A shorter gate deletes a live
+// holder's own record, runningOurCode() then answers null, and takeOver() exits
+// 0 — the "swept /tmp turned a deploy into a no-op that read as a success"
+// incident, caused by us this time. Age is still the only discriminator
+// available: the name says which PORT, never which process.
+//
+// Best effort throughout. A survivor is disk, not correctness — it is only read
+// by a proxy that hashes the same bytes anyway.
+function reapFingerprintRecords() {
+  const recordAgeMs = 7 * 86_400_000;
+  try {
+    for (const f of readdirSync(tmpdir())) {
+      if (!f.startsWith(RECORD_PREFIX) || !f.endsWith(".sha256")) continue;
+      const p = join(tmpdir(), f);
+      try { if (Date.now() - statSync(p).mtimeMs > recordAgeMs) rmSync(p); }
+      catch { /* raced, gone, or refused — see above */ }
+    }
+  } catch { /* unreadable tmpdir: publishing already degraded, say nothing more */ }
+}
+
 // TRUE, FALSE, or NULL for "cannot tell" — a third state because the callers
 // must be able to TELL unknown apart, not because they answer it differently.
 // Both end at exit 0; only one of them says why (see otherHolderOn). Unknown is
-// ordinary: the record lives in /tmp, which systemd-tmpfiles sweeps.
+// ordinary: the record is age-reaped (see reapFingerprintRecords) and a host
+// with a /tmp sweeper clears it too.
 function runningOurCode(port) {
   let theirs = "";
   try { theirs = readFileSync(fingerprintPath(port), "utf8").trim(); } catch { return null; }
@@ -816,6 +854,18 @@ function holdPort(rest) {
   for (const s of [process.stdout, process.stderr]) {
     s.on("error", () => { /* the reader left; putting the proxy back is the job */ });
   }
+  // ONCE PER LAUNCHER PROCESS, AND OFF THIS PATH. Inside publishFingerprint it
+  // sat behind that function's `if (!fp) return;` — reaping only while
+  // publishing works, the mistake the CA reaper below documents — and ran on
+  // every respawn, a full readdirSync(tmpdir()) per attempt on a ladder
+  // measured at 51 spawns in 1.2s.
+  //
+  // Deferred because the scan is not free and nothing waits on it: 135-193 ms
+  // at 68,533 tmpdir entries. Run inline here it delays the bind, and
+  // proxy-held-port.test.mjs then failed 2 of 10 interleaved runs against
+  // upstream/main's 0 of 14 — with the same diff's scan body disabled, 0 of 5.
+  // unref so it can never hold the process open.
+  setTimeout(reapFingerprintRecords, 0).unref();
   // The proxy's own default: holding a different port than the proxy would have
   // served leaves nothing at the documented address.
   // `|| 9801` REWROTE PORT 0 to 9801. "0" is a truthy string so the run-service

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -811,10 +811,18 @@ async function reapFingerprintRecords() {
 // number is not ours to judge, so it is kept.
 //
 // It answers "is anything LISTENING", which is not the same as "is anyone using
-// this port": a holder in the bound-but-not-listening state this file creates on
-// purpose reads as free. That window is the ~80 ms before the gap relay boots,
-// and losing a record there ends in the announced exit 0 above rather than
-// anything silent.
+// this port". Two consequences, both narrow and neither silent:
+//
+// A holder in the bound-but-not-listening state this file creates on purpose
+// reads as free, so a record could be reaped during the window before its relay
+// takes over. The window has not been measured for the relay specifically; the
+// ~80 ms nearby belongs to the proxy child's boot, which is a larger spawn.
+// Losing a record there ends in the announced exit 0 above.
+//
+// And this probe IS a listener while it asks. A launcher starting concurrently
+// runs otherHolderOn(), which selects on a LISTEN socket plus a run-service
+// command line plus greater uptime — a peer mid-probe can satisfy those and be
+// read as an incumbent. Bounded by the bind lifetime, under 59 µs per record.
 //
 // Serialized, and it does not yield: measured at 3,000 over-age records the loop
 // held the event loop for 176 ms. listen and close resolve on nextTick, so the

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -753,11 +753,10 @@ function codeFingerprint(root) {
   } catch { return ""; }
 }
 
-// ONE CONSTANT, TWO SITES: the writer here and the reaper below. Deriving the
-// reaper's prefix from this path at runtime read `lastIndexOf("/")`, which is
-// -1 on Windows — the whole absolute path became the prefix, no basename from
-// readdirSync matched, and the reaper was a silent no-op there. Same reason
-// SCRATCH_PREFIX exists rather than two matching literals.
+// The writer and the reaper below must name the same thing, so they read one
+// constant. Deriving the reaper's prefix from this path instead is not
+// portable: the separator is not "/" everywhere, and readdirSync yields
+// basenames.
 const RECORD_PREFIX = "cache-fix-proxy-";
 
 function fingerprintPath(port) {
@@ -776,24 +775,20 @@ function publishFingerprint(port) {
   } catch { /* best effort: an unwritable tmpdir must not stop a proxy starting */ }
 }
 
-// ONE RECORD PER PORT, AND THE PORT IS EPHEMERAL, so every proxy start leaves a
-// `cache-fix-proxy-<port>.sha256` nothing removed. runningOurCode() below used
-// to call that ordinary because systemd-tmpfiles sweeps /tmp; that is a
-// deployment assumption, false in a container. Measured on one with zsh as PID
-// 1: 6,743 records, 461 a day. The cost is not the 284 KB — the scratch-CA
-// reaper walks readdirSync(tmpdir()) on every start, 117 ms at 74,493 entries,
-// and this litter is what fills it.
+// Nothing else removes these. The port is ephemeral wherever the OS picks one,
+// so without this a record accumulates per proxy start without bound, and the
+// scratch-CA reaper below pays for it — it walks the same tmpdir on every
+// launcher start.
 //
-// SEVEN DAYS, matching the scratch reaper, because nothing republishes a
-// record: publishFingerprint has one call site, the spawn path, so an
-// unrestarted holder's mtime is its launch time. A shorter gate deletes a live
-// holder's own record, runningOurCode() then answers null, and takeOver() exits
-// 0 — the "swept /tmp turned a deploy into a no-op that read as a success"
-// incident, caused by us this time. Age is still the only discriminator
-// available: the name says which PORT, never which process.
+// Seven days, matching that reaper. publishFingerprint has one call site, the
+// spawn path, and nothing republishes: an unrestarted holder's record mtime is
+// its launch time, so a shorter gate deletes a live holder's own record and
+// runningOurCode() then cannot tell a stale proxy from a healthy one. Age is
+// the only discriminator available — the name says which PORT, never which
+// process.
 //
-// Best effort throughout. A survivor is disk, not correctness — it is only read
-// by a proxy that hashes the same bytes anyway.
+// Best effort throughout: a survivor is disk, not correctness, since it is only
+// read by a proxy that hashes the same bytes anyway.
 function reapFingerprintRecords() {
   const recordAgeMs = 7 * 86_400_000;
   try {
@@ -854,17 +849,11 @@ function holdPort(rest) {
   for (const s of [process.stdout, process.stderr]) {
     s.on("error", () => { /* the reader left; putting the proxy back is the job */ });
   }
-  // ONCE PER LAUNCHER PROCESS, AND OFF THIS PATH. Inside publishFingerprint it
-  // sat behind that function's `if (!fp) return;` — reaping only while
-  // publishing works, the mistake the CA reaper below documents — and ran on
-  // every respawn, a full readdirSync(tmpdir()) per attempt on a ladder
-  // measured at 51 spawns in 1.2s.
-  //
-  // Deferred because the scan is not free and nothing waits on it: 135-193 ms
-  // at 68,533 tmpdir entries. Run inline here it delays the bind, and
-  // proxy-held-port.test.mjs then failed 2 of 10 interleaved runs against
-  // upstream/main's 0 of 14 — with the same diff's scan body disabled, 0 of 5.
-  // unref so it can never hold the process open.
+  // Here, not in publishFingerprint: that returns early when the fingerprint is
+  // unreadable, which would stop reaping exactly when publishing is broken, and
+  // it runs on every respawn. Deferred because the scan walks the whole tmpdir
+  // and would delay the bind; nothing waits on its result. unref so it cannot
+  // hold the process open.
   setTimeout(reapFingerprintRecords, 0).unref();
   // The proxy's own default: holding a different port than the proxy would have
   // served leaves nothing at the documented address.

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -753,12 +753,18 @@ function codeFingerprint(root) {
   } catch { return ""; }
 }
 
-// One constant, because the reaper matches the basenames readdirSync() yields
-// and cannot derive the prefix from a joined path.
+// BOTH HALVES, because the reaper matches the basenames readdirSync() yields and
+// cannot derive them from a joined path. A literal on either side drifts the
+// reaper into matching nothing, which collects nothing and reports nothing.
 const RECORD_PREFIX = "cache-fix-proxy-";
+const RECORD_SUFFIX = ".sha256";
+
+// Shared with the scratch-CA reaper below: the two gates are equal by
+// construction, not by a comment claiming they are.
+const REAP_AGE_MS = 7 * 86_400_000;
 
 function fingerprintPath(port) {
-  return join(tmpdir(), `${RECORD_PREFIX}${port}.sha256`);
+  return join(tmpdir(), `${RECORD_PREFIX}${port}${RECORD_SUFFIX}`);
 }
 
 // Temp + rename: a reader that opens this mid-write would compare against a
@@ -783,14 +789,22 @@ function publishFingerprint(port) {
 //
 // Seven days on top, matching the scratch-CA reaper, bounds what a crashed
 // holder leaves behind on a port nobody rebinds.
+//
+// The suffix check also excludes publishFingerprint's `<record>.<pid>` temp,
+// deliberately: that name is a concurrent launcher's pending rename, not litter.
 async function reapFingerprintRecords() {
+  let seen = 0;
   try {
     for (const f of readdirSync(tmpdir())) {
-      if (!f.startsWith(RECORD_PREFIX) || !f.endsWith(".sha256")) continue;
+      // Yield periodically. Nothing awaited below reaches the poll phase, so an
+      // uninterrupted pass holds the event loop between the bind and the first
+      // accept — which is the delay deferring this was meant to avoid.
+      if (++seen % 100 === 0) await new Promise(setImmediate);
+      if (!f.startsWith(RECORD_PREFIX) || !f.endsWith(RECORD_SUFFIX)) continue;
       const p = join(tmpdir(), f);
       try {
-        if (Date.now() - statSync(p).mtimeMs <= 7 * 86_400_000) continue;
-        if (!(await portFree(f.slice(RECORD_PREFIX.length, -".sha256".length)))) continue;
+        if (Date.now() - statSync(p).mtimeMs <= REAP_AGE_MS) continue;
+        if (!(await portFree(f.slice(RECORD_PREFIX.length, -RECORD_SUFFIX.length)))) continue;
         rmSync(p);
       } catch { /* raced, gone, or refused; a survivor is disk, not correctness */ }
     }
@@ -801,15 +815,24 @@ async function reapFingerprintRecords() {
 // this needs one bit, and a host without lsof would otherwise make the reap a
 // silent no-op. A name whose port is not a number is not ours to judge.
 //
-// "Is anything LISTENING" is not "is anyone using this port", and the gap cuts
-// both ways. A holder in the bound-but-not-listening state this file creates on
-// purpose reads as free, so an over-age record can be lost in the window before
-// its relay takes over, which ends in the announced exit 0 above. And this probe
-// is itself a listener while it asks, so a launcher running otherHolderOn()
-// concurrently can read it as an incumbent; that window is the bind's lifetime.
+// THREE THINGS THIS DOES NOT ANSWER, all narrow, none free to close here:
 //
-// Awaiting this does not yield: listen and close resolve on nextTick, so the
-// caller's loop never reaches the poll phase and holds it for the whole scan.
+// 1. "Is anything LISTENING" is not "is anyone using this port". A holder in the
+//    bound-but-not-listening state this file creates on purpose reads as free,
+//    so an over-age record can be lost in the window before its relay takes over.
+// 2. A record is keyed by PORT ALONE, and this asks about bindAddr(). A holder on
+//    another address reads as free to a reaper on loopback. Probing the wildcard
+//    would close it and open a worse one — an externally reachable socket per
+//    over-age record — and carrying the address would change the record format.
+// 3. The probe is itself a listener while it asks, so a launcher in otherHolderOn()
+//    can read it as an incumbent, print "this one is surplus" and settle(0),
+//    leaving the port empty. Needs a record for the exact port a second launcher
+//    is binding, i.e. one idle seven days and then reused.
+//
+// All three end in the same place: runningOurCode() answers null and takeOver()
+// exits 0 announcing a deploy that has not taken effect. The local variant of 3
+// cannot happen — listen() is the last synchronous statement of holdPort's
+// executor, so this launcher already owns its own port when the reap runs.
 function portFree(port) {
   const n = Number(port);
   if (!Number.isInteger(n) || n < 1 || n > 65535) return Promise.resolve(false);
@@ -2325,7 +2348,7 @@ if (remoteControl) {
     // unique; it guarantees nothing about what else shares a prefix, so the two
     // sites read one constant rather than two matching string literals.
     try {
-      const scratchAgeMs = 7 * 86_400_000;
+      const scratchAgeMs = REAP_AGE_MS;
       for (const f of readdirSync(tmpdir())) {
         if (!f.startsWith(SCRATCH_PREFIX)) continue;
         const p = join(tmpdir(), f);

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -753,10 +753,8 @@ function codeFingerprint(root) {
   } catch { return ""; }
 }
 
-// The writer and the reaper below must name the same thing, so they read one
-// constant. Deriving the reaper's prefix from this path instead is not
-// portable: the separator is not "/" everywhere, and readdirSync yields
-// basenames.
+// One constant, because the reaper matches the basenames readdirSync() yields
+// and cannot derive the prefix from a joined path.
 const RECORD_PREFIX = "cache-fix-proxy-";
 
 function fingerprintPath(port) {
@@ -775,19 +773,15 @@ function publishFingerprint(port) {
   } catch { /* best effort: an unwritable tmpdir must not stop a proxy starting */ }
 }
 
-// Nothing else removes these. The port is ephemeral wherever the OS picks one,
-// so without this a record accumulates per proxy start without bound, and every
-// later scan of tmpdir pays for the ones already there.
+// Nothing else removes these, and the port is ephemeral wherever the OS picks
+// one, so a record accumulates per proxy start without bound.
 //
-// A PORT THAT STILL ANSWERS OUTRANKS THE CLOCK, because nothing republishes a
-// record: one call site, the spawn path, so the mtime is the last child spawn.
-// Age alone would therefore make the gate a deadline rather than a margin — a
-// holder that neither respawns nor is redeployed for a week is fully live with
-// an over-age record, and deleting it makes runningOurCode() answer null, which
-// ends in takeOver() exiting 0 while announcing a deploy that has not taken
-// effect.
+// A PORT THAT STILL ANSWERS OUTRANKS THE CLOCK. Nothing republishes a record —
+// its mtime is the last child spawn — so age alone reaps the record of a holder
+// that has merely been up a week. runningOurCode() then answers null and
+// takeOver() exits 0 announcing a deploy that has not taken effect.
 //
-// Seven days on top, matching the scratch-CA reaper, to bound what a crashed
+// Seven days on top, matching the scratch-CA reaper, bounds what a crashed
 // holder leaves behind on a port nobody rebinds.
 async function reapFingerprintRecords() {
   const recordAgeMs = 7 * 86_400_000;
@@ -804,31 +798,19 @@ async function reapFingerprintRecords() {
   } catch { /* unreadable tmpdir: publishing already degraded, say nothing more */ }
 }
 
-// ASKED BY BINDING, NOT BY lsof. holderPidOn needs a PID and so has to shell
-// out; this needs one bit and the kernel answers it directly, which keeps the
-// reap working on a host with no lsof — otherwise the leak fix is a silent
-// no-op exactly where nobody would look for it. A name whose port is not a
-// number is not ours to judge, so it is kept.
+// ASKED BY BINDING, NOT BY lsof: holderPidOn needs a pid and has to shell out,
+// this needs one bit, and a host without lsof would otherwise make the reap a
+// silent no-op. A name whose port is not a number is not ours to judge.
 //
-// It answers "is anything LISTENING", which is not the same as "is anyone using
-// this port". Two consequences, both narrow and neither silent:
+// "Is anything LISTENING" is not "is anyone using this port", and the gap cuts
+// both ways. A holder in the bound-but-not-listening state this file creates on
+// purpose reads as free, so an over-age record can be lost in the window before
+// its relay takes over, which ends in the announced exit 0 above. And this probe
+// is itself a listener while it asks, so a launcher running otherHolderOn()
+// concurrently can read it as an incumbent; that window is the bind's lifetime.
 //
-// A holder in the bound-but-not-listening state this file creates on purpose
-// reads as free, so a record could be reaped during the window before its relay
-// takes over. The window has not been measured for the relay specifically; the
-// ~80 ms nearby belongs to the proxy child's boot, which is a larger spawn.
-// Losing a record there ends in the announced exit 0 above.
-//
-// And this probe IS a listener while it asks. A launcher starting concurrently
-// runs otherHolderOn(), which selects on a LISTEN socket plus a run-service
-// command line plus greater uptime — a peer mid-probe can satisfy those and be
-// read as an incumbent. Bounded by the bind lifetime, under 59 µs per record.
-//
-// Serialized, and it does not yield: measured at 3,000 over-age records the loop
-// held the event loop for 176 ms. listen and close resolve on nextTick, so the
-// await never reaches the poll phase. It runs after the bind, so it delays no
-// listener — but budget roughly 60 ms per 1,000 eligible records before calling
-// it free.
+// The loop does not yield: listen and close resolve on nextTick, so the await
+// never reaches the poll phase. It runs after the bind and delays no listener.
 function portFree(port) {
   const n = Number(port);
   if (!Number.isInteger(n) || n < 1 || n > 65535) return Promise.resolve(false);
@@ -888,14 +870,10 @@ function holdPort(rest) {
     s.on("error", () => { /* the reader left; putting the proxy back is the job */ });
   }
   // Here, not in publishFingerprint: that returns early when the fingerprint is
-  // unreadable, which would stop reaping exactly when publishing is broken, and
-  // it runs on every respawn. Deferred because the scan walks the whole tmpdir
-  // and would delay the bind; nothing waits on its result. unref so it cannot
-  // hold the process open.
-  //
-  // The idempotent exits below settle before the timers phase and so never reap,
-  // but they publish nothing either: a launcher that leaves a record is one that
-  // reaps.
+  // unreadable, which would stop the reap exactly when publishing is broken, and
+  // it runs on every respawn. Deferred and unref'd because the scan walks the
+  // whole tmpdir, nothing waits on its result, and it must neither delay the
+  // bind nor hold the process open.
   setTimeout(reapFingerprintRecords, 0).unref();
   // The proxy's own default: holding a different port than the proxy would have
   // served leaves nothing at the documented address.

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -779,43 +779,44 @@ function publishFingerprint(port) {
 // so without this a record accumulates per proxy start without bound, and every
 // later scan of tmpdir pays for the ones already there.
 //
-// A LISTENING PORT OUTRANKS THE CLOCK, because nothing republishes a record: one
-// call site, the spawn path, so the mtime is the last child spawn. Age alone
-// would therefore make the gate a deadline rather than a margin — a holder that
-// neither respawns nor is redeployed for a week is fully live with an over-age
-// record, and deleting it makes runningOurCode() answer null, which ends in
-// takeOver() exiting 0 while announcing a deploy that has not taken effect.
+// A PORT THAT STILL ANSWERS OUTRANKS THE CLOCK, because nothing republishes a
+// record: one call site, the spawn path, so the mtime is the last child spawn.
+// Age alone would therefore make the gate a deadline rather than a margin — a
+// holder that neither respawns nor is redeployed for a week is fully live with
+// an over-age record, and deleting it makes runningOurCode() answer null, which
+// ends in takeOver() exiting 0 while announcing a deploy that has not taken
+// effect.
 //
 // Seven days on top, matching the scratch-CA reaper, to bound what a crashed
 // holder leaves behind on a port nobody rebinds.
-function reapFingerprintRecords() {
+async function reapFingerprintRecords() {
   const recordAgeMs = 7 * 86_400_000;
-  // One lsof, and only once something is actually eligible: on a swept host
-  // nothing is, and the reap costs a readdir.
-  let live = null;
   try {
     for (const f of readdirSync(tmpdir())) {
       if (!f.startsWith(RECORD_PREFIX) || !f.endsWith(".sha256")) continue;
       const p = join(tmpdir(), f);
       try {
         if (Date.now() - statSync(p).mtimeMs <= recordAgeMs) continue;
-        live ??= listeningPorts();
-        if (live.has(f.slice(RECORD_PREFIX.length, -".sha256".length))) continue;
+        if (!(await portFree(f.slice(RECORD_PREFIX.length, -".sha256".length)))) continue;
         rmSync(p);
       } catch { /* raced, gone, or refused; a survivor is disk, not correctness */ }
     }
   } catch { /* unreadable tmpdir: publishing already degraded, say nothing more */ }
 }
 
-// EMPTY MEANS "COULD NOT ASK", AND THE CALLER KEEPS EVERYTHING RATHER THAN
-// GUESSING — an lsof that fails would otherwise read as "nothing is listening"
-// and hand the reaper every record on the box. lsof and not /proc for the reason
-// holderPidOn gives: this has to work on macOS.
-function listeningPorts() {
-  try {
-    return new Set(probe("lsof", ["-nP", "-iTCP", "-sTCP:LISTEN", "-F", "n"])
-      .split("\n").filter((l) => l.startsWith("n")).map((l) => l.slice(l.lastIndexOf(":") + 1)));
-  } catch { return { has: () => true }; }
+// ASKED BY BINDING, NOT BY lsof. holderPidOn needs a PID and so has to shell
+// out; this needs one bit and the kernel answers it directly, which keeps the
+// reap working on a host with no lsof — otherwise the leak fix is a silent
+// no-op exactly where nobody would look for it. A name whose port is not a
+// number is not ours to judge, so it is kept.
+function portFree(port) {
+  const n = Number(port);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) return Promise.resolve(false);
+  return new Promise((res) => {
+    const s = net.createServer();
+    s.once("error", () => res(false));
+    s.listen(n, bindAddr(), () => s.close(() => res(true)));
+  });
 }
 
 // TRUE, FALSE, or NULL for "cannot tell" — a third state because the callers

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -813,6 +813,11 @@ async function reapFingerprintRecords() {
         if (Date.now() - statSync(p).mtimeMs <= REAP_AGE_MS) continue;
         // Only a record answers to a port. A temp is nobody's to read.
         if (isRecord && !(await portFree(f.slice(RECORD_PREFIX.length, -RECORD_SUFFIX.length)))) continue;
+        // RE-READ: publishFingerprint renames a new record over this path, and the
+        // probe's await is wide enough to land inside. Losing a FRESH record makes
+        // runningOurCode() answer null, which holderVerdict() reads as an incumbent
+        // of ours and takeOver() reports as a deploy that has not landed.
+        if (Date.now() - statSync(p).mtimeMs <= REAP_AGE_MS) continue;
         rmSync(p);
       } catch { /* raced, gone, or refused; a survivor is disk, not correctness */ }
     }

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -2348,11 +2348,10 @@ if (remoteControl) {
     // unique; it guarantees nothing about what else shares a prefix, so the two
     // sites read one constant rather than two matching string literals.
     try {
-      const scratchAgeMs = REAP_AGE_MS;
       for (const f of readdirSync(tmpdir())) {
         if (!f.startsWith(SCRATCH_PREFIX)) continue;
         const p = join(tmpdir(), f);
-        try { if (Date.now() - statSync(p).mtimeMs > scratchAgeMs) rmSync(p, { recursive: true }); }
+        try { if (Date.now() - statSync(p).mtimeMs > REAP_AGE_MS) rmSync(p, { recursive: true }); }
         // Someone else's, already gone, or REFUSED (dir mode 0500, measured).
         // A survivor is litter under tmpdir() that nothing reads — unlike a
         // refused delete that leaves a live state armed, which would need code.

--- a/bin/claude-via-proxy.mjs
+++ b/bin/claude-via-proxy.mjs
@@ -776,29 +776,46 @@ function publishFingerprint(port) {
 }
 
 // Nothing else removes these. The port is ephemeral wherever the OS picks one,
-// so without this a record accumulates per proxy start without bound, and the
-// scratch-CA reaper below pays for it — it walks the same tmpdir on every
-// launcher start.
+// so without this a record accumulates per proxy start without bound, and every
+// later scan of tmpdir pays for the ones already there.
 //
-// Seven days, matching that reaper. publishFingerprint has one call site, the
-// spawn path, and nothing republishes: an unrestarted holder's record mtime is
-// its launch time, so a shorter gate deletes a live holder's own record and
-// runningOurCode() then cannot tell a stale proxy from a healthy one. Age is
-// the only discriminator available — the name says which PORT, never which
-// process.
+// A LISTENING PORT OUTRANKS THE CLOCK, because nothing republishes a record: one
+// call site, the spawn path, so the mtime is the last child spawn. Age alone
+// would therefore make the gate a deadline rather than a margin — a holder that
+// neither respawns nor is redeployed for a week is fully live with an over-age
+// record, and deleting it makes runningOurCode() answer null, which ends in
+// takeOver() exiting 0 while announcing a deploy that has not taken effect.
 //
-// Best effort throughout: a survivor is disk, not correctness, since it is only
-// read by a proxy that hashes the same bytes anyway.
+// Seven days on top, matching the scratch-CA reaper, to bound what a crashed
+// holder leaves behind on a port nobody rebinds.
 function reapFingerprintRecords() {
   const recordAgeMs = 7 * 86_400_000;
+  // One lsof, and only once something is actually eligible: on a swept host
+  // nothing is, and the reap costs a readdir.
+  let live = null;
   try {
     for (const f of readdirSync(tmpdir())) {
       if (!f.startsWith(RECORD_PREFIX) || !f.endsWith(".sha256")) continue;
       const p = join(tmpdir(), f);
-      try { if (Date.now() - statSync(p).mtimeMs > recordAgeMs) rmSync(p); }
-      catch { /* raced, gone, or refused — see above */ }
+      try {
+        if (Date.now() - statSync(p).mtimeMs <= recordAgeMs) continue;
+        live ??= listeningPorts();
+        if (live.has(f.slice(RECORD_PREFIX.length, -".sha256".length))) continue;
+        rmSync(p);
+      } catch { /* raced, gone, or refused; a survivor is disk, not correctness */ }
     }
   } catch { /* unreadable tmpdir: publishing already degraded, say nothing more */ }
+}
+
+// EMPTY MEANS "COULD NOT ASK", AND THE CALLER KEEPS EVERYTHING RATHER THAN
+// GUESSING — an lsof that fails would otherwise read as "nothing is listening"
+// and hand the reaper every record on the box. lsof and not /proc for the reason
+// holderPidOn gives: this has to work on macOS.
+function listeningPorts() {
+  try {
+    return new Set(probe("lsof", ["-nP", "-iTCP", "-sTCP:LISTEN", "-F", "n"])
+      .split("\n").filter((l) => l.startsWith("n")).map((l) => l.slice(l.lastIndexOf(":") + 1)));
+  } catch { return { has: () => true }; }
 }
 
 // TRUE, FALSE, or NULL for "cannot tell" — a third state because the callers
@@ -854,6 +871,10 @@ function holdPort(rest) {
   // it runs on every respawn. Deferred because the scan walks the whole tmpdir
   // and would delay the bind; nothing waits on its result. unref so it cannot
   // hold the process open.
+  //
+  // The idempotent exits below settle before the timers phase and so never reap,
+  // but they publish nothing either: a launcher that leaves a record is one that
+  // reaps.
   setTimeout(reapFingerprintRecords, 0).unref();
   // The proxy's own default: holding a different port than the proxy would have
   // served leaves nothing at the documented address.

--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -123,4 +123,9 @@ export const HOP_ENV = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"
 // once, the oldest 788 s, accumulating across files and runs until a later
 // file's readiness assertion times out on the CPU and ports they hold. See
 // ours() for the mechanism and the two markers it reads.
-export const onPort = (port) => [...new Set([...listeners(port), ...ours(port)])];
+// Port 0 is the "assign me one" sentinel, never a port anything holds -- and it
+// is what a caller's `let port = 0` still carries if it throws before the
+// assignment. ours() would then match every proxy child running with
+// CACHE_FIX_PROXY_PORT=0, the operator's live one included.
+export const onPort = (port) =>
+  Number(port) > 0 ? [...new Set([...listeners(port), ...ours(port)])] : [];

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import net, { createServer } from "node:net";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
-import { onPort } from "./proc-helpers.mjs";
+import { HOP_ENV, freePort, onPort } from "./proc-helpers.mjs";
 
 const LAUNCHER = fileURLToPath(new URL("../bin/claude-via-proxy.mjs", import.meta.url));
 const SRC = readFileSync(LAUNCHER, "utf-8");
@@ -38,22 +38,6 @@ function runReaper(dir) {
     `${lift("async function reapFingerprintRecords()")}\nreturn reapFingerprintRecords();`
   )(readdirSync, statSync, rmSync, join, () => dir, net, () => "127.0.0.1");
 }
-
-// A FIXED PORT SITS INSIDE THE EPHEMERAL RANGE, so a sibling test's launcher can
-// be handed one and hold it for a whole run; portFree then answers false and the
-// reaper correctly keeps a record these cases expect reaped. A port the kernel
-// has just released is the last one it hands out again.
-function releasedPort() {
-  return new Promise((res) => {
-    const s = createServer();
-    s.listen(0, "127.0.0.1", () => { const port = s.address().port; s.close(() => res(port)); });
-  });
-}
-
-test("the launcher carries a reaper for its own fingerprint records", () => {
-  assert.match(SRC, /const\s+recordAgeMs\s*=/,
-               "no fingerprint reaper found in claude-via-proxy.mjs — this test guards nothing");
-});
 
 // Once per launcher process, not once per spawn, and not behind
 // publishFingerprint's early return.
@@ -84,7 +68,10 @@ test("a record whose port still has a listener is kept however old it is", async
     await new Promise((r) => srv.listen(0, "127.0.0.1", r));
     const port = srv.address().port;
     const live = join(dir, `cache-fix-proxy-${port}.sha256`);
-    const deadPort = await releasedPort();
+    // Derived, not fixed: a fixed port sits inside the ephemeral range, so a
+    // sibling file's launcher can hold it for a whole run and portFree() then
+    // answers false for a record this case expects reaped.
+    const deadPort = await freePort();
     const dead = join(dir, `cache-fix-proxy-${deadPort}.sha256`);
     for (const p of [live, dead]) writeFileSync(p, "x");
     const old = Date.now() / 1000 - 30 * 86400;
@@ -110,16 +97,21 @@ test("a launcher that binds reaps on the way up", { timeout: 30_000 }, async () 
   const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-e2e-"));
   let child = null, port = 0;
   try {
-    const stalePort = await releasedPort();
+    const stalePort = await freePort();
     const stale = join(dir, `cache-fix-proxy-${stalePort}.sha256`);
     writeFileSync(stale, "x");
     const old = Date.now() / 1000 - 30 * 86400;
     utimesSync(stale, old, old);
 
-    port = await releasedPort();
-    const env = { ...process.env, TMPDIR: dir, CACHE_FIX_PROXY_PORT: String(port),
-                  CACHE_FIX_FORWARD_PROXY: "on", CACHE_FIX_SELF_HEAL: "off" };
-    for (const k of ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"]) delete env[k];
+    port = await freePort();
+    // CLAUDE_CONFIG_DIR with TMPDIR, or the launcher mints its CA in the
+    // operator's real ~/.claude and republishes ca-trust.d/ccf.pem — the
+    // rendezvous file every sibling component reads — from under a live proxy.
+    // CACHE_FIX_FORWARD_PROXY is what asks for that publish, and the reap does
+    // not need a CA at all.
+    const env = { ...process.env, TMPDIR: dir, CLAUDE_CONFIG_DIR: dir,
+                  CACHE_FIX_PROXY_PORT: String(port), CACHE_FIX_SELF_HEAL: "off" };
+    for (const k of HOP_ENV) delete env[k];
     child = spawn(process.execPath, [LAUNCHER, "run-service"], { env, stdio: "ignore" });
 
     const deadline = Date.now() + 25_000;
@@ -160,7 +152,7 @@ test("a record whose port is not a number is kept", async () => {
 test("a stale record is removed, and anything a live holder may still own is kept", async () => {
   const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-"));
   try {
-    const stalePort = await releasedPort();
+    const stalePort = await freePort();
     const stale = join(dir, `cache-fix-proxy-${stalePort}.sha256`);
     // Fixed numbers, below the ephemeral floor so they cannot collide with the
     // derived one above: none of these four reaches portFree, so only the name

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -208,7 +208,12 @@ test("a stale record is removed, and anything a live holder may still own is kep
     // A concurrent launcher's in-flight write. publishFingerprint writes
     // `<record>.<pid>` and renames; that name carries RECORD_PREFIX, so only the
     // suffix check stands between this reaper and someone else's pending rename.
+    // Left FRESH, because that is the only state a pending rename is ever in.
     const inflight = join(dir, "cache-fix-proxy-30006.sha256.99999");
+    // The same name over the gate. A rename pends for microseconds, so at eight
+    // days it is a crashed publish -- and the suffix test skips it forever, so
+    // nothing in this file or any other ever collects it.
+    const abandoned = join(dir, "cache-fix-proxy-30007.sha256.99998");
     // Ends in .sha256 on purpose: with any other suffix endsWith() alone saves
     // it and an empty prefix would pass.
     const alien = join(dir, "cache-fix-ca-scratch-keepme.sha256");
@@ -221,9 +226,9 @@ test("a stale record is removed, and anything a live holder may still own is kep
     // wrong: listen(0) binds a random free port and always succeeds, so without
     // the floor the probe would call every port-0 record collectable.
     const zero = join(dir, "cache-fix-proxy-0.sha256");
-    for (const p of [stale, fresh, longLived, nearGate, alien, inflight, unparsed, zero]) writeFileSync(p, "x");
+    for (const p of [stale, fresh, longLived, nearGate, alien, inflight, abandoned, unparsed, zero]) writeFileSync(p, "x");
     const age = (p, days) => utimesSync(p, Date.now() / 1000 - days * 86400, Date.now() / 1000 - days * 86400);
-    age(stale, 8); age(longLived, 3); age(nearGate, 6); age(alien, 8); age(inflight, 8); age(unparsed, 8);
+    age(stale, 8); age(longLived, 3); age(nearGate, 6); age(alien, 8); age(abandoned, 8); age(unparsed, 8);
     age(zero, 8);
 
     await runReaper(dir);
@@ -237,6 +242,8 @@ test("a stale record is removed, and anything a live holder may still own is kep
               `a 6-day-old record was reaped: the gate is shorter than 7 days — ${left}`);
     assert.ok(left.includes("cache-fix-proxy-30006.sha256.99999"),
               `the reaper took a concurrent launcher's pending write — ${left}`);
+    assert.ok(!left.includes("cache-fix-proxy-30007.sha256.99998"),
+              `an eight-day-old <record>.<pid> survived: no reaper anywhere collects it — ${left}`);
     assert.ok(left.includes("cache-fix-ca-scratch-keepme.sha256"),
               `the reaper took a name that is not its own: ${left}`);
     assert.ok(left.includes("cache-fix-proxy-healthcheck.sha256"),

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -14,6 +14,7 @@ import { HOP_ENV, freePort, onPort } from "./proc-helpers.mjs";
 
 const LAUNCHER = fileURLToPath(new URL("../bin/claude-via-proxy.mjs", import.meta.url));
 const SRC = readFileSync(LAUNCHER, "utf-8");
+const rec = (port) => `${recordConst("RECORD_PREFIX")}${port}${recordConst("RECORD_SUFFIX")}`;
 
 // Brace-counted, not regex: a lazy match stops at an inner block's close and
 // yields a fragment that fails as a SyntaxError rather than a named assertion.
@@ -33,7 +34,12 @@ function lift(decl) {
 // touched. Every callee comes with it.
 function runReaper(dir) {
   return new Function("readdirSync", "statSync", "rmSync", "join", "tmpdir", "net", "bindAddr",
-    `const RECORD_PREFIX = ${JSON.stringify(recordPrefix())};\n` +
+    `const RECORD_PREFIX = ${JSON.stringify(recordConst("RECORD_PREFIX"))};\n` +
+    `const RECORD_SUFFIX = ${JSON.stringify(recordConst("RECORD_SUFFIX"))};\n` +
+    // Verbatim, not a copy of the number: the inner catch swallows a
+    // ReferenceError, so a constant this harness forgets to inject makes the
+    // reaper collect NOTHING while every case still reports what it expected.
+    `const REAP_AGE_MS = ${ageGate()};\n` +
     `${lift("function portFree(")}\n` +
     `${lift("async function reapFingerprintRecords()")}\nreturn reapFingerprintRecords();`
   )(readdirSync, statSync, rmSync, join, () => dir, net, () => "127.0.0.1");
@@ -53,6 +59,13 @@ test("the reap is driven by the supervisor, and off its startup path", () => {
   assert.match(hold, /setTimeout\(reapFingerprintRecords, 0\)\.unref\(\)/,
                "the reap runs inline on the supervisor's startup path; a tmpdir scan " +
                "there delays the bind and destabilises the held-port suite");
+  // Deferring alone does not stop it blocking: nothing the loop awaits reaches
+  // the poll phase, so without a periodic yield the scan holds the event loop
+  // between the bind and the first accept. Measured at 300 records: a
+  // setImmediate queued first fires 13 ms into a 28 ms scan with the yield, and
+  // not at all without it, at no cost to the total.
+  assert.match(lift("async function reapFingerprintRecords()"), /await new Promise\(setImmediate\)/,
+               "the scan never yields, so it holds the event loop for its whole pass");
 });
 
 // AGE ALONE MAKES SEVEN DAYS A DEADLINE, NOT A MARGIN. Nothing republishes a
@@ -130,6 +143,19 @@ test("a launcher that binds reaps on the way up", { timeout: 30_000 }, async () 
   }
 });
 
+// THE CEILING IS INVISIBLE FROM THE DIRECTORY. Without it listen() throws
+// ERR_SOCKET_BAD_PORT, the reaper's inner catch keeps the record, and a fixture
+// asserting "the record survived" passes either way — measured, that case stayed
+// green with the guard deleted. Asked of the predicate the two differ: answer
+// false, or reject.
+test("portFree answers false outside the port range, rather than throwing", async () => {
+  const portFree = new Function("net", "bindAddr",
+    `${lift("function portFree(")}\nreturn portFree;`)(net, () => "127.0.0.1");
+  assert.equal(await portFree("70000"), false, "a port above 65535 reached listen()");
+  assert.equal(await portFree("0"), false, "port 0 reached listen(), which takes a random port");
+  assert.equal(await portFree("-1"), false);
+});
+
 test("a stale record is removed, and anything a live holder may still own is kept", async () => {
   const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-"));
   try {
@@ -155,9 +181,15 @@ test("a stale record is removed, and anything a live holder may still own is kep
     // reaper's to judge, and asking the kernel to bind NaN throws rather than
     // answering.
     const unparsed = join(dir, "cache-fix-proxy-healthcheck.sha256");
-    for (const p of [stale, fresh, longLived, nearGate, alien, inflight, unparsed]) writeFileSync(p, "x");
+    // The range edges, both over-age so they DO reach portFree. Port 0 is a name
+    // older launcher versions demonstrably wrote, and it is the worst one to get
+    // wrong: listen(0) binds a random free port and always succeeds, so without
+    // the floor the probe would call every port-0 record collectable.
+    const zero = join(dir, "cache-fix-proxy-0.sha256");
+    for (const p of [stale, fresh, longLived, nearGate, alien, inflight, unparsed, zero]) writeFileSync(p, "x");
     const age = (p, days) => utimesSync(p, Date.now() / 1000 - days * 86400, Date.now() / 1000 - days * 86400);
     age(stale, 8); age(longLived, 3); age(nearGate, 6); age(alien, 8); age(inflight, 8); age(unparsed, 8);
+    age(zero, 8);
 
     await runReaper(dir);
 
@@ -174,17 +206,28 @@ test("a stale record is removed, and anything a live holder may still own is kep
               `the reaper took a name that is not its own: ${left}`);
     assert.ok(left.includes("cache-fix-proxy-healthcheck.sha256"),
               `the reaper judged a name it cannot parse a port out of: ${left}`);
+    assert.ok(left.includes("cache-fix-proxy-0.sha256"),
+              `port 0 was probed: listen(0) takes a random port and always succeeds — ${left}`);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-// The writer and the reaper must read one constant, or they drift apart on any
-// platform whose separator is not "/".
-function recordPrefix() {
-  const m = SRC.match(/const RECORD_PREFIX = "([^"]+)";/);
-  assert.ok(m, "RECORD_PREFIX is gone — the writer and the reaper can drift apart again");
-  assert.ok(lift("function fingerprintPath(").includes("RECORD_PREFIX"),
-            "fingerprintPath no longer builds the name from RECORD_PREFIX");
+// BOTH HALVES OF THE NAME, from the launcher's own constants. A hardcoded copy
+// here drifts silently the other way: the reaper would match nothing and collect
+// nothing, with every case in this file still green.
+function ageGate() {
+  const m = SRC.match(/const REAP_AGE_MS = ([^;]+);/);
+  assert.ok(m, "REAP_AGE_MS is gone — the two reapers can drift to different gates");
+  assert.match(lift("async function reapFingerprintRecords()"), /REAP_AGE_MS/,
+               "the reaper no longer reads the shared gate");
+  return m[1];
+}
+
+function recordConst(name) {
+  const m = SRC.match(new RegExp(`const ${name} = "([^"]+)";`));
+  assert.ok(m, `${name} is gone — the writer and the reaper can drift apart again`);
+  assert.ok(lift("function fingerprintPath(").includes(name),
+            `fingerprintPath no longer builds the name from ${name}`);
   return m[1];
 }

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import net, { createServer } from "node:net";
+import net from "node:net";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 import { HOP_ENV, freePort, onPort } from "./proc-helpers.mjs";
@@ -63,7 +63,7 @@ test("the reap is driven by the supervisor, and off its startup path", () => {
 // cannot be.
 test("a record whose port still has a listener is kept however old it is", async () => {
   const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-live-"));
-  const srv = createServer();
+  const srv = net.createServer();
   try {
     await new Promise((r) => srv.listen(0, "127.0.0.1", r));
     const port = srv.address().port;
@@ -130,25 +130,6 @@ test("a launcher that binds reaps on the way up", { timeout: 30_000 }, async () 
   }
 });
 
-// A NAME WHOSE PORT IS NOT A NUMBER is not this reaper's to judge, and asking
-// the kernel to bind NaN throws rather than answering.
-test("a record whose port is not a number is kept", async () => {
-  const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-nan-"));
-  try {
-    const odd = join(dir, "cache-fix-proxy-healthcheck.sha256");
-    writeFileSync(odd, "x");
-    const old = Date.now() / 1000 - 30 * 86400;
-    utimesSync(odd, old, old);
-
-    await runReaper(dir);
-
-    assert.ok(readdirSync(dir).includes("cache-fix-proxy-healthcheck.sha256"),
-              "the reaper judged a name it cannot parse a port out of");
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
 test("a stale record is removed, and anything a live holder may still own is kept", async () => {
   const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-"));
   try {
@@ -170,9 +151,13 @@ test("a stale record is removed, and anything a live holder may still own is kep
     // Ends in .sha256 on purpose: with any other suffix endsWith() alone saves
     // it and an empty prefix would pass.
     const alien = join(dir, "cache-fix-ca-scratch-keepme.sha256");
-    for (const p of [stale, fresh, longLived, nearGate, alien, inflight]) writeFileSync(p, "x");
+    // Over-age, so it DOES reach portFree: a name with no port in it is not this
+    // reaper's to judge, and asking the kernel to bind NaN throws rather than
+    // answering.
+    const unparsed = join(dir, "cache-fix-proxy-healthcheck.sha256");
+    for (const p of [stale, fresh, longLived, nearGate, alien, inflight, unparsed]) writeFileSync(p, "x");
     const age = (p, days) => utimesSync(p, Date.now() / 1000 - days * 86400, Date.now() / 1000 - days * 86400);
-    age(stale, 8); age(longLived, 3); age(nearGate, 6); age(alien, 8); age(inflight, 8);
+    age(stale, 8); age(longLived, 3); age(nearGate, 6); age(alien, 8); age(inflight, 8); age(unparsed, 8);
 
     await runReaper(dir);
 
@@ -187,6 +172,8 @@ test("a stale record is removed, and anything a live holder may still own is kep
               `the reaper took a concurrent launcher's pending write — ${left}`);
     assert.ok(left.includes("cache-fix-ca-scratch-keepme.sha256"),
               `the reaper took a name that is not its own: ${left}`);
+    assert.ok(left.includes("cache-fix-proxy-healthcheck.sha256"),
+              `the reaper judged a name it cannot parse a port out of: ${left}`);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -39,6 +39,17 @@ function runReaper(dir) {
   )(readdirSync, statSync, rmSync, join, () => dir, net, () => "127.0.0.1");
 }
 
+// A FIXED PORT SITS INSIDE THE EPHEMERAL RANGE, so a sibling test's launcher can
+// be handed one and hold it for a whole run; portFree then answers false and the
+// reaper correctly keeps a record these cases expect reaped. A port the kernel
+// has just released is the last one it hands out again.
+function releasedPort() {
+  return new Promise((res) => {
+    const s = createServer();
+    s.listen(0, "127.0.0.1", () => { const port = s.address().port; s.close(() => res(port)); });
+  });
+}
+
 test("the launcher carries a reaper for its own fingerprint records", () => {
   assert.match(SRC, /const\s+recordAgeMs\s*=/,
                "no fingerprint reaper found in claude-via-proxy.mjs — this test guards nothing");
@@ -73,7 +84,8 @@ test("a record whose port still has a listener is kept however old it is", async
     await new Promise((r) => srv.listen(0, "127.0.0.1", r));
     const port = srv.address().port;
     const live = join(dir, `cache-fix-proxy-${port}.sha256`);
-    const dead = join(dir, "cache-fix-proxy-40404.sha256");
+    const deadPort = await releasedPort();
+    const dead = join(dir, `cache-fix-proxy-${deadPort}.sha256`);
     for (const p of [live, dead]) writeFileSync(p, "x");
     const old = Date.now() / 1000 - 30 * 86400;
     for (const p of [live, dead]) utimesSync(p, old, old);
@@ -83,7 +95,7 @@ test("a record whose port still has a listener is kept however old it is", async
     const left = readdirSync(dir);
     assert.ok(left.includes(`cache-fix-proxy-${port}.sha256`),
               `the reaper deleted a live holder's record: ${left}`);
-    assert.ok(!left.includes("cache-fix-proxy-40404.sha256"),
+    assert.ok(!left.includes(`cache-fix-proxy-${deadPort}.sha256`),
               `a record for a port nothing listens on survived: ${left}`);
   } finally {
     srv.close();
@@ -98,16 +110,13 @@ test("a launcher that binds reaps on the way up", { timeout: 30_000 }, async () 
   const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-e2e-"));
   let child = null, port = 0;
   try {
-    const stale = join(dir, "cache-fix-proxy-40808.sha256");
+    const stalePort = await releasedPort();
+    const stale = join(dir, `cache-fix-proxy-${stalePort}.sha256`);
     writeFileSync(stale, "x");
     const old = Date.now() / 1000 - 30 * 86400;
     utimesSync(stale, old, old);
 
-    port = await new Promise((res) => {
-      const s = createServer().listen(0, "127.0.0.1", () => {
-        const p = s.address().port; s.close(() => res(p));
-      });
-    });
+    port = await releasedPort();
     const env = { ...process.env, TMPDIR: dir, CACHE_FIX_PROXY_PORT: String(port),
                   CACHE_FIX_FORWARD_PROXY: "on", CACHE_FIX_SELF_HEAL: "off" };
     for (const k of ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"]) delete env[k];
@@ -151,17 +160,21 @@ test("a record whose port is not a number is kept", async () => {
 test("a stale record is removed, and anything a live holder may still own is kept", async () => {
   const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-"));
   try {
-    const stale = join(dir, "cache-fix-proxy-40001.sha256");
-    const fresh = join(dir, "cache-fix-proxy-40002.sha256");
+    const stalePort = await releasedPort();
+    const stale = join(dir, `cache-fix-proxy-${stalePort}.sha256`);
+    // Fixed numbers, below the ephemeral floor so they cannot collide with the
+    // derived one above: none of these four reaches portFree, so only the name
+    // has to be distinct.
+    const fresh = join(dir, "cache-fix-proxy-30002.sha256");
     // A holder that merely lives long: nothing republishes, so its mtime is its
     // launch time and a short gate would reap a live proxy's own record.
-    const longLived = join(dir, "cache-fix-proxy-40003.sha256");
+    const longLived = join(dir, "cache-fix-proxy-30003.sha256");
     // Just inside the gate: pins the number, not merely its sign.
-    const nearGate = join(dir, "cache-fix-proxy-40005.sha256");
+    const nearGate = join(dir, "cache-fix-proxy-30005.sha256");
     // A concurrent launcher's in-flight write. publishFingerprint writes
     // `<record>.<pid>` and renames; that name carries RECORD_PREFIX, so only the
     // suffix check stands between this reaper and someone else's pending rename.
-    const inflight = join(dir, "cache-fix-proxy-40006.sha256.99999");
+    const inflight = join(dir, "cache-fix-proxy-30006.sha256.99999");
     // Ends in .sha256 on purpose: with any other suffix endsWith() alone saves
     // it and an empty prefix would pass.
     const alien = join(dir, "cache-fix-ca-scratch-keepme.sha256");
@@ -172,13 +185,13 @@ test("a stale record is removed, and anything a live holder may still own is kep
     await runReaper(dir);
 
     const left = readdirSync(dir).sort();
-    assert.ok(!left.includes("cache-fix-proxy-40001.sha256"), `the stale record survived: ${left}`);
-    assert.ok(left.includes("cache-fix-proxy-40002.sha256"), `the fresh record was removed: ${left}`);
-    assert.ok(left.includes("cache-fix-proxy-40003.sha256"),
+    assert.ok(!left.includes(`cache-fix-proxy-${stalePort}.sha256`), `the stale record survived: ${left}`);
+    assert.ok(left.includes("cache-fix-proxy-30002.sha256"), `the fresh record was removed: ${left}`);
+    assert.ok(left.includes("cache-fix-proxy-30003.sha256"),
               `a 3-day-old record was reaped: a holder up that long loses its own record — ${left}`);
-    assert.ok(left.includes("cache-fix-proxy-40005.sha256"),
+    assert.ok(left.includes("cache-fix-proxy-30005.sha256"),
               `a 6-day-old record was reaped: the gate is shorter than 7 days — ${left}`);
-    assert.ok(left.includes("cache-fix-proxy-40006.sha256.99999"),
+    assert.ok(left.includes("cache-fix-proxy-30006.sha256.99999"),
               `the reaper took a concurrent launcher's pending write — ${left}`);
     assert.ok(left.includes("cache-fix-ca-scratch-keepme.sha256"),
               `the reaper took a name that is not its own: ${left}`);

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { createServer } from "node:net";
 import { fileURLToPath } from "node:url";
 import { execFileSync, spawn } from "node:child_process";
+import { onPort } from "./proc-helpers.mjs";
 
 const LAUNCHER = fileURLToPath(new URL("../bin/claude-via-proxy.mjs", import.meta.url));
 const SRC = readFileSync(LAUNCHER, "utf-8");
@@ -96,14 +97,14 @@ test("a record whose port still has a listener is kept however old it is", async
 // This one spawns the real thing.
 test("a launcher that binds reaps on the way up", { timeout: 30_000 }, async () => {
   const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-e2e-"));
-  let child = null;
+  let child = null, port = 0;
   try {
     const stale = join(dir, "cache-fix-proxy-40808.sha256");
     writeFileSync(stale, "x");
     const old = Date.now() / 1000 - 30 * 86400;
     utimesSync(stale, old, old);
 
-    const port = await new Promise((res) => {
+    port = await new Promise((res) => {
       const s = createServer().listen(0, "127.0.0.1", () => {
         const p = s.address().port; s.close(() => res(p));
       });
@@ -118,7 +119,13 @@ test("a launcher that binds reaps on the way up", { timeout: 30_000 }, async () 
     assert.ok(!existsSync(stale),
               "the launcher bound its port and never reaped — the call is unreachable");
   } finally {
+    // THE HOLDER IS NOT THE ONLY PROCESS THIS STARTED. run-service spawns a
+    // DETACHED standby gap-relay that only stands down for a claimant's SIGHUP,
+    // so killing the launcher reparents it to init still holding the port —
+    // measured, one per run. Holder first, then whatever is left on the port,
+    // the order proxy-held-port's own sweep documents.
     if (child) { try { child.kill("SIGKILL"); } catch { /* already gone */ } }
+    for (const p of onPort(port)) { try { process.kill(Number(p), "SIGKILL"); } catch { /* gone */ } }
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -1,0 +1,116 @@
+// A fingerprint record must not outlive every proxy that could read it.
+//
+// `publishFingerprint(port)` writes `cache-fix-proxy-<port>.sha256` before each
+// spawn and nothing removed it. The port is ephemeral wherever the OS picks it,
+// so the records accumulate one per proxy start, forever. Measured on a
+// long-lived container 2026-08-20: 6,743 records, 461 a day. `runningOurCode`
+// assumed systemd-tmpfiles sweeps /tmp; that host has zsh as PID 1 and no
+// sweeper. The cost is not the 284 KB — the launcher's own scratch reaper walks
+// `readdirSync(tmpdir())` on every start, 117 ms at 74,493 entries.
+//
+// This file lifts the shipped source and runs it, the way
+// proxy-held-port.test.mjs lifts holderPidOn: the assert on each slice is the
+// control, so a rename fails the test instead of quietly testing nothing.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const LAUNCHER = fileURLToPath(new URL("../bin/claude-via-proxy.mjs", import.meta.url));
+const SRC = readFileSync(LAUNCHER, "utf-8");
+
+// A lazy regex stopped at the first `\n}` — an inner block's close — and
+// produced an unbalanced fragment that failed only as a SyntaxError inside
+// new Function(). Count braces.
+function lift(decl) {
+  const start = SRC.indexOf(decl);
+  assert.ok(start >= 0, `${decl} is gone from the launcher — this test guards nothing`);
+  let depth = 0, end = -1;
+  for (let i = SRC.indexOf("{", start); i < SRC.length; i++) {
+    if (SRC[i] === "{") depth++;
+    else if (SRC[i] === "}" && --depth === 0) { end = i + 1; break; }
+  }
+  assert.ok(end > start, `could not lift ${decl} whole — this test guards nothing`);
+  return SRC.slice(start, end);
+}
+
+test("the launcher carries a reaper for its own fingerprint records", () => {
+  assert.match(SRC, /const\s+recordAgeMs\s*=/,
+               "no fingerprint reaper found in claude-via-proxy.mjs — this test guards nothing");
+});
+
+// ONCE PER LAUNCHER PROCESS, NOT ONCE PER SPAWN. publishFingerprint runs on
+// every respawn — the restart ladder is documented at 51 spawns in 1.2 s — and
+// each reap is a full readdirSync(tmpdir()). It also opens with `if (!fp)
+// return;`, so reaping from there stops exactly when publishing is persistently
+// broken: the mistake the sibling CA reaper documents ("Sharing that block made
+// reaping conditional on the rename succeeding").
+test("the reap is driven by the supervisor, and off its startup path", () => {
+  const hold = lift("function holdPort(");
+  assert.ok(hold.includes("reapFingerprintRecords"),
+            "holdPort does not reap — the records are never collected");
+  assert.ok(!lift("function publishFingerprint(").includes("reapFingerprintRecords"),
+            "publishFingerprint reaps, so it is skipped whenever publishing fails and " +
+            "repeated on every respawn");
+  // DEFERRED, and this is measured, not taste. Calling it inline costs one
+  // readdirSync(tmpdir()) before the bind — 135-193 ms at the 68,533 entries
+  // this box carries. Interleaved against upstream/main at one load,
+  // test/proxy-held-port.test.mjs failed 2 of 10 runs with the scan inline and
+  // 0 of 5 with the same diff's scan body disabled; upstream/main was 0 of 14.
+  // Nothing reads the result, so nothing has to wait for it.
+  assert.match(hold, /setTimeout\(reapFingerprintRecords, 0\)\.unref\(\)/,
+               "the reap runs inline on the supervisor's startup path; a tmpdir scan " +
+               "there delays the bind and destabilises the held-port suite");
+});
+
+test("a stale record is removed, and anything a live holder may still own is kept", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-"));
+  try {
+    const stale = join(dir, "cache-fix-proxy-40001.sha256");
+    const fresh = join(dir, "cache-fix-proxy-40002.sha256");
+    // A HOLDER THAT MERELY LIVES LONG. Nothing republishes a record: the one
+    // call site is the spawn path, so an unrestarted holder's mtime is its
+    // launch time. Reaping it makes runningOurCode() answer null, and the
+    // launcher's own comment says where that ends — "a swept /tmp turned a
+    // deploy into a no-op that read as a success".
+    const longLived = join(dir, "cache-fix-proxy-40003.sha256");
+    // PREFIX DISCIPLINE, the mistake the CA reaper already paid for once. It
+    // ends in .sha256 on purpose: with any other suffix the endsWith() check
+    // alone saves it, and an empty prefix would pass this test.
+    const alien = join(dir, "cache-fix-ca-scratch-keepme.sha256");
+    for (const p of [stale, fresh, longLived, alien]) writeFileSync(p, "x");
+    const age = (p, days) => utimesSync(p, Date.now() / 1000 - days * 86400, Date.now() / 1000 - days * 86400);
+    age(stale, 8); age(longLived, 3); age(alien, 8);
+
+    // EVERY CALLEE COMES TOO, and tmpdir() is rebound to the scratch dir so the
+    // real temp directory is never touched.
+    const run = new Function("readdirSync", "statSync", "rmSync", "join", "tmpdir",
+      `const RECORD_PREFIX = ${JSON.stringify(recordPrefix())};\n` +
+      `${lift("function reapFingerprintRecords()")}\nreturn reapFingerprintRecords();`);
+    run(readdirSync, statSync, rmSync, join, () => dir);
+
+    const left = readdirSync(dir).sort();
+    assert.ok(!left.includes("cache-fix-proxy-40001.sha256"), `the stale record survived: ${left}`);
+    assert.ok(left.includes("cache-fix-proxy-40002.sha256"), `the fresh record was removed: ${left}`);
+    assert.ok(left.includes("cache-fix-proxy-40003.sha256"),
+              `a 3-day-old record was reaped: a holder up that long loses its own record — ${left}`);
+    assert.ok(left.includes("cache-fix-ca-scratch-keepme.sha256"),
+              `the reaper took a name that is not its own: ${left}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ONE CONSTANT, TWO SITES — the writer and the reaper. Deriving the reaper's
+// prefix from fingerprintPath() at runtime read `head.lastIndexOf("/")`, which
+// is -1 on Windows: the whole absolute path became the prefix and no basename
+// from readdirSync ever matched, so the reaper was a silent no-op there.
+function recordPrefix() {
+  const m = SRC.match(/const RECORD_PREFIX = "([^"]+)";/);
+  assert.ok(m, "RECORD_PREFIX is gone — the writer and the reaper can drift apart again");
+  assert.ok(lift("function fingerprintPath(").includes("RECORD_PREFIX"),
+            "fingerprintPath no longer builds the name from RECORD_PREFIX");
+  return m[1];
+}

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -14,7 +14,6 @@ import { HOP_ENV, freePort, onPort } from "./proc-helpers.mjs";
 
 const LAUNCHER = fileURLToPath(new URL("../bin/claude-via-proxy.mjs", import.meta.url));
 const SRC = readFileSync(LAUNCHER, "utf-8");
-const rec = (port) => `${recordConst("RECORD_PREFIX")}${port}${recordConst("RECORD_SUFFIX")}`;
 
 // Brace-counted, not regex: a lazy match stops at an inner block's close and
 // yields a fragment that fails as a SyntaxError rather than a named assertion.
@@ -54,8 +53,6 @@ test("the reap is driven by the supervisor, and off its startup path", () => {
   assert.ok(!lift("function publishFingerprint(").includes("reapFingerprintRecords"),
             "publishFingerprint reaps, so it is skipped whenever publishing fails and " +
             "repeated on every respawn");
-  // Deferred: run inline the tmpdir scan delays the bind and destabilises the
-  // held-port suite. Nothing reads the result.
   assert.match(hold, /setTimeout\(reapFingerprintRecords, 0\)\.unref\(\)/,
                "the reap runs inline on the supervisor's startup path; a tmpdir scan " +
                "there delays the bind and destabilises the held-port suite");

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -4,7 +4,7 @@
 // asserted, so a rename fails the test instead of quietly testing nothing.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import net from "node:net";
@@ -31,7 +31,7 @@ function lift(decl) {
 
 // tmpdir() is rebound to the scratch dir, so the real temp directory is never
 // touched. Every callee comes with it.
-function runReaper(dir) {
+function runReaper(dir, statFn = statSync) {
   return new Function("readdirSync", "statSync", "rmSync", "join", "tmpdir", "net", "bindAddr",
     `const RECORD_PREFIX = ${JSON.stringify(recordConst("RECORD_PREFIX"))};\n` +
     `const RECORD_SUFFIX = ${JSON.stringify(recordConst("RECORD_SUFFIX"))};\n` +
@@ -41,7 +41,7 @@ function runReaper(dir) {
     `const REAP_AGE_MS = ${ageGate()};\n` +
     `${lift("function portFree(")}\n` +
     `${lift("async function reapFingerprintRecords()")}\nreturn reapFingerprintRecords();`
-  )(readdirSync, statSync, rmSync, join, () => dir, net, () => "127.0.0.1");
+  )(readdirSync, statFn, rmSync, join, () => dir, net, () => "127.0.0.1");
 }
 
 // Once per launcher process, not once per spawn, and not behind
@@ -134,6 +134,44 @@ test("onPort(0) selects nothing, and still selects on a real port", async () => 
       "onPort(0) selected a process carrying CACHE_FIX_PROXY_PORT=0; the sweep would SIGKILL the live proxy");
   } finally {
     for (const c of kids) { try { c.kill("SIGKILL"); } catch { /* gone */ } }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a record republished during the port probe is not reaped", async () => {
+  // stat -> age check -> AWAIT portFree() -> rm. Another launcher publishes by
+  // renaming `<record>.<pid>` over the record, and that await is wide enough to
+  // land inside: the unlink then takes a decision made about a file that is no
+  // longer there. Losing a FRESH record is not cosmetic -- runningOurCode()
+  // answers null for the port, holderVerdict() reads unknown as an incumbent of
+  // ours, and takeOver() exits 0 announcing a deploy that has not taken effect.
+  const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-race-"));
+  try {
+    const port = await freePort();
+    const rec = join(dir, `cache-fix-proxy-${port}.sha256`);
+    writeFileSync(rec, "stale");
+    const old = Date.now() / 1000 - 30 * 86400;
+    utimesSync(rec, old, old);
+
+    let republished = false;
+    const racingStat = (target, ...rest) => {
+      const st = statSync(target, ...rest);
+      if (!republished && String(target) === rec) {
+        republished = true;
+        const tmp = `${rec}.99999`;
+        writeFileSync(tmp, "fresh");
+        renameSync(tmp, rec);
+      }
+      return st;                       // the STALE stat the reaper decided on
+    };
+    await runReaper(dir, racingStat);
+
+    assert.ok(republished, "premise: the injected publish never fired");
+    assert.ok(existsSync(rec),
+              "the reaper unlinked a record republished during the port probe");
+    assert.equal(readFileSync(rec, "utf8"), "fresh",
+                 "a record survived, but it is not the republished one");
+  } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -1,16 +1,7 @@
-// A fingerprint record must not outlive every proxy that could read it.
-//
-// `publishFingerprint(port)` writes `cache-fix-proxy-<port>.sha256` before each
-// spawn and nothing removed it. The port is ephemeral wherever the OS picks it,
-// so the records accumulate one per proxy start, forever. Measured on a
-// long-lived container 2026-08-20: 6,743 records, 461 a day. `runningOurCode`
-// assumed systemd-tmpfiles sweeps /tmp; that host has zsh as PID 1 and no
-// sweeper. The cost is not the 284 KB — the launcher's own scratch reaper walks
-// `readdirSync(tmpdir())` on every start, 117 ms at 74,493 entries.
-//
-// This file lifts the shipped source and runs it, the way
-// proxy-held-port.test.mjs lifts holderPidOn: the assert on each slice is the
-// control, so a rename fails the test instead of quietly testing nothing.
+// The launcher leaks one `cache-fix-proxy-<port>.sha256` per proxy start and
+// nothing removed them. These tests lift the shipped reaper out of the launcher
+// and run it, the way proxy-held-port.test.mjs lifts holderPidOn: every slice is
+// asserted, so a rename fails the test instead of quietly testing nothing.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
@@ -21,9 +12,8 @@ import { fileURLToPath } from "node:url";
 const LAUNCHER = fileURLToPath(new URL("../bin/claude-via-proxy.mjs", import.meta.url));
 const SRC = readFileSync(LAUNCHER, "utf-8");
 
-// A lazy regex stopped at the first `\n}` — an inner block's close — and
-// produced an unbalanced fragment that failed only as a SyntaxError inside
-// new Function(). Count braces.
+// Brace-counted, not regex: a lazy match stops at an inner block's close and
+// yields a fragment that fails as a SyntaxError rather than a named assertion.
 function lift(decl) {
   const start = SRC.indexOf(decl);
   assert.ok(start >= 0, `${decl} is gone from the launcher — this test guards nothing`);
@@ -41,12 +31,8 @@ test("the launcher carries a reaper for its own fingerprint records", () => {
                "no fingerprint reaper found in claude-via-proxy.mjs — this test guards nothing");
 });
 
-// ONCE PER LAUNCHER PROCESS, NOT ONCE PER SPAWN. publishFingerprint runs on
-// every respawn — the restart ladder is documented at 51 spawns in 1.2 s — and
-// each reap is a full readdirSync(tmpdir()). It also opens with `if (!fp)
-// return;`, so reaping from there stops exactly when publishing is persistently
-// broken: the mistake the sibling CA reaper documents ("Sharing that block made
-// reaping conditional on the rename succeeding").
+// Once per launcher process, not once per spawn, and not behind
+// publishFingerprint's early return.
 test("the reap is driven by the supervisor, and off its startup path", () => {
   const hold = lift("function holdPort(");
   assert.ok(hold.includes("reapFingerprintRecords"),
@@ -54,12 +40,8 @@ test("the reap is driven by the supervisor, and off its startup path", () => {
   assert.ok(!lift("function publishFingerprint(").includes("reapFingerprintRecords"),
             "publishFingerprint reaps, so it is skipped whenever publishing fails and " +
             "repeated on every respawn");
-  // DEFERRED, and this is measured, not taste. Calling it inline costs one
-  // readdirSync(tmpdir()) before the bind — 135-193 ms at the 68,533 entries
-  // this box carries. Interleaved against upstream/main at one load,
-  // test/proxy-held-port.test.mjs failed 2 of 10 runs with the scan inline and
-  // 0 of 5 with the same diff's scan body disabled; upstream/main was 0 of 14.
-  // Nothing reads the result, so nothing has to wait for it.
+  // Deferred: run inline the tmpdir scan delays the bind and destabilises the
+  // held-port suite. Nothing reads the result.
   assert.match(hold, /setTimeout\(reapFingerprintRecords, 0\)\.unref\(\)/,
                "the reap runs inline on the supervisor's startup path; a tmpdir scan " +
                "there delays the bind and destabilises the held-port suite");
@@ -70,22 +52,18 @@ test("a stale record is removed, and anything a live holder may still own is kep
   try {
     const stale = join(dir, "cache-fix-proxy-40001.sha256");
     const fresh = join(dir, "cache-fix-proxy-40002.sha256");
-    // A HOLDER THAT MERELY LIVES LONG. Nothing republishes a record: the one
-    // call site is the spawn path, so an unrestarted holder's mtime is its
-    // launch time. Reaping it makes runningOurCode() answer null, and the
-    // launcher's own comment says where that ends — "a swept /tmp turned a
-    // deploy into a no-op that read as a success".
+    // A holder that merely lives long: nothing republishes, so its mtime is its
+    // launch time and a short gate would reap a live proxy's own record.
     const longLived = join(dir, "cache-fix-proxy-40003.sha256");
-    // PREFIX DISCIPLINE, the mistake the CA reaper already paid for once. It
-    // ends in .sha256 on purpose: with any other suffix the endsWith() check
-    // alone saves it, and an empty prefix would pass this test.
+    // Ends in .sha256 on purpose: with any other suffix endsWith() alone saves
+    // it and an empty prefix would pass.
     const alien = join(dir, "cache-fix-ca-scratch-keepme.sha256");
     for (const p of [stale, fresh, longLived, alien]) writeFileSync(p, "x");
     const age = (p, days) => utimesSync(p, Date.now() / 1000 - days * 86400, Date.now() / 1000 - days * 86400);
     age(stale, 8); age(longLived, 3); age(alien, 8);
 
-    // EVERY CALLEE COMES TOO, and tmpdir() is rebound to the scratch dir so the
-    // real temp directory is never touched.
+    // tmpdir() is rebound to the scratch dir; the real temp directory is never
+    // touched.
     const run = new Function("readdirSync", "statSync", "rmSync", "join", "tmpdir",
       `const RECORD_PREFIX = ${JSON.stringify(recordPrefix())};\n` +
       `${lift("function reapFingerprintRecords()")}\nreturn reapFingerprintRecords();`);
@@ -103,10 +81,8 @@ test("a stale record is removed, and anything a live holder may still own is kep
   }
 });
 
-// ONE CONSTANT, TWO SITES — the writer and the reaper. Deriving the reaper's
-// prefix from fingerprintPath() at runtime read `head.lastIndexOf("/")`, which
-// is -1 on Windows: the whole absolute path became the prefix and no basename
-// from readdirSync ever matched, so the reaper was a silent no-op there.
+// The writer and the reaper must read one constant, or they drift apart on any
+// platform whose separator is not "/".
 function recordPrefix() {
   const m = SRC.match(/const RECORD_PREFIX = "([^"]+)";/);
   assert.ok(m, "RECORD_PREFIX is gone — the writer and the reaper can drift apart again");

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -4,13 +4,16 @@
 // asserted, so a rename fails the test instead of quietly testing nothing.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { createServer } from "node:net";
 import { fileURLToPath } from "node:url";
+import { execFileSync, spawn } from "node:child_process";
 
 const LAUNCHER = fileURLToPath(new URL("../bin/claude-via-proxy.mjs", import.meta.url));
 const SRC = readFileSync(LAUNCHER, "utf-8");
+const realProbe = (cmd, args) => execFileSync(cmd, args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
 
 // Brace-counted, not regex: a lazy match stops at an inner block's close and
 // yields a fragment that fails as a SyntaxError rather than a named assertion.
@@ -24,6 +27,16 @@ function lift(decl) {
   }
   assert.ok(end > start, `could not lift ${decl} whole — this test guards nothing`);
   return SRC.slice(start, end);
+}
+
+// tmpdir() is rebound to the scratch dir, so the real temp directory is never
+// touched. Every callee comes with it.
+function runReaper(dir, probe = realProbe) {
+  new Function("readdirSync", "statSync", "rmSync", "join", "tmpdir", "probe",
+    `const RECORD_PREFIX = ${JSON.stringify(recordPrefix())};\n` +
+    `${lift("function listeningPorts()")}\n` +
+    `${lift("function reapFingerprintRecords()")}\nreturn reapFingerprintRecords();`
+  )(readdirSync, statSync, rmSync, join, () => dir, probe);
 }
 
 test("the launcher carries a reaper for its own fingerprint records", () => {
@@ -47,6 +60,89 @@ test("the reap is driven by the supervisor, and off its startup path", () => {
                "there delays the bind and destabilises the held-port suite");
 });
 
+// AGE ALONE MAKES SEVEN DAYS A DEADLINE, NOT A MARGIN. Nothing republishes a
+// record, so a holder that neither respawns nor is redeployed for a week has an
+// over-age record while fully live, and the next launcher to start would delete
+// it: runningOurCode() then answers null and takeOver() exits 0 announcing a
+// deploy that has not taken effect. A listening port is the discriminator age
+// cannot be.
+test("a record whose port still has a listener is kept however old it is", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-live-"));
+  const srv = createServer();
+  try {
+    await new Promise((r) => srv.listen(0, "127.0.0.1", r));
+    const port = srv.address().port;
+    const live = join(dir, `cache-fix-proxy-${port}.sha256`);
+    const dead = join(dir, "cache-fix-proxy-40404.sha256");
+    for (const p of [live, dead]) writeFileSync(p, "x");
+    const old = Date.now() / 1000 - 30 * 86400;
+    for (const p of [live, dead]) utimesSync(p, old, old);
+
+    runReaper(dir);
+
+    const left = readdirSync(dir);
+    assert.ok(left.includes(`cache-fix-proxy-${port}.sha256`),
+              `the reaper deleted a live holder's record: ${left}`);
+    assert.ok(!left.includes("cache-fix-proxy-40404.sha256"),
+              `a record for a port nothing listens on survived: ${left}`);
+  } finally {
+    srv.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// THE TESTS ABOVE ALL RUN LIFTED SOURCE, SO NONE OF THEM CAN SEE WHETHER THE
+// LAUNCHER EVER CALLS IT. Commenting the call out leaves every one of them green.
+// This one spawns the real thing.
+test("a launcher that binds reaps on the way up", { timeout: 30_000 }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-e2e-"));
+  let child = null;
+  try {
+    const stale = join(dir, "cache-fix-proxy-40808.sha256");
+    writeFileSync(stale, "x");
+    const old = Date.now() / 1000 - 30 * 86400;
+    utimesSync(stale, old, old);
+
+    const port = await new Promise((res) => {
+      const s = createServer().listen(0, "127.0.0.1", () => {
+        const p = s.address().port; s.close(() => res(p));
+      });
+    });
+    const env = { ...process.env, TMPDIR: dir, CACHE_FIX_PROXY_PORT: String(port),
+                  CACHE_FIX_FORWARD_PROXY: "on", CACHE_FIX_SELF_HEAL: "off" };
+    for (const k of ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"]) delete env[k];
+    child = spawn(process.execPath, [LAUNCHER, "run-service"], { env, stdio: "ignore" });
+
+    const deadline = Date.now() + 25_000;
+    while (existsSync(stale) && Date.now() < deadline) await new Promise((r) => setTimeout(r, 200));
+    assert.ok(!existsSync(stale),
+              "the launcher bound its port and never reaped — the call is unreachable");
+  } finally {
+    if (child) { try { child.kill("SIGKILL"); } catch { /* already gone */ } }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// A host with no lsof must keep everything rather than read "could not ask" as
+// "nothing is listening" — that reading hands the reaper every record on the box,
+// live holders included.
+test("a probe that cannot answer reaps nothing", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-nolsof-"));
+  try {
+    const rec = join(dir, "cache-fix-proxy-40707.sha256");
+    writeFileSync(rec, "x");
+    const old = Date.now() / 1000 - 30 * 86400;
+    utimesSync(rec, old, old);
+
+    runReaper(dir, () => { throw new Error("lsof: not found"); });
+
+    assert.ok(readdirSync(dir).includes("cache-fix-proxy-40707.sha256"),
+              "an unanswerable probe was read as 'nothing is listening' and the record was reaped");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("a stale record is removed, and anything a live holder may still own is kept", () => {
   const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-"));
   try {
@@ -55,25 +151,30 @@ test("a stale record is removed, and anything a live holder may still own is kep
     // A holder that merely lives long: nothing republishes, so its mtime is its
     // launch time and a short gate would reap a live proxy's own record.
     const longLived = join(dir, "cache-fix-proxy-40003.sha256");
+    // Just inside the gate: pins the number, not merely its sign.
+    const nearGate = join(dir, "cache-fix-proxy-40005.sha256");
+    // A concurrent launcher's in-flight write. publishFingerprint writes
+    // `<record>.<pid>` and renames; that name carries RECORD_PREFIX, so only the
+    // suffix check stands between this reaper and someone else's pending rename.
+    const inflight = join(dir, "cache-fix-proxy-40006.sha256.99999");
     // Ends in .sha256 on purpose: with any other suffix endsWith() alone saves
     // it and an empty prefix would pass.
     const alien = join(dir, "cache-fix-ca-scratch-keepme.sha256");
-    for (const p of [stale, fresh, longLived, alien]) writeFileSync(p, "x");
+    for (const p of [stale, fresh, longLived, nearGate, alien, inflight]) writeFileSync(p, "x");
     const age = (p, days) => utimesSync(p, Date.now() / 1000 - days * 86400, Date.now() / 1000 - days * 86400);
-    age(stale, 8); age(longLived, 3); age(alien, 8);
+    age(stale, 8); age(longLived, 3); age(nearGate, 6); age(alien, 8); age(inflight, 8);
 
-    // tmpdir() is rebound to the scratch dir; the real temp directory is never
-    // touched.
-    const run = new Function("readdirSync", "statSync", "rmSync", "join", "tmpdir",
-      `const RECORD_PREFIX = ${JSON.stringify(recordPrefix())};\n` +
-      `${lift("function reapFingerprintRecords()")}\nreturn reapFingerprintRecords();`);
-    run(readdirSync, statSync, rmSync, join, () => dir);
+    runReaper(dir);
 
     const left = readdirSync(dir).sort();
     assert.ok(!left.includes("cache-fix-proxy-40001.sha256"), `the stale record survived: ${left}`);
     assert.ok(left.includes("cache-fix-proxy-40002.sha256"), `the fresh record was removed: ${left}`);
     assert.ok(left.includes("cache-fix-proxy-40003.sha256"),
               `a 3-day-old record was reaped: a holder up that long loses its own record — ${left}`);
+    assert.ok(left.includes("cache-fix-proxy-40005.sha256"),
+              `a 6-day-old record was reaped: the gate is shorter than 7 days — ${left}`);
+    assert.ok(left.includes("cache-fix-proxy-40006.sha256.99999"),
+              `the reaper took a concurrent launcher's pending write — ${left}`);
     assert.ok(left.includes("cache-fix-ca-scratch-keepme.sha256"),
               `the reaper took a name that is not its own: ${left}`);
   } finally {

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -4,7 +4,7 @@
 // asserted, so a rename fails the test instead of quietly testing nothing.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import net from "node:net";
@@ -96,6 +96,44 @@ test("a record whose port still has a listener is kept however old it is", async
               `a record for a port nothing listens on survived: ${left}`);
   } finally {
     srv.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// Port 0 is the value `port` carries before freePort() assigns it, and the
+// finally below sweeps whatever onPort() returns. The marker ours() reads is
+// CACHE_FIX_PROXY_PORT, which a proxy child legitimately carries as 0 when it
+// inherits the holder's listening fd -- so a throw above the assignment aims
+// the sweep at the operator's live proxy. Measured on this host: 7 processes,
+// one of them the deployed ~/.local/share/cache-fix-fork/proxy/server.mjs.
+test("onPort(0) selects nothing, and still selects on a real port", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ccf-onport0-"));
+  const kids = [];
+  try {
+    mkdirSync(join(dir, "bin"));
+    const stub = join(dir, "bin", "stub.mjs");
+    writeFileSync(stub, "setInterval(() => {}, 1e9);\n");
+    const real = await freePort();
+    const spawnStub = (portValue) => {
+      const env = { ...process.env, CACHE_FIX_PROXY_PORT: String(portValue) };
+      for (const k of HOP_ENV) delete env[k];
+      const c = spawn(process.execPath, [stub], { env, stdio: "ignore" });
+      kids.push(c);
+      return c;
+    };
+    const zero = spawnStub(0);
+    const named = spawnStub(real);
+    for (const c of [zero, named]) await new Promise((r) => setTimeout(r, 50));
+
+    // THE CONTROL. Without it an empty onPort(0) proves nothing: a host with no
+    // proxy at all answers [] either way.
+    assert.ok(onPort(real).includes(String(named.pid)),
+      `the instrument cannot see a stub on its own port ${real} -- the case below is vacuous`);
+
+    assert.ok(!onPort(0).includes(String(zero.pid)),
+      "onPort(0) selected a process carrying CACHE_FIX_PROXY_PORT=0; the sweep would SIGKILL the live proxy");
+  } finally {
+    for (const c of kids) { try { c.kill("SIGKILL"); } catch { /* gone */ } }
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/test/proxy-fingerprint-reap.test.mjs
+++ b/test/proxy-fingerprint-reap.test.mjs
@@ -7,14 +7,13 @@ import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createServer } from "node:net";
+import net, { createServer } from "node:net";
 import { fileURLToPath } from "node:url";
-import { execFileSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import { onPort } from "./proc-helpers.mjs";
 
 const LAUNCHER = fileURLToPath(new URL("../bin/claude-via-proxy.mjs", import.meta.url));
 const SRC = readFileSync(LAUNCHER, "utf-8");
-const realProbe = (cmd, args) => execFileSync(cmd, args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
 
 // Brace-counted, not regex: a lazy match stops at an inner block's close and
 // yields a fragment that fails as a SyntaxError rather than a named assertion.
@@ -32,12 +31,12 @@ function lift(decl) {
 
 // tmpdir() is rebound to the scratch dir, so the real temp directory is never
 // touched. Every callee comes with it.
-function runReaper(dir, probe = realProbe) {
-  new Function("readdirSync", "statSync", "rmSync", "join", "tmpdir", "probe",
+function runReaper(dir) {
+  return new Function("readdirSync", "statSync", "rmSync", "join", "tmpdir", "net", "bindAddr",
     `const RECORD_PREFIX = ${JSON.stringify(recordPrefix())};\n` +
-    `${lift("function listeningPorts()")}\n` +
-    `${lift("function reapFingerprintRecords()")}\nreturn reapFingerprintRecords();`
-  )(readdirSync, statSync, rmSync, join, () => dir, probe);
+    `${lift("function portFree(")}\n` +
+    `${lift("async function reapFingerprintRecords()")}\nreturn reapFingerprintRecords();`
+  )(readdirSync, statSync, rmSync, join, () => dir, net, () => "127.0.0.1");
 }
 
 test("the launcher carries a reaper for its own fingerprint records", () => {
@@ -79,7 +78,7 @@ test("a record whose port still has a listener is kept however old it is", async
     const old = Date.now() / 1000 - 30 * 86400;
     for (const p of [live, dead]) utimesSync(p, old, old);
 
-    runReaper(dir);
+    await runReaper(dir);
 
     const left = readdirSync(dir);
     assert.ok(left.includes(`cache-fix-proxy-${port}.sha256`),
@@ -130,27 +129,26 @@ test("a launcher that binds reaps on the way up", { timeout: 30_000 }, async () 
   }
 });
 
-// A host with no lsof must keep everything rather than read "could not ask" as
-// "nothing is listening" — that reading hands the reaper every record on the box,
-// live holders included.
-test("a probe that cannot answer reaps nothing", () => {
-  const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-nolsof-"));
+// A NAME WHOSE PORT IS NOT A NUMBER is not this reaper's to judge, and asking
+// the kernel to bind NaN throws rather than answering.
+test("a record whose port is not a number is kept", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-nan-"));
   try {
-    const rec = join(dir, "cache-fix-proxy-40707.sha256");
-    writeFileSync(rec, "x");
+    const odd = join(dir, "cache-fix-proxy-healthcheck.sha256");
+    writeFileSync(odd, "x");
     const old = Date.now() / 1000 - 30 * 86400;
-    utimesSync(rec, old, old);
+    utimesSync(odd, old, old);
 
-    runReaper(dir, () => { throw new Error("lsof: not found"); });
+    await runReaper(dir);
 
-    assert.ok(readdirSync(dir).includes("cache-fix-proxy-40707.sha256"),
-              "an unanswerable probe was read as 'nothing is listening' and the record was reaped");
+    assert.ok(readdirSync(dir).includes("cache-fix-proxy-healthcheck.sha256"),
+              "the reaper judged a name it cannot parse a port out of");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("a stale record is removed, and anything a live holder may still own is kept", () => {
+test("a stale record is removed, and anything a live holder may still own is kept", async () => {
   const dir = mkdtempSync(join(tmpdir(), "ccf-fpreap-"));
   try {
     const stale = join(dir, "cache-fix-proxy-40001.sha256");
@@ -171,7 +169,7 @@ test("a stale record is removed, and anything a live holder may still own is kep
     const age = (p, days) => utimesSync(p, Date.now() / 1000 - days * 86400, Date.now() / 1000 - days * 86400);
     age(stale, 8); age(longLived, 3); age(nearGate, 6); age(alien, 8); age(inflight, 8);
 
-    runReaper(dir);
+    await runReaper(dir);
 
     const left = readdirSync(dir).sort();
     assert.ok(!left.includes("cache-fix-proxy-40001.sha256"), `the stale record survived: ${left}`);

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -45,6 +45,13 @@ const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", 
 // them, so the body is tested before the code.
 const OUTAGE = { REFUSED: "refused", RESET: "reset", DEGRADED: "degraded" };
 function classify(body) {
+  // A NUMBER IS NOT AN OUTAGE, AND MUST NOT BE A TypeError EITHER. Six of this
+  // file's seven probes resolve `ERR:${e.code}`; the seventh resolves a bare
+  // statusCode on success, and its caller filters out 200 and hands the rest
+  // here. Measured on CI Node 22: one 502 reached this line and the case died
+  // as `body.startsWith is not a function` — a crash where the answer is
+  // simply "that was a reply, not an outage".
+  if (typeof body !== "string") return null;
   if (!body.startsWith("ERR:")) return null;
   if (/"carrying"\s*:\s*"gap-relay"/.test(body)) return null;
   if (/"status"\s*:\s*"degraded"/.test(body)) return OUTAGE.DEGRADED;
@@ -124,6 +131,20 @@ async function freePort() {
 const CONCURRENCY = Math.max(1, Math.floor(availableParallelism() / 2));
 
 describe("held port (CACHE_FIX_HOLD_PORT)", { concurrency: CONCURRENCY }, () => {
+
+  // THE SEVENTH PROBE RESOLVES A NUMBER. Six of this file's probes resolve
+  // `ERR:${e.code}`; the one at the forced-kill case resolves a bare statusCode
+  // on success, and its caller filters out 200 and hands the rest to classify().
+  // A 502 therefore reaches it as a Number. Pinned as a unit case because the
+  // path only opens when a non-200 is actually observed — CI Node 22 saw one and
+  // the case died as `body.startsWith is not a function`, three runners apart
+  // from where it was introduced.
+  it("classify survives a probe that answers with a status code", () => {
+    assert.equal(classify(502), null, "a status code is a reply, not an outage");
+    assert.equal(classify(200), null);
+    assert.equal(classify("ERR:ECONNREFUSED"), OUTAGE.REFUSED);
+    assert.equal(classify("ECONNRESET"), null, "no ERR: prefix means it is not ours to classify");
+  });
 // The default is declared in proxy/config.mjs and repeated in the launcher.
 // If they drift, an unset CACHE_FIX_PROXY_PORT binds one port while callers
 // dial the other.

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -45,8 +45,10 @@ const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", 
 // them, so the body is tested before the code.
 const OUTAGE = { REFUSED: "refused", RESET: "reset", DEGRADED: "degraded" };
 function classify(body) {
-  // A NUMBER IS NOT AN OUTAGE, AND MUST NOT BE A TypeError EITHER — a probe that
-  // resolves a bare statusCode reaches here. See the unit case that pins it.
+  // A BOUNDARY GUARD, NOT A LIVE PATH: every caller now hands this an ERR: string,
+  // because health() replaced the probe that resolved a bare statusCode. Kept
+  // because this is a shared helper with a history of differently shaped probes,
+  // and the answer to one is "that was a reply, not an outage", not a TypeError.
   if (typeof body !== "string") return null;
   if (!body.startsWith("ERR:")) return null;
   if (/"carrying"\s*:\s*"gap-relay"/.test(body)) return null;

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -67,6 +67,12 @@ const health = (port) => new Promise((res) => {
   }).on("error", (e) => res(`ERR:${e.code}`));
 });
 
+// THE ONE TEST FOR "the holder is up", because 200 alone does not say who
+// answered. takePort() releases the port before the launcher binds it and every
+// worker draws ephemeral ports from one pool, so anything a sibling stands up on
+// 127.0.0.1:0 can be handed the same number and answer this probe.
+const readyBody = (b) => { try { return JSON.parse(b)?.status === "ok"; } catch { return false; } };
+
 const usedPorts = [];
 // The shared allocator plus this file's own cleanup registry — the registry is
 // file-local (its after() hook sweeps it), the allocation is not.
@@ -166,6 +172,21 @@ describe("held port (CACHE_FIX_HOLD_PORT)", { concurrency: CONCURRENCY }, () => 
     assert.equal(classify(await health(1)), OUTAGE.REFUSED,
                  "the forced-kill case's refusal count is empty whatever happens");
   });
+
+  // 200 IS NOT READINESS, AND THE PORT IS NOT OURS UNTIL THE HOLDER HAS IT.
+  // freePort() releases the port before the launcher binds it, and a sibling
+  // worker binding 0 draws from the same pool. Two files stand up a stand-in
+  // release channel that answers ANY path with 200 and a bare version string,
+  // and a version string is a JSON number followed by a dot: readiness that
+  // accepts any 200 hands it to JSON.parse and the holder's case dies for a
+  // neighbour's fixture, at whichever case lost the race.
+  it("a 200 that is not the proxy's health JSON is not readiness", () => {
+    assert.equal(readyBody('{"status":"ok"}'), true);
+    assert.equal(readyBody("2.1.222"), false, "a release channel's 200 read as readiness");
+    assert.equal(readyBody("ERR:ECONNREFUSED"), false);
+    assert.equal(readyBody('{"status":"degraded"}'), false);
+    assert.equal(readyBody(""), false);
+  });
 // The default is declared in proxy/config.mjs and repeated in the launcher.
 // If they drift, an unset CACHE_FIX_PROXY_PORT binds one port while callers
 // dial the other.
@@ -259,16 +280,13 @@ async function withHeldPort(fn, { subcommand = "server", extraEnv = {} } = {}) {
   try {
     const up = Date.now() + 20_000;
     let body = await get();
-    while (body.startsWith("ERR:") && Date.now() < up) body = await get();
-    // THE LAST BODY RIDES ALONG. Without it a 200 from something that is not our
-    // proxy dies as a bare SyntaxError with the responder unrecoverable from the
-    // log, and a readiness timeout dies with no clue either. Same rule the probes
-    // in this file already follow.
-    let ready;
-    try { ready = JSON.parse(body); }
-    catch { assert.fail(`the held port never answered with the proxy's health JSON; ` +
-                        `last body was ${JSON.stringify(body.slice(0, 160))}`); }
-    assert.equal(ready.status, "ok", "the held port never came up");
+    // KEEP POLLING, do not fail on the first 200: a squatter holds the port for
+    // the width of its own fixture, and the holder takes it back. Failing here
+    // reds this case for a neighbour's server. THE LAST BODY RIDES ALONG so a
+    // real timeout still names whoever answered.
+    while (!readyBody(body) && Date.now() < up) body = await get();
+    assert.ok(readyBody(body), `the held port never answered with the proxy's health JSON; ` +
+                               `last body was ${JSON.stringify(String(body).slice(0, 160))}`);
     await fn({ get, killProxy, proxyPid, launcher, exited, port });
   } finally {
     // SIGTERM first: SIGKILL cannot be forwarded, so the proxy would outlive
@@ -793,8 +811,9 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
         killProxy();
         const deadline = Date.now() + 20_000;
         let body = await get();
-        while (body.startsWith("ERR:") && Date.now() < deadline) body = await get();
-        assert.equal(JSON.parse(body).status, "ok", "the port did not come back under run-service");
+        while (!readyBody(body) && Date.now() < deadline) body = await get();
+        assert.ok(readyBody(body), `the port did not come back under run-service; last body ` +
+                                   `was ${JSON.stringify(String(body).slice(0, 160))}`);
       }, { subcommand: "run-service", extraEnv: { CACHE_FIX_HOLD_PORT: "" } });
     });
 
@@ -923,11 +942,9 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
       const port = await freePort();
       const env = { ...process.env, CACHE_FIX_PROXY_PORT: String(port), CACHE_FIX_FORWARD_PROXY: "on" };
       for (const k of [...HOP_ENV, "LISTEN_FDS", "LISTEN_PID"]) delete env[k];
-      // 200 OR IT IS NOT THE PROXY. A standby relay carrying this address answers
-      // /health with a 503 and a JSON body of its own, and a helper that returned
-      // any body let a readiness loop finish on it — measured, `JSON.parse(body)
-      // .status` came back undefined against a relay that was working perfectly.
-      // The body rides along on a failure for the reason withHeldPort's does.
+      // 200 OR IT IS NOT THE PROXY: a standby relay carrying this address answers
+      // /health with a 503 and a JSON body of its own. readyBody() is the test;
+      // the body rides along on a failure for the reason withHeldPort's does.
       const get = () => new Promise((res) => {
         http.get({ host: "127.0.0.1", port, path: "/health", timeout: 3_000 }, (r) => {
           let b = ""; r.on("data", (d) => (b += d));
@@ -938,8 +955,9 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
       try {
         const up = Date.now() + 15_000;
         let body = await get();
-        while (body.startsWith("ERR:") && Date.now() < up) body = await get();
-        assert.equal(JSON.parse(body).status, "ok", "the holder never came up");
+        while (!readyBody(body) && Date.now() < up) body = await get();
+        assert.ok(readyBody(body), `the holder never came up; last body was ` +
+                                   `${JSON.stringify(String(body).slice(0, 160))}`);
 
         // SIGKILL, the shape a supervisor cannot catch: OOM, container stop, kill -9.
         first.kill("SIGKILL");
@@ -1072,11 +1090,9 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
       const env = { ...process.env, CACHE_FIX_PROXY_PORT: String(port), CACHE_FIX_FORWARD_PROXY: "on",
                     CACHE_FIX_SELF_HEAL: "off" };
       for (const k of [...HOP_ENV, "LISTEN_FDS", "LISTEN_PID", "CACHE_FIX_HOLD_PORT"]) delete env[k];
-      // 200 OR IT IS NOT THE PROXY. A standby relay carrying this address answers
-      // /health with a 503 and a JSON body of its own, and a helper that returned
-      // any body let a readiness loop finish on it — measured, `JSON.parse(body)
-      // .status` came back undefined against a relay that was working perfectly.
-      // The body rides along on a failure for the reason withHeldPort's does.
+      // 200 OR IT IS NOT THE PROXY: a standby relay carrying this address answers
+      // /health with a 503 and a JSON body of its own. readyBody() is the test;
+      // the body rides along on a failure for the reason withHeldPort's does.
       const get = () => new Promise((res) => {
         http.get({ host: "127.0.0.1", port, path: "/health", timeout: 3_000 }, (r) => {
           let b = ""; r.on("data", (d) => (b += d));
@@ -1089,8 +1105,9 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
       try {
         const up = Date.now() + 15_000;
         let body = await get();
-        while (body.startsWith("ERR:") && Date.now() < up) body = await get();
-        assert.equal(JSON.parse(body).status, "ok", "nothing served the port");
+        while (!readyBody(body) && Date.now() < up) body = await get();
+        assert.ok(readyBody(body), `nothing served the port; last body was ` +
+                                   `${JSON.stringify(String(body).slice(0, 160))}`);
 
         // TRAFFIC ACROSS THE TAKEOVER, started before the taker exists — the
         // whole window is between the incumbent letting go and the new child
@@ -1288,7 +1305,10 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
         's.listen({ fd }, () => process.stdout.write("proxy listening on 127.0.0.1:0\\n"));\n',
         async ({ launcher, port }) => {
           const get = () => health(port);
-          const up = Date.now() + 10_000;
+          // 20 s, the budget every other case here gives a launcher-spawned child
+          // to start serving. 10 s was this file's outlier and it expired on a
+          // loaded box while the case itself costs 3.3 s quiet.
+          const up = Date.now() + 20_000;
           while (Date.now() < up && (await get()) !== 200) await new Promise((r) => setTimeout(r, 50));
           assert.equal(await get(), 200, "the stand-in never came up behind the holder");
 

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -45,12 +45,8 @@ const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", 
 // them, so the body is tested before the code.
 const OUTAGE = { REFUSED: "refused", RESET: "reset", DEGRADED: "degraded" };
 function classify(body) {
-  // A NUMBER IS NOT AN OUTAGE, AND MUST NOT BE A TypeError EITHER. Six of this
-  // file's seven probes resolve `ERR:${e.code}`; the seventh resolves a bare
-  // statusCode on success, and its caller filters out 200 and hands the rest
-  // here. Measured on CI Node 22: one 502 reached this line and the case died
-  // as `body.startsWith is not a function` — a crash where the answer is
-  // simply "that was a reply, not an outage".
+  // A NUMBER IS NOT AN OUTAGE, AND MUST NOT BE A TypeError EITHER — a probe that
+  // resolves a bare statusCode reaches here. See the unit case that pins it.
   if (typeof body !== "string") return null;
   if (!body.startsWith("ERR:")) return null;
   if (/"carrying"\s*:\s*"gap-relay"/.test(body)) return null;

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -59,6 +59,18 @@ function classify(body) {
   return OUTAGE.RESET;
 }
 
+// 200, or a string classify() can read. A bare status code or a bare e.code is
+// neither: classify() answers null for both, so the refusal count they feed is
+// empty whatever the holder does.
+const health = (port) => new Promise((res) => {
+  http.get({ host: "127.0.0.1", port, path: "/health", timeout: 3_000 }, (r) => {
+    let b = "";
+    r.setEncoding("utf8");
+    r.on("data", (d) => { b += d; });
+    r.on("end", () => res(r.statusCode === 200 ? 200 : `ERR:${r.statusCode} ${b.slice(0, 160)}`));
+  }).on("error", (e) => res(`ERR:${e.code}`));
+});
+
 const usedPorts = [];
 // The shared allocator plus this file's own cleanup registry — the registry is
 // file-local (its after() hook sweeps it), the allocation is not.
@@ -144,6 +156,19 @@ describe("held port (CACHE_FIX_HOLD_PORT)", { concurrency: CONCURRENCY }, () => 
     assert.equal(classify(200), null);
     assert.equal(classify("ERR:ECONNREFUSED"), OUTAGE.REFUSED);
     assert.equal(classify("ECONNRESET"), null, "no ERR: prefix means it is not ours to classify");
+  });
+
+  // AND THE FORCED-KILL PROBE MUST SPEAK IT. That case counts refusals with
+  // classify(), which reads nothing but an ERR: prefix, so a probe resolving a
+  // bare code makes the count empty whatever the holder does and the bound it
+  // asserts cannot fail.
+  //
+  // Port 1 rather than a released one: it needs root to bind, so no fixture here
+  // or in a neighbouring file can be holding it, and this case allocates nothing
+  // that the OS could hand to a launcher about to bind.
+  it("a probe that finds nobody home is a refusal classify can see", async () => {
+    assert.equal(classify(await health(1)), OUTAGE.REFUSED,
+                 "the forced-kill case's refusal count is empty whatever happens");
   });
 // The default is declared in proxy/config.mjs and repeated in the launcher.
 // If they drift, an unset CACHE_FIX_PROXY_PORT binds one port while callers
@@ -239,7 +264,15 @@ async function withHeldPort(fn, { subcommand = "server", extraEnv = {} } = {}) {
     const up = Date.now() + 20_000;
     let body = await get();
     while (body.startsWith("ERR:") && Date.now() < up) body = await get();
-    assert.equal(JSON.parse(body).status, "ok", "the held port never came up");
+    // THE LAST BODY RIDES ALONG. Without it a 200 from something that is not our
+    // proxy dies as a bare SyntaxError with the responder unrecoverable from the
+    // log, and a readiness timeout dies with no clue either. Same rule the probes
+    // in this file already follow.
+    let ready;
+    try { ready = JSON.parse(body); }
+    catch { assert.fail(`the held port never answered with the proxy's health JSON; ` +
+                        `last body was ${JSON.stringify(body.slice(0, 160))}`); }
+    assert.equal(ready.status, "ok", "the held port never came up");
     await fn({ get, killProxy, proxyPid, launcher, exited, port });
   } finally {
     // SIGTERM first: SIGKILL cannot be forwarded, so the proxy would outlive
@@ -1258,11 +1291,7 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
         'if (fd === null) { process.stderr.write("no LISTEN_FDS\\n"); process.exit(1); }\n' +
         's.listen({ fd }, () => process.stdout.write("proxy listening on 127.0.0.1:0\\n"));\n',
         async ({ launcher, port }) => {
-          const get = () => new Promise((res) => {
-            http.get({ host: "127.0.0.1", port, path: "/health", timeout: 3_000 }, (r) => {
-              r.resume(); r.on("end", () => res(r.statusCode));
-            }).on("error", (e) => res(e.code));
-          });
+          const get = () => health(port);
           const up = Date.now() + 10_000;
           while (Date.now() < up && (await get()) !== 200) await new Promise((r) => setTimeout(r, 50));
           assert.equal(await get(), 200, "the stand-in never came up behind the holder");

--- a/test/proxy-probe-bounded.test.mjs
+++ b/test/proxy-probe-bounded.test.mjs
@@ -96,6 +96,10 @@ describe("probe bounding", () => {
     ]);
 
     if (!settled) {
+      // NO-STANDBY: this SIGKILL needs no port sweep. The hang under test is a
+      // probe, and the launcher blocks in it before it ever binds, so there is
+      // no detached standby to reparent. Measured with the deadline forced to
+      // 200 ms, 3 s and 6 s: orphan delta 0 in all three.
       child.kill("SIGKILL");
       assert.fail(`the launcher was still running after ${DEADLINE}ms with a hanging ${hang} — ` +
                   "the probe is unbounded, and on a sick machine it would block here for ever");

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -145,7 +145,7 @@ test("every test that SIGKILLs a launcher sweeps the port or says why not", () =
     const src = readFileSync(join(testDir, f), "utf8");
     if (!/claude-via-proxy\.mjs|launcherPath/.test(src)) continue;
     if (!/SIGKILL/.test(src)) continue;
-    if (/onPort\(|listeners\(|-iTCP/.test(src)) continue;
+    if (/onPort\(|listeners\(|process\.kill\(-/.test(src)) continue;
     if (/NO-STANDBY:/.test(src)) continue;
     offenders.push(f);
   }

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -126,6 +126,27 @@ test("a test that SIGKILLs a holder reaps the successor, holder first", () => {
     "that a live holder immediately replaces");
 });
 
+// THE SAME DEBT, IN THE FILE THAT LEARNED IT SECOND. proxy-fingerprint-reap
+// spawns a run-service to prove the reaper is reachable, and a run-service
+// leaves a DETACHED standby that stands down only for a claimant's SIGHUP —
+// measured, one orphan per run holding an ephemeral port until something else
+// times out on it.
+//
+// Named rather than swept. A form-based sweep — every .test.mjs carrying both
+// "run-service" and SIGKILL — was tried and measured: it also flags
+// proxy-probe-bounded and stdio-epipe-survival, whose orphan delta over a full
+// run is 0. Those two spawn a holder that never reaches the standby, so the
+// predicate describes the shape of the code rather than the debt it incurs, and
+// a guard that reds two innocent files is a guard someone deletes.
+test("the fingerprint reaper's spawn case sweeps the port it leaves behind", () => {
+  const src = readFileSync(join(testDir, "proxy-fingerprint-reap.test.mjs"), "utf8");
+  const spawned = /test\("a launcher that binds reaps on the way up"[\s\S]*?\n\}\);/.exec(src)?.[0];
+  assert.ok(spawned, "the spawn case moved — this no longer guards anything");
+  assert.match(spawned, /onPort\(/,
+    "the launcher is SIGKILLed but nothing sweeps the port, so its detached " +
+    "standby survives every run");
+});
+
 // A FAILURE MESSAGE IS PUBLISHED OUTPUT. proxy-held-port's probes append the
 // 503 body to what they assert on, and the gap relay's 503 body carries the hop
 // it would forward to — so an env var that gives a child a hop and is not

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -126,25 +126,32 @@ test("a test that SIGKILLs a holder reaps the successor, holder first", () => {
     "that a live holder immediately replaces");
 });
 
-// THE SAME DEBT, IN THE FILE THAT LEARNED IT SECOND. proxy-fingerprint-reap
-// spawns a run-service to prove the reaper is reachable, and a run-service
-// leaves a DETACHED standby that stands down only for a claimant's SIGHUP —
-// measured, one orphan per run holding an ephemeral port until something else
-// times out on it.
+// A LAUNCHER THAT IS SIGKILLED LEAVES A DETACHED STANDBY ON ITS PORT. It stands
+// down only for a claimant's SIGHUP, so the kill reparents it to init still
+// listening — measured, one per run from proxy-fingerprint-reap's spawn case,
+// eight alive at once, the oldest over three hours, each one a listener in the
+// band the suite's own fixtures bind from.
 //
-// Named rather than swept. A form-based sweep — every .test.mjs carrying both
-// "run-service" and SIGKILL — was tried and measured: it also flags
-// proxy-probe-bounded and stdio-epipe-survival, whose orphan delta over a full
-// run is 0. Those two spawn a holder that never reaches the standby, so the
-// predicate describes the shape of the code rather than the debt it incurs, and
-// a guard that reds two innocent files is a guard someone deletes.
-test("the fingerprint reaper's spawn case sweeps the port it leaves behind", () => {
-  const src = readFileSync(join(testDir, "proxy-fingerprint-reap.test.mjs"), "utf8");
-  const spawned = /test\("a launcher that binds reaps on the way up"[\s\S]*?\n\}\);/.exec(src)?.[0];
-  assert.ok(spawned, "the spawn case moved — this no longer guards anything");
-  assert.match(spawned, /onPort\(/,
-    "the launcher is SIGKILLed but nothing sweeps the port, so its detached " +
-    "standby survives every run");
+// Swept over every file rather than named, because the guard above went blind
+// the moment a second file learned the same debt. Any spelling of the sweep
+// counts: onPort(), listeners(), or a raw lsof -iTCP. A file that kills a
+// launcher and genuinely has nothing to sweep says so with NO-STANDBY: and why
+// — proxy-probe-bounded blocks in a probe before it binds, measured at three
+// deadlines.
+test("every test that SIGKILLs a launcher sweeps the port or says why not", () => {
+  const offenders = [];
+  for (const f of readdirSync(testDir).filter((n) => n.endsWith(".test.mjs"))) {
+    if (f === "suite-collection.test.mjs") continue;
+    const src = readFileSync(join(testDir, f), "utf8");
+    if (!/claude-via-proxy\.mjs|launcherPath/.test(src)) continue;
+    if (!/SIGKILL/.test(src)) continue;
+    if (/onPort\(|listeners\(|-iTCP/.test(src)) continue;
+    if (/NO-STANDBY:/.test(src)) continue;
+    offenders.push(f);
+  }
+  assert.deepEqual(offenders, [],
+    "these spawn a launcher and SIGKILL it without reaping what it left on the " +
+    "port, and without saying why none is owed");
 });
 
 // A FAILURE MESSAGE IS PUBLISHED OUTPUT. proxy-held-port's probes append the


### PR DESCRIPTION
## The record nobody collects

`publishFingerprint` writes `<tmpdir>/cache-fix-proxy-<port>.sha256` once, on the holder's spawn path. Nothing republishes it and nothing removes it. `runningOurCode()` reads it to decide whether an arriving launcher is looking at the same build — so a missing record makes that answer `null`, `holderVerdict()` reads unknown as an incumbent of ours, and `takeOver()` exits 0 while printing *"if this was a deploy, it has NOT taken effect."* Every other check on the host stays green through that.

The launcher now reaps them on the way up, off the startup path: `setTimeout(reapFingerprintRecords, 0).unref()` from `holdPort`, once per launcher process rather than once per spawn.

## What it removes, and what it will not touch

A **record** goes only when it is over the age gate **and** its port does not answer. Both conditions, in that order.

A **temp** — `<record>.<pid>`, what `publishFingerprint` writes before its rename — is different, and this is the one asymmetry worth stating plainly: a temp answers to no port, so it skips the probe entirely and the age gate is its only discriminator. A pending rename lives for microseconds; past the gate the only thing that leaves one behind is a publish that died. The suffix test used to skip that name forever, and a case here **pinned** that, asserting an eight-day-old temp must survive.

The age gate is `REAP_AGE_MS`, shared by construction with the scratch-CA reaper twenty lines below rather than by a comment claiming they match.

## Three things the port probe does not answer

`portFree()` asks the kernel to bind, because that needs one bit and a host without `lsof` would otherwise make the reap a silent no-op.

1. "Is anything **listening**" is not "is anyone using this port". A holder in the bound-but-not-listening state this file creates on purpose reads as free.
2. A record is keyed by **port alone**, and this asks about `bindAddr()`. A holder on another address reads as free to a reaper on loopback.
3. The probe is itself a listener while it asks, so a launcher in `otherHolderOn()` can read it as an incumbent.

All three end in the same place: `runningOurCode()` answers null and the deploy announces itself as not taken effect. The local variant of (3) cannot happen — `listen()` is the last synchronous statement of `holdPort`'s executor, so this launcher already owns its own port when the reap runs.

## The scan yields

`readdirSync(tmpdir())` on a developer box here: **17,905 entries in 33.7 ms**. The loop hands the event loop back every 100 entries, because nothing else awaited in it reaches the poll phase and an uninterrupted pass would hold the loop between the bind and the first accept — the delay deferring the reap was meant to avoid.

## Two defects this branch fixed in itself

**`onPort(0)` selected the live proxy.** The e2e case initialises `port = 0` and assigns it from `freePort()` seven lines later; its `finally` swept `onPort(port)` unconditionally, so anything throwing in between aimed a SIGKILL sweep at port 0. `ours()` matches `CACHE_FIX_PROXY_PORT`, which a proxy child legitimately carries as `0` when it inherits the holder's listening fd — so port 0 is not the empty set it looks like. Measured read-only on a dev host: **8 processes, one of them the deployed proxy serving 9901**. Guarded at `onPort()`, where three other files' sweeps also route.

**The reaper could unlink a record published inside its own probe.** `stat` → age check → `await portFree()` → `rm`, and that await is a real gap: another launcher publishes by renaming over the same path. Re-read after the probe. Measured: the closed window is 41.8 µs median, the residual (two syscalls, nothing awaited between them) 3.0 µs.

## Verification

Focused file **7/7**; whole suite **1957 pass / 0 fail / 1 skipped** (the skip is pre-existing and unconditional). CI green on node 18 / 20 / 22.

| reverted | dies |
| --- | --- |
| `Number(port) > 0` in `onPort` | `onPort(0) selected a process carrying CACHE_FIX_PROXY_PORT=0; the sweep would SIGKILL the live proxy` |
| the re-read `statSync` | `the reaper unlinked a record republished during the port probe` |
| the temp branch, back to one `endsWith` | `an eight-day-old <record>.<pid> survived: no reaper anywhere collects it` |
| the `n < 1` port floor | two cases, including `port 0 was probed` |

**6 files changed, +540 / −29.** Production is `bin/claude-via-proxy.mjs` **+97 / −4** — 34 code, 59 comment, 4 blank, a 1.74:1 comment ratio. Tests are +443 / −25. New files: 1. New exports, env vars, on-disk path shapes: 0.

## Known, and not fixed here

- The `setImmediate` yield is pinned only by a source regex; no case executes it, because the largest directory any reaper run scans in the suite is 9 entries. A positive control at 301 entries fires it three times in 4 ms.
- The crashed-publish temp is collected at the **seven-day** gate, while the scratch-CA reaper in the same file collects its own equivalent at **60 s** with a written rationale. Two answers to one hazard; the wider one is the choice here, and it deserves a second look rather than a defence.
