### PR TITLE
fix(test): keep the microcompact scratch when a case FAILS, not when it passes

### DIFF
--- a/test/proxy-microcompact-stability.test.mjs
+++ b/test/proxy-microcompact-stability.test.mjs
@@ -1,4 +1,4 @@
-import { test } from "node:test";
+import { after, test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -11,6 +11,25 @@ import ext, {
   buildDiagnosticRecord,
   runMicrocompactStability,
 } from "../proxy/extensions/microcompact-stability.mjs";
+
+// EVERY SCRATCH DIR, EVEN THE RUNS THAT FAIL. Thirteen cases remove theirs on the
+// last line of the test body, so an assertion that throws skips it, and the
+// fourteenth removes nothing at all — that one leaked on the green path too.
+// Those calls stay as they are, since they free disk during a long run; this
+// collects what they miss.
+const scratch = [];
+async function mcTemp() {
+  const d = await mkdtemp(join(tmpdir(), "mc-"));
+  scratch.push(d);
+  return d;
+}
+after(async () => {
+  for (const d of scratch) {
+    // Per dir, so one refused removal cannot strand the rest. `force` already
+    // swallows a missing dir; this is for EPERM and EBUSY.
+    try { await rm(d, { recursive: true, force: true }); } catch { /* see above */ }
+  }
+});
 
 // --- Fixture helpers ---
 
@@ -149,7 +168,7 @@ test("4. unrelated truncation message → no match in either mode (rejected from
 // --- Mode B ---
 
 test("4a. sentinel + trailing text → Mode B match, body NOT mutated, prefix_64 only in dump", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),
@@ -182,7 +201,7 @@ test("4a. sentinel + trailing text → Mode B match, body NOT mutated, prefix_64
 
 test("4b. long trailing → prefix_64 captures only first 64 chars, byte_length reports full size", async () => {
   const long = SENTINEL_TS + " " + "x".repeat(200);
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),
@@ -201,7 +220,7 @@ test("4b. long trailing → prefix_64 captures only first 64 chars, byte_length 
 });
 
 test("4c. CACHE_FIX_MICROCOMPACT_REDACT_LEN=0 → prefix_64 absent", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),
@@ -237,7 +256,7 @@ test("5a. CACHE_FIX_MICROCOMPACT_SENTINEL_PATTERN_1 adds custom Mode A pattern",
 });
 
 test("5b. custom Mode A regex + custom Mode B prefix → exact match goes to exact_matches", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   // Exact match against a custom regex from a sentinel family that does NOT
   // share the built-in prefix. Verifies exact-match path for custom families.
@@ -269,7 +288,7 @@ test("5c. custom Mode B prefix → variant-of-custom-family captured redacted in
   // EXACTLY normalizes, but its prefix-only variant must also be captured
   // in Mode B (redacted) — not silently dropped just because the variant
   // doesn't share the built-in `[Old tool result content cleared` prefix.
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const text = "[CC microcompact rev2 at 2026-04-30T17:00:00Z] (with trailing content)";
   const body = makeBody([
@@ -352,7 +371,7 @@ test("8. mixed array (text + image) — only the text matches → image untouche
 // --- Diagnostic dump ---
 
 test("9. dump set + sentinel match → JSONL line; session_id is hashed (no plaintext)", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),
@@ -373,7 +392,7 @@ test("9. dump set + sentinel match → JSONL line; session_id is hashed (no plai
 });
 
 test("10. dump unset → no fs activity", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),
@@ -395,7 +414,7 @@ test("10. dump unset → no fs activity", async () => {
 });
 
 test("11. multiple matches in one request → ONE JSONL line with arrays split A/B", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),
@@ -455,7 +474,7 @@ test("13. normalize on + custom canonical → matched sentinel becomes the custo
 });
 
 test("14. normalize disabled, dump enabled → matches recorded in dump but body NOT mutated", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),
@@ -500,7 +519,7 @@ test("15. two requests with different timestamps → byte-identical bodies after
 // --- Activation ---
 
 test("16. both gates unset → extension fires but exits early; no telemetry, no mutation, no fs", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),
@@ -526,7 +545,7 @@ test("16. both gates unset → extension fires but exits early; no telemetry, no
 });
 
 test("17. only diagnostic enabled → telemetry present, JSONL written, no mutation", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),
@@ -548,7 +567,7 @@ test("17. only diagnostic enabled → telemetry present, JSONL written, no mutat
 });
 
 test("18. only normalize enabled → telemetry present, mutation happens, no JSONL", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),
@@ -568,7 +587,7 @@ test("18. only normalize enabled → telemetry present, mutation happens, no JSO
 });
 
 test("19. both enabled → telemetry, mutation, AND JSONL all happen; raw text captured pre-normalization", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),
@@ -598,7 +617,7 @@ test("19. both enabled → telemetry, mutation, AND JSONL all happen; raw text c
 });
 
 test("19a. CACHE_FIX_DUMP_MICROCOMPACT_INCLUDE_NORMALIZED=1 → adds normalized_text alongside raw sentinel_text", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "mc-"));
+  const dir = await mcTemp();
   const dumpPath = join(dir, "dump.jsonl");
   const body = makeBody([
     assistantMsg("t1"),

--- a/test/proxy-microcompact-stability.test.mjs
+++ b/test/proxy-microcompact-stability.test.mjs
@@ -782,14 +782,16 @@ test("15. all sources missing → null", () => {
 test("scratch: no test body mints an unregistered temp dir", async () => {
   const src = await readFile(new URL(import.meta.url), "utf8");
   // Matches any quoted prefix, which the registrar (passing a const) does not
-  // have. Comment lines are skipped and this line's own escaping keeps it from
+  // have. Line comments are skipped and this line's own escaping keeps it from
   // matching itself, so neither the prose above nor the assertion self-flags.
-  // Ceiling: a single-line textual match on one exact call form, so any other
-  // spelling passes.
+  // Only "//": nothing can follow it on the line, while a block comment closes
+  // mid-line, so skipping "/*" and "*" would hide a real mint after the close
+  // and behind any generator method. Ceiling: a single-line textual match on
+  // one exact call form, so any other spelling passes.
   const call = /mkdtemp(?:Sync)?\(join\(tmpdir\(\),\s*["'`][^"'`]+["'`]\s*\)\)/;
   const raw = src.split("\n")
     .map((line, i) => [i + 1, line])
-    .filter(([, l]) => !/^(\/\/|\/?\*)/.test(l.trim()))
+    .filter(([, l]) => !l.trim().startsWith("//"))
     .filter(([, l]) => call.test(l))
     .map(([n]) => n);
   assert.deepEqual(raw, [],

--- a/test/proxy-microcompact-stability.test.mjs
+++ b/test/proxy-microcompact-stability.test.mjs
@@ -16,8 +16,9 @@ import ext, {
 // registered here and removed once the file is done. Per dir, so one refused
 // removal cannot strand the rest.
 const scratch = [];
+const SCRATCH_PREFIX = "mc-";
 async function mcTemp() {
-  const d = await mkdtemp(join(tmpdir(), "mc-"));
+  const d = await mkdtemp(join(tmpdir(), SCRATCH_PREFIX));
   scratch.push(d);
   return d;
 }
@@ -779,10 +780,12 @@ test("15. all sources missing → null", () => {
 // and a throwing case strands it, with the suite green either way.
 test("scratch: no test body mints an unregistered temp dir", async () => {
   const src = await readFile(new URL(import.meta.url), "utf8");
-  const call = /mkdtemp(?:Sync)?\(join\(tmpdir\(\),\s*"[^"]+"\s*\)\)/;  // escaped: cannot match its own line
+  // Matches only a literal prefix, so the registrar (which passes a const) is not
+  // a special case, and the escaping keeps this line from matching itself.
+  const call = /mkdtemp(?:Sync)?\(join\(tmpdir\(\),\s*"[^"]+"\s*\)\)/;
   const raw = src.split("\n")
     .map((line, i) => [i + 1, line])
-    .filter(([, l]) => call.test(l) && !l.includes("const d = await mkdtemp"))  // the registrar
+    .filter(([, l]) => call.test(l))
     .map(([n]) => n);
   assert.deepEqual(raw, [],
     `every temp dir must go through mcTemp(); raw mkdtemp at line(s): ${raw.join(", ")}`);

--- a/test/proxy-microcompact-stability.test.mjs
+++ b/test/proxy-microcompact-stability.test.mjs
@@ -12,11 +12,9 @@ import ext, {
   runMicrocompactStability,
 } from "../proxy/extensions/microcompact-stability.mjs";
 
-// EVERY SCRATCH DIR, EVEN THE RUNS THAT FAIL. Thirteen cases remove theirs on the
-// last line of the test body, so an assertion that throws skips it, and the
-// fourteenth removes nothing at all — that one leaked on the green path too.
-// Those calls stay as they are, since they free disk during a long run; this
-// collects what they miss.
+// A test body that throws never reaches its own cleanup, so every scratch dir is
+// registered here and removed once the file is done. Per dir, so one refused
+// removal cannot strand the rest.
 const scratch = [];
 async function mcTemp() {
   const d = await mkdtemp(join(tmpdir(), "mc-"));
@@ -25,9 +23,7 @@ async function mcTemp() {
 }
 after(async () => {
   for (const d of scratch) {
-    // Per dir, so one refused removal cannot strand the rest. `force` already
-    // swallows a missing dir; this is for EPERM and EBUSY.
-    try { await rm(d, { recursive: true, force: true }); } catch { /* see above */ }
+    try { await rm(d, { recursive: true, force: true }); } catch { /* best effort */ }
   }
 });
 
@@ -196,7 +192,6 @@ test("4a. sentinel + trailing text → Mode B match, body NOT mutated, prefix_64
   assert.equal(rec.partial_matches[0].sentinel_text, undefined);
   assert.ok(rec.partial_matches[0].prefix_64.length <= 64);
   assert.ok(rec.partial_matches[0].prefix_64.startsWith("[Old tool result content cleared"));
-  await rm(dir, { recursive: true, force: true });
 });
 
 test("4b. long trailing → prefix_64 captures only first 64 chars, byte_length reports full size", async () => {
@@ -216,7 +211,6 @@ test("4b. long trailing → prefix_64 captures only first 64 chars, byte_length 
   assert.equal(rec.partial_matches.length, 1);
   assert.equal(rec.partial_matches[0].prefix_64.length, 64);
   assert.equal(rec.partial_matches[0].byte_length, Buffer.byteLength(long, "utf8"));
-  await rm(dir, { recursive: true, force: true });
 });
 
 test("4c. CACHE_FIX_MICROCOMPACT_REDACT_LEN=0 → prefix_64 absent", async () => {
@@ -241,7 +235,6 @@ test("4c. CACHE_FIX_MICROCOMPACT_REDACT_LEN=0 → prefix_64 absent", async () =>
   assert.equal(rec.partial_matches.length, 1);
   assert.equal(rec.partial_matches[0].prefix_64, undefined);
   assert.equal(typeof rec.partial_matches[0].byte_length, "number");
-  await rm(dir, { recursive: true, force: true });
 });
 
 // --- Custom patterns ---
@@ -280,7 +273,6 @@ test("5b. custom Mode A regex + custom Mode B prefix → exact match goes to exa
   assert.equal(rec.exact_matches.length, 1);
   assert.equal(rec.partial_matches.length, 0);
   assert.equal(rec.exact_matches[0].sentinel_text, "[CC microcompact rev2]");
-  await rm(dir, { recursive: true, force: true });
 });
 
 test("5c. custom Mode B prefix → variant-of-custom-family captured redacted in partial_matches", async () => {
@@ -318,7 +310,6 @@ test("5c. custom Mode B prefix → variant-of-custom-family captured redacted in
   assert.equal(rec.partial_matches.length, 1);
   assert.equal(rec.partial_matches[0].sentinel_text, undefined); // never full text
   assert.ok(rec.partial_matches[0].prefix_64.startsWith("[CC microcompact"));
-  await rm(dir, { recursive: true, force: true });
 });
 
 // --- Tool_result content shapes ---
@@ -388,7 +379,6 @@ test("9. dump set + sentinel match → JSONL line; session_id is hashed (no plai
   assert.equal(rec.session_id_hash.length, 8);
   assert.ok(!JSON.stringify(rec).includes("secret-session-12345"));
   assert.equal(rec.model, "claude-opus-4-7-20260101");
-  await rm(dir, { recursive: true, force: true });
 });
 
 test("10. dump unset → no fs activity", async () => {
@@ -410,7 +400,6 @@ test("10. dump unset → no fs activity", async () => {
     );
   });
   await assert.rejects(() => stat(dumpPath), /ENOENT/);
-  await rm(dir, { recursive: true, force: true });
 });
 
 test("11. multiple matches in one request → ONE JSONL line with arrays split A/B", async () => {
@@ -495,7 +484,6 @@ test("14. normalize disabled, dump enabled → matches recorded in dump but body
   assert.equal(JSON.stringify(body), before);
   const rec = JSON.parse((await readFile(dumpPath, "utf8")).trim());
   assert.equal(rec.exact_matches.length, 1);
-  await rm(dir, { recursive: true, force: true });
 });
 
 test("15. two requests with different timestamps → byte-identical bodies after normalization", async () => {
@@ -541,7 +529,6 @@ test("16. both gates unset → extension fires but exits early; no telemetry, no
   assert.equal(JSON.stringify(body), before);
   assert.equal(ctx.meta.microcompactStats, undefined);
   await assert.rejects(() => stat(dumpPath), /ENOENT/);
-  await rm(dir, { recursive: true, force: true });
 });
 
 test("17. only diagnostic enabled → telemetry present, JSONL written, no mutation", async () => {
@@ -563,7 +550,6 @@ test("17. only diagnostic enabled → telemetry present, JSONL written, no mutat
   assert.equal(ctx.meta.microcompactStats.diagnostic_enabled, true);
   assert.equal(ctx.meta.microcompactStats.normalization_enabled, false);
   assert.equal(ctx.meta.microcompactStats.diagnostic_records_written, 1);
-  await rm(dir, { recursive: true, force: true });
 });
 
 test("18. only normalize enabled → telemetry present, mutation happens, no JSONL", async () => {
@@ -583,7 +569,6 @@ test("18. only normalize enabled → telemetry present, mutation happens, no JSO
   assert.equal(ctx.meta.microcompactStats.normalization_enabled, true);
   assert.equal(ctx.meta.microcompactStats.sentinels_normalized, 1);
   await assert.rejects(() => stat(dumpPath), /ENOENT/);
-  await rm(dir, { recursive: true, force: true });
 });
 
 test("19. both enabled → telemetry, mutation, AND JSONL all happen; raw text captured pre-normalization", async () => {
@@ -613,7 +598,6 @@ test("19. both enabled → telemetry, mutation, AND JSONL all happen; raw text c
   assert.equal(rec.exact_matches[0].normalized_text, undefined);
   // Telemetry attached.
   assert.equal(ctx.meta.microcompactStats.sentinels_normalized, 1);
-  await rm(dir, { recursive: true, force: true });
 });
 
 test("19a. CACHE_FIX_DUMP_MICROCOMPACT_INCLUDE_NORMALIZED=1 → adds normalized_text alongside raw sentinel_text", async () => {
@@ -638,7 +622,6 @@ test("19a. CACHE_FIX_DUMP_MICROCOMPACT_INCLUDE_NORMALIZED=1 → adds normalized_
   const rec = JSON.parse((await readFile(dumpPath, "utf8")).trim());
   assert.equal(rec.exact_matches[0].sentinel_text, SENTINEL_TS);
   assert.equal(rec.exact_matches[0].normalized_text, SENTINEL_BARE);
-  await rm(dir, { recursive: true, force: true });
 });
 
 // --- Telemetry shape ---
@@ -790,4 +773,18 @@ test("15. all sources missing → null", () => {
   const reqCtx = { body: { messages: [] } };
   const rec = buildDiagnosticRecord(reqCtx, [], [], 0, { ts: "t" });
   assert.equal(rec.session_id_hash, null);
+});
+
+// A dir minted outside mcTemp() is unregistered, so `after()` cannot remove it
+// and a throwing case strands it, with the suite green either way.
+test("scratch: no test body mints an unregistered temp dir", async () => {
+  const src = await readFile(new URL(import.meta.url), "utf8");
+  const call = /mkdtemp(?:Sync)?\(join\(tmpdir\(\),\s*"[^"]+"\s*\)\)/;  // escaped: cannot match its own line
+  const raw = src.split("\n")
+    .map((line, i) => [i + 1, line])
+    .filter(([, l]) => call.test(l) && !l.includes("const d = await mkdtemp"))  // the registrar
+    .map(([n]) => n);
+  assert.deepEqual(raw, [],
+    `every temp dir must go through mcTemp(); raw mkdtemp at line(s): ${raw.join(", ")}`);
+  assert.ok(scratch.length > 0, "premise: this file does mint temp dirs");
 });

--- a/test/proxy-microcompact-stability.test.mjs
+++ b/test/proxy-microcompact-stability.test.mjs
@@ -16,6 +16,7 @@ import ext, {
 // registered here and removed once the file is done. Per dir, so one refused
 // removal cannot strand the rest.
 const scratch = [];
+// Load-bearing: a literal here instead would make the guard below flag mcTemp().
 const SCRATCH_PREFIX = "mc-";
 async function mcTemp() {
   const d = await mkdtemp(join(tmpdir(), SCRATCH_PREFIX));
@@ -783,12 +784,12 @@ test("scratch: no test body mints an unregistered temp dir", async () => {
   // Matches any quoted prefix, which the registrar (passing a const) does not
   // have. Comment lines are skipped and this line's own escaping keeps it from
   // matching itself, so neither the prose above nor the assertion self-flags.
-  // Ceiling: one line at a time, and a const prefix is the very thing that
-  // excludes the registrar, so that one shape cannot be closed here.
+  // Ceiling: a single-line textual match on one exact call form, so any other
+  // spelling passes.
   const call = /mkdtemp(?:Sync)?\(join\(tmpdir\(\),\s*["'`][^"'`]+["'`]\s*\)\)/;
   const raw = src.split("\n")
     .map((line, i) => [i + 1, line])
-    .filter(([, l]) => !l.trim().startsWith("//"))
+    .filter(([, l]) => !/^(\/\/|\/?\*)/.test(l.trim()))
     .filter(([, l]) => call.test(l))
     .map(([n]) => n);
   assert.deepEqual(raw, [],

--- a/test/proxy-microcompact-stability.test.mjs
+++ b/test/proxy-microcompact-stability.test.mjs
@@ -780,11 +780,15 @@ test("15. all sources missing → null", () => {
 // and a throwing case strands it, with the suite green either way.
 test("scratch: no test body mints an unregistered temp dir", async () => {
   const src = await readFile(new URL(import.meta.url), "utf8");
-  // Matches only a literal prefix, so the registrar (which passes a const) is not
-  // a special case, and the escaping keeps this line from matching itself.
-  const call = /mkdtemp(?:Sync)?\(join\(tmpdir\(\),\s*"[^"]+"\s*\)\)/;
+  // Matches any quoted prefix, which the registrar (passing a const) does not
+  // have. Comment lines are skipped and this line's own escaping keeps it from
+  // matching itself, so neither the prose above nor the assertion self-flags.
+  // Ceiling: one line at a time, and a const prefix is the very thing that
+  // excludes the registrar, so that one shape cannot be closed here.
+  const call = /mkdtemp(?:Sync)?\(join\(tmpdir\(\),\s*["'`][^"'`]+["'`]\s*\)\)/;
   const raw = src.split("\n")
     .map((line, i) => [i + 1, line])
+    .filter(([, l]) => !l.trim().startsWith("//"))
     .filter(([, l]) => call.test(l))
     .map(([n]) => n);
   assert.deepEqual(raw, [],

--- a/test/proxy-microcompact-stability.test.mjs
+++ b/test/proxy-microcompact-stability.test.mjs
@@ -1,8 +1,11 @@
-import { after, test } from "node:test";
+import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { existsSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { join } from "node:path";
+import { scratchDir } from "./scratch-registry.mjs";
 
 import ext, {
   matchesSentinelPattern,
@@ -12,22 +15,11 @@ import ext, {
   runMicrocompactStability,
 } from "../proxy/extensions/microcompact-stability.mjs";
 
-// A test body that throws never reaches its own cleanup, so every scratch dir is
-// registered here and removed once the file is done. Per dir, so one refused
-// removal cannot strand the rest.
-const scratch = [];
-// Load-bearing: a literal here instead would make the guard below flag mcTemp().
+// Registration lives in scratch-registry.mjs, which gates removal on the FILE's
+// outcome: a green run cleans up, a red one keeps the dirs and names them. A
+// test body that throws never reaches its own cleanup, which is the whole point.
 const SCRATCH_PREFIX = "mc-";
-async function mcTemp() {
-  const d = await mkdtemp(join(tmpdir(), SCRATCH_PREFIX));
-  scratch.push(d);
-  return d;
-}
-after(async () => {
-  for (const d of scratch) {
-    try { await rm(d, { recursive: true, force: true }); } catch { /* best effort */ }
-  }
-});
+const mcTemp = () => scratchDir(SCRATCH_PREFIX);
 
 // --- Fixture helpers ---
 
@@ -779,6 +771,54 @@ test("15. all sources missing → null", () => {
 
 // A dir minted outside mcTemp() is unregistered, so `after()` cannot remove it
 // and a throwing case strands it, with the suite green either way.
+// The lifecycle cannot be asserted in-process: the decision is taken on the way
+// out, after every hook this file could run. So it is measured through a real
+// child, both ways -- the passing arm is the control, without which "the dir is
+// there" would also be what a registry that never cleans anything looks like.
+test("scratch: a failing run keeps its scratch, a passing one does not", async () => {
+  const registry = new URL("./scratch-registry.mjs", import.meta.url).href;
+  const run = async (outcome) => {
+    const dir = await mcTemp();
+    const file = join(dir, `probe-${outcome}.test.mjs`);
+    await writeFile(file, `
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { scratchDir } from ${JSON.stringify(registry)};
+test("probe", async () => {
+  const d = await scratchDir("mcprobe-");
+  console.error("PROBE_DIR=" + d);
+  ${outcome === "fail" ? 'assert.fail("deliberate");' : "assert.ok(true);"}
+});
+`);
+    // NODE_TEST_CONTEXT is inherited, and the runner refuses to run files when it
+    // sees it ("run() is being called recursively"), so the child would report
+    // nothing and the case would fail on its own plumbing.
+    const env = { ...process.env };
+    delete env.NODE_TEST_CONTEXT;
+    const r = spawnSync(process.execPath, ["--test", file],
+                        { env, encoding: "utf8", timeout: 60_000 });
+    // STDOUT, not stderr: node:test captures a case's output and re-emits it on
+    // its own stream, so a child's `process.stderr.write` arrives here.
+    const out = `${r.stdout}${r.stderr}`;
+    const probe = /PROBE_DIR=(.*)/.exec(out)?.[1]?.trim();
+    assert.ok(probe, `the probe never reported its dir: ${out}`);
+    return { probe, status: r.status, out };
+  };
+
+  const failed = await run("fail");
+  assert.notEqual(failed.status, 0, "premise: the failing probe exited 0");
+  assert.ok(existsSync(failed.probe),
+    "a failing run deleted the scratch that is the only record of what it was looking at");
+  assert.match(failed.out, /\[scratch kept\]/,
+    "the dir was kept and never named — the caller cannot find it");
+  rmSync(failed.probe, { recursive: true, force: true });
+
+  const passed = await run("pass");
+  assert.equal(passed.status, 0, "premise: the passing probe did not pass");
+  assert.ok(!existsSync(passed.probe),
+    "a passing run left its scratch behind — the registry cleans nothing");
+});
+
 test("scratch: no test body mints an unregistered temp dir", async () => {
   const src = await readFile(new URL(import.meta.url), "utf8");
   // Matches any quoted prefix, which the registrar (passing a const) does not
@@ -796,5 +836,13 @@ test("scratch: no test body mints an unregistered temp dir", async () => {
     .map(([n]) => n);
   assert.deepEqual(raw, [],
     `every temp dir must go through mcTemp(); raw mkdtemp at line(s): ${raw.join(", ")}`);
-  assert.ok(scratch.length > 0, "premise: this file does mint temp dirs");
+  // POSITIVE CONTROL. Without it the pattern can be neutered -- a typo, a
+  // rename, anything -- and this case stays green over a file it no longer
+  // matches. Assembled from pieces so the sample itself is not a mint on this
+  // line for the pattern above to find.
+  const sample = ["mkdtemp", "(join(tmpdir(), ", '"x-"))'].join("");
+  assert.ok(call.test(sample), "the pattern no longer matches a raw mint");
+  // The premise is a SOURCE count, not a runtime array: the registration moved
+  // out of this file, so a runtime one would now be empty here and read green.
+  assert.ok(src.split("mcTemp(").length - 1 > 1, "premise: this file does mint temp dirs");
 });

--- a/test/scratch-registry.mjs
+++ b/test/scratch-registry.mjs
@@ -1,0 +1,35 @@
+// Scratch dirs that survive the failure they exist to explain.
+//
+// A test body that throws never reaches its own cleanup, so every dir is
+// registered here. Removal is gated on the FILE's outcome: after a green run the
+// scratch is litter, after a red one it is the only record of what the case was
+// looking at when it died.
+//
+// `process.on("exit")` and not `after()`, because the hook runs too early to
+// know: measured on node 24, `process.exitCode` is `undefined` inside a
+// file-level `after()` on a file that HAS a failure, and `1` by exit on the same
+// file (and `undefined` at both points on a file without one).
+//
+// Sync removal for the same reason -- an exit handler cannot await, so a
+// promise-based rm would be registered and never run.
+import { mkdtemp } from "node:fs/promises";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const registered = [];
+
+export async function scratchDir(prefix) {
+  const d = await mkdtemp(join(tmpdir(), prefix));
+  registered.push(d);
+  return d;
+}
+
+process.on("exit", () => {
+  for (const d of registered) {
+    // Named on the way out, or keeping them helps nobody: the runner's output is
+    // the only place the caller will look for the path.
+    if (process.exitCode) { process.stderr.write(`[scratch kept] ${d}\n`); continue; }
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});


### PR DESCRIPTION
> **Retitled.** It read *"keep the microcompact scratch dirs off /tmp when a case fails"*, which is the opposite of what this does. The branch name was the honest one.

## What a failing case leaves behind

`proxy-microcompact-stability.test.mjs` mints temp dirs for fixtures. A body that throws never reaches its own cleanup, so every dir is registered and removed once the file is done.

That removal was an `after()` hook, and `after()` runs after a **red** case too — so the directory holding whatever the case was looking at when it died was deleted before anyone could open it. The branch is named for keeping it; it did the opposite.

## `after()` cannot know the outcome

Measured, four runtimes, on a file that HAS a failure and on one that does not:

| | node 18 | node 20 | node 22 | node 24 |
| --- | --- | --- | --- | --- |
| `process.exitCode` inside `after()` | `1` | `1` | `undefined` | `undefined` |
| `process.exitCode` at `exit` | `1` | `1` | `1` | `1` |
| same, on an all-green file | `undefined` everywhere | | | |

The all-green row is the control: at `exit` the value discriminates, and it does so on every runtime CI runs. Inside `after()` it does not — on 22 and 24 the hook simply runs too early to know.

So the decision moves to `process.on("exit")`, and the removal becomes synchronous, because an exit handler cannot await and a promise-based `rm` would be registered and never run.

## Where it lives

Registration moves to `test/scratch-registry.mjs` — **one new file, one new export** (`scratchDir`). That is also what makes the lifecycle testable: it cannot be asserted in-process, because the decision is taken after every hook this file could run. The new case drives a real child both ways, and the **passing arm is the control** — without it, "the directory is there" is also what a registry that never cleans anything looks like.

A kept directory is named on stderr on the way out. Preserving one silently helps nobody.

## Two holes in the guard beside it

The file carries a source-scanning guard: every temp dir must go through `mcTemp()`.

- **It had no positive control.** Neutering its pattern left it green over a file it no longer matched. The sample that proves the pattern still matches is assembled from pieces, so it is not itself a mint for the pattern to find.
- **Its premise was a runtime array** this change empties, since the mint moved out of the file. It counts call sites in the source instead.

## Verification

`37/37` on the touched file, and green on 18 / 20 / 22 / 24.

| reverted | dies |
| --- | --- |
| always clean, ignoring the outcome | `a failing run deleted the scratch that is the only record of what it was looking at` |
| never clean | `a passing run left its scratch behind — the registry cleans nothing` |
| guard pattern neutered | `the pattern no longer matches a raw mint` |

**2 files changed, +137 / −28.** New files: 1. New exports: 1. New env vars: 0. New on-disk path shapes: `mcprobe-*`, from the new case's child.

## Corrections to what is already written here

- The commit message says the registry matches `file-tmpdir.mjs` "next to it". That file is on #347, not on this branch. The two are the same shape and are not yet siblings.
- An earlier revision of this description showed the `const scratch = []` + `after(...)` block as "the change". That block is what the change **deletes**.
