### PR TITLE
test: give each launcher-spawning file its own TMPDIR

### DIFF
--- a/test/file-tmpdir.mjs
+++ b/test/file-tmpdir.mjs
@@ -14,10 +14,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-test-"));
-// ALL THREE. os.tmpdir() reads TMPDIR on POSIX and TEMP then TMP on Windows, so
-// setting only the key THIS platform happens to read leaves the other one
-// writing to the shared root -- and an assertion that the inherited directory is
-// empty then passes because it was never used, not because anything moved.
+// ALL THREE, because os.tmpdir() reads a DIFFERENT one first per platform:
+// TMPDIR || TMP || TEMP on POSIX, TEMP || TMP on Windows. Setting only the key
+// this platform happens to read first leaves a run on another platform writing
+// to the shared root.
 for (const key of ["TMPDIR", "TMP", "TEMP"]) process.env[key] = FILE_TMP;
 process.on("exit", () => {
   try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* already gone */ }

--- a/test/file-tmpdir.mjs
+++ b/test/file-tmpdir.mjs
@@ -1,0 +1,20 @@
+// A private TMPDIR for the importing test file — `import "./file-tmpdir.mjs";`,
+// for side effect, first among its imports.
+//
+// The ENV VAR rather than a path threaded through each spawn: the launcher
+// writes `cache-fix-proxy-<port>.sha256` and its scratch CA under its OWN
+// os.tmpdir(), so the isolation only reaches it by being inherited. node:test
+// gives each FILE its own process, so one dir per file falls out of that.
+//
+// `exit`, not after(): it runs after every hook, so it cannot delete the dir
+// out from under a sweep that reaps ports once the cases are done, and it is
+// armed before the importing file's body runs rather than at the end of it.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-test-"));
+process.env.TMPDIR = FILE_TMP;
+process.on("exit", () => {
+  try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* already gone */ }
+});

--- a/test/file-tmpdir.mjs
+++ b/test/file-tmpdir.mjs
@@ -14,7 +14,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-test-"));
-process.env.TMPDIR = FILE_TMP;
+// ALL THREE. os.tmpdir() reads TMPDIR on POSIX and TEMP then TMP on Windows, so
+// setting only the key THIS platform happens to read leaves the other one
+// writing to the shared root -- and an assertion that the inherited directory is
+// empty then passes because it was never used, not because anything moved.
+for (const key of ["TMPDIR", "TMP", "TEMP"]) process.env[key] = FILE_TMP;
 process.on("exit", () => {
   try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* already gone */ }
 });

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -5,13 +5,21 @@ import net from "node:net";
 import { execFileSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { writeFile, rm } from "node:fs/promises";
-import { readdirSync, readFileSync, existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir, availableParallelism } from "node:os";
 import { join, dirname } from "node:path";
 
 import { sourceFingerprintSync } from "../proxy/source-fingerprint.mjs";
 import { HOP_ENV, OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
+
+// A PRIVATE TMPDIR FOR THE WHOLE FILE. Every launcher spawned here inherits
+// process.env, and the launcher writes cache-fix-proxy-<port>.sha256 under
+// os.tmpdir() on each spawn — so without this the run leaves those records in
+// the shared /tmp, one per spawn. Set once rather than at each spawn site: the
+// env is inherited, so this also covers sites added later.
+const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-hp-"));
+process.env.TMPDIR = FILE_TMP;
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -2366,3 +2374,7 @@ after(async () => {
     await new Promise((r) => setTimeout(r, 700));
   }
 });
+
+// LAST, so it cannot delete the dir out from under a sweep that reaps ports
+// after the cases: node runs root hooks in registration order.
+after(() => { try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* gone */ } });

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -1,3 +1,6 @@
+// A private TMPDIR for this file, because the launchers spawned below write
+// under os.tmpdir(). First, so nothing reads one before it is set.
+import "./file-tmpdir.mjs";
 import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
@@ -5,21 +8,13 @@ import net from "node:net";
 import { execFileSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { writeFile, rm } from "node:fs/promises";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { readdirSync, readFileSync, existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync, utimesSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir, availableParallelism } from "node:os";
 import { join, dirname } from "node:path";
 
 import { sourceFingerprintSync } from "../proxy/source-fingerprint.mjs";
 import { HOP_ENV, OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
-
-// A PRIVATE TMPDIR FOR THE WHOLE FILE. Every launcher spawned here inherits
-// process.env, and the launcher writes cache-fix-proxy-<port>.sha256 under
-// os.tmpdir() on each spawn — so without this the run leaves those records in
-// the shared /tmp, one per spawn. Set once rather than at each spawn site: the
-// env is inherited, so this also covers sites added later.
-const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-hp-"));
-process.env.TMPDIR = FILE_TMP;
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -2374,7 +2369,3 @@ after(async () => {
     await new Promise((r) => setTimeout(r, 700));
   }
 });
-
-// LAST, so it cannot delete the dir out from under a sweep that reaps ports
-// after the cases: node runs root hooks in registration order.
-after(() => { try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* gone */ } });

--- a/test/proxy-holder-handover.test.mjs
+++ b/test/proxy-holder-handover.test.mjs
@@ -8,8 +8,17 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
+
+// A PRIVATE TMPDIR FOR THE WHOLE FILE. Every launcher spawned here inherits
+// process.env, and the launcher writes cache-fix-proxy-<port>.sha256 under
+// os.tmpdir() on each spawn — so without this the run leaves those records in
+// the shared /tmp, one per spawn, for every box the suite has ever run on.
+// Set once here rather than at each spawn site: the env is inherited, so this
+// also covers spawn sites added later.
+const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-hh-"));
+process.env.TMPDIR = FILE_TMP;
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -1011,3 +1020,7 @@ describe("openGap identity", () => {
   assert.ok(holder._gap === second, "a late 'error' from the retired gap cleared the live one");
 });
 });
+
+// LAST, so it cannot delete the dir out from under a sweep that reaps ports
+// after the cases: node runs root hooks in registration order.
+after(() => { try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* gone */ } });

--- a/test/proxy-holder-handover.test.mjs
+++ b/test/proxy-holder-handover.test.mjs
@@ -1,3 +1,6 @@
+// A private TMPDIR for this file, because the launchers spawned below write
+// under os.tmpdir(). First, so nothing reads one before it is set.
+import "./file-tmpdir.mjs";
 import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
@@ -8,17 +11,8 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
-
-// A PRIVATE TMPDIR FOR THE WHOLE FILE. Every launcher spawned here inherits
-// process.env, and the launcher writes cache-fix-proxy-<port>.sha256 under
-// os.tmpdir() on each spawn — so without this the run leaves those records in
-// the shared /tmp, one per spawn, for every box the suite has ever run on.
-// Set once here rather than at each spawn site: the env is inherited, so this
-// also covers spawn sites added later.
-const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-hh-"));
-process.env.TMPDIR = FILE_TMP;
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -1020,7 +1014,3 @@ describe("openGap identity", () => {
   assert.ok(holder._gap === second, "a late 'error' from the retired gap cleared the live one");
 });
 });
-
-// LAST, so it cannot delete the dir out from under a sweep that reaps ports
-// after the cases: node runs root hooks in registration order.
-after(() => { try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* gone */ } });

--- a/test/proxy-server.test.mjs
+++ b/test/proxy-server.test.mjs
@@ -5,13 +5,21 @@ import net from "node:net";
 import { execFileSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { mkdir, writeFile, rm } from "node:fs/promises";
-import { readdirSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { startProxy, upstreamPointsAtSelf } from "../proxy/server.mjs";
 import { startWatcher } from "../proxy/watcher.mjs";
 import { loadExtensions, getRegistry } from "../proxy/pipeline.mjs";
 import { OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
+
+// A PRIVATE TMPDIR FOR THE WHOLE FILE. Every launcher spawned here inherits
+// process.env, and the launcher writes cache-fix-proxy-<port>.sha256 under
+// os.tmpdir() on each spawn — so without this the run leaves those records in
+// the shared /tmp, one per spawn. Set once rather than at each spawn site: the
+// env is inherited, so this also covers sites added later.
+const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-ps-"));
+process.env.TMPDIR = FILE_TMP;
 
 const serverPath = join(dirname(fileURLToPath(import.meta.url)), "..", "proxy", "server.mjs");
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
@@ -1047,3 +1055,7 @@ describe("client-abandon abort", () => {
     } finally { restore(saved); if (h) await h.close(); }
   });
 });
+
+// LAST, so it cannot delete the dir out from under a sweep that reaps ports
+// after the cases: node runs root hooks in registration order.
+after(() => { try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* gone */ } });

--- a/test/proxy-server.test.mjs
+++ b/test/proxy-server.test.mjs
@@ -1,3 +1,6 @@
+// A private TMPDIR for this file, because the launchers spawned below write
+// under os.tmpdir(). First, so nothing reads one before it is set.
+import "./file-tmpdir.mjs";
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
@@ -5,21 +8,13 @@ import net from "node:net";
 import { execFileSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { mkdir, writeFile, rm } from "node:fs/promises";
-import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { startProxy, upstreamPointsAtSelf } from "../proxy/server.mjs";
 import { startWatcher } from "../proxy/watcher.mjs";
 import { loadExtensions, getRegistry } from "../proxy/pipeline.mjs";
 import { OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
-
-// A PRIVATE TMPDIR FOR THE WHOLE FILE. Every launcher spawned here inherits
-// process.env, and the launcher writes cache-fix-proxy-<port>.sha256 under
-// os.tmpdir() on each spawn — so without this the run leaves those records in
-// the shared /tmp, one per spawn. Set once rather than at each spawn site: the
-// env is inherited, so this also covers sites added later.
-const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-ps-"));
-process.env.TMPDIR = FILE_TMP;
 
 const serverPath = join(dirname(fileURLToPath(import.meta.url)), "..", "proxy", "server.mjs");
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
@@ -1055,7 +1050,3 @@ describe("client-abandon abort", () => {
     } finally { restore(saved); if (h) await h.close(); }
   });
 });
-
-// LAST, so it cannot delete the dir out from under a sweep that reaps ports
-// after the cases: node runs root hooks in registration order.
-after(() => { try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* gone */ } });

--- a/test/proxy-shutdown-once.test.mjs
+++ b/test/proxy-shutdown-once.test.mjs
@@ -10,15 +10,24 @@
 // mutation-checked; it needed isolating, not deleting.
 //
 // node gives each FILE its own process, which is the whole mechanism.
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
 import net from "node:net";
 import { spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { OURS, cmdOf, freePort, listeners } from "./proc-helpers.mjs";
+import { tmpdir } from "node:os";
+
+// A PRIVATE TMPDIR FOR THE WHOLE FILE. Every launcher spawned here inherits
+// process.env, and the launcher writes cache-fix-proxy-<port>.sha256 under
+// os.tmpdir() on each spawn — so without this the run leaves those records in
+// the shared /tmp, one per spawn. Set once rather than at each spawn site: the
+// env is inherited, so this also covers sites added later.
+const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-so-"));
+process.env.TMPDIR = FILE_TMP;
 
 const here = dirname(fileURLToPath(import.meta.url));
 const launcherPath = join(here, "..", "bin", "claude-via-proxy.mjs");
@@ -234,3 +243,7 @@ describe("shutdown runs once per stop", () => {
     }
   });
 });
+
+// LAST, so it cannot delete the dir out from under a sweep that reaps ports
+// after the cases: node runs root hooks in registration order.
+after(() => { try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* gone */ } });

--- a/test/proxy-shutdown-once.test.mjs
+++ b/test/proxy-shutdown-once.test.mjs
@@ -10,24 +10,19 @@
 // mutation-checked; it needed isolating, not deleting.
 //
 // node gives each FILE its own process, which is the whole mechanism.
-import { after, describe, it } from "node:test";
+
+// A private TMPDIR for this file, because the launchers spawned below write
+// under os.tmpdir(). First, so nothing reads one before it is set.
+import "./file-tmpdir.mjs";
+import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
 import net from "node:net";
 import { spawn } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { OURS, cmdOf, freePort, listeners } from "./proc-helpers.mjs";
-import { tmpdir } from "node:os";
-
-// A PRIVATE TMPDIR FOR THE WHOLE FILE. Every launcher spawned here inherits
-// process.env, and the launcher writes cache-fix-proxy-<port>.sha256 under
-// os.tmpdir() on each spawn — so without this the run leaves those records in
-// the shared /tmp, one per spawn. Set once rather than at each spawn site: the
-// env is inherited, so this also covers sites added later.
-const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-so-"));
-process.env.TMPDIR = FILE_TMP;
 
 const here = dirname(fileURLToPath(import.meta.url));
 const launcherPath = join(here, "..", "bin", "claude-via-proxy.mjs");
@@ -243,7 +238,3 @@ describe("shutdown runs once per stop", () => {
     }
   });
 });
-
-// LAST, so it cannot delete the dir out from under a sweep that reaps ports
-// after the cases: node runs root hooks in registration order.
-after(() => { try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* gone */ } });

--- a/test/proxy-wrapper.test.mjs
+++ b/test/proxy-wrapper.test.mjs
@@ -37,6 +37,13 @@ function tempDir(prefix) {
   tempDirs.push(d);
   return d;
 }
+// A PRIVATE TMPDIR FOR THE WHOLE FILE, for the same reason the launcher-spawning
+// files carry one: runWrapper forks the wrapper with the inherited env, and the
+// launcher writes its scratch CA under os.tmpdir() — measured, 7
+// cache-fix-ca-scratch-* dirs left in the shared /tmp per run, collected by the
+// launcher's own reaper only after seven days.
+process.env.TMPDIR = tempDir("ccf-pw-");
+
 after(() => {
   for (const d of tempDirs) {
     try { rmSync(d, { recursive: true, force: true }); } catch { /* already gone */ }

--- a/test/proxy-wrapper.test.mjs
+++ b/test/proxy-wrapper.test.mjs
@@ -1,3 +1,6 @@
+// A private TMPDIR for this file, because the launchers spawned below write
+// under os.tmpdir(). First, so nothing reads one before it is set.
+import "./file-tmpdir.mjs";
 import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { withDeadline, exitWithin } from "./child-deadline.mjs";
@@ -37,13 +40,6 @@ function tempDir(prefix) {
   tempDirs.push(d);
   return d;
 }
-// A PRIVATE TMPDIR FOR THE WHOLE FILE, for the same reason the launcher-spawning
-// files carry one: runWrapper forks the wrapper with the inherited env, and the
-// launcher writes its scratch CA under os.tmpdir() — measured, 7
-// cache-fix-ca-scratch-* dirs left in the shared /tmp per run, collected by the
-// launcher's own reaper only after seven days.
-process.env.TMPDIR = tempDir("ccf-pw-");
-
 after(() => {
   for (const d of tempDirs) {
     try { rmSync(d, { recursive: true, force: true }); } catch { /* already gone */ }

--- a/test/stdio-epipe-survival.test.mjs
+++ b/test/stdio-epipe-survival.test.mjs
@@ -22,14 +22,23 @@
 // mode, and the holder through BOTH of its dispatch doors — `server` with
 // CACHE_FIX_HOLD_PORT=on was the one an earlier fix missed while the other
 // passed, so a single holder row would have called that fixed.
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import net from "node:net";
 import { spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { withDeadline } from "./child-deadline.mjs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+// A PRIVATE TMPDIR FOR THE WHOLE FILE. Every launcher spawned here inherits
+// process.env, and the launcher writes cache-fix-proxy-<port>.sha256 under
+// os.tmpdir() on each spawn — so without this the run leaves those records in
+// the shared /tmp, one per spawn. Set once rather than at each spawn site: the
+// env is inherited, so this also covers sites added later.
+const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-se-"));
+process.env.TMPDIR = FILE_TMP;
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const reap = (p) => { try { process.kill(-p.pid, "SIGKILL"); } catch {} try { p.kill("SIGKILL"); } catch {} };
@@ -192,3 +201,7 @@ describe("a dead stdio reader does not kill the port's process", () => {
 // does this holder have", which is a number on the machine, not a shape in the
 // source. `openStandby` states the same identity rule twenty lines below and had
 // always followed it; this is the sibling that was missed in the same sweep.
+
+// LAST, so it cannot delete the dir out from under a sweep that reaps ports
+// after the cases: node runs root hooks in registration order.
+after(() => { try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* gone */ } });

--- a/test/stdio-epipe-survival.test.mjs
+++ b/test/stdio-epipe-survival.test.mjs
@@ -22,23 +22,18 @@
 // mode, and the holder through BOTH of its dispatch doors — `server` with
 // CACHE_FIX_HOLD_PORT=on was the one an earlier fix missed while the other
 // passed, so a single holder row would have called that fixed.
-import { after, describe, it } from "node:test";
+
+// A private TMPDIR for this file, because the launchers spawned below write
+// under os.tmpdir(). First, so nothing reads one before it is set.
+import "./file-tmpdir.mjs";
+import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import net from "node:net";
 import { spawn } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { withDeadline } from "./child-deadline.mjs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { tmpdir } from "node:os";
-
-// A PRIVATE TMPDIR FOR THE WHOLE FILE. Every launcher spawned here inherits
-// process.env, and the launcher writes cache-fix-proxy-<port>.sha256 under
-// os.tmpdir() on each spawn — so without this the run leaves those records in
-// the shared /tmp, one per spawn. Set once rather than at each spawn site: the
-// env is inherited, so this also covers sites added later.
-const FILE_TMP = mkdtempSync(join(tmpdir(), "ccf-se-"));
-process.env.TMPDIR = FILE_TMP;
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const reap = (p) => { try { process.kill(-p.pid, "SIGKILL"); } catch {} try { p.kill("SIGKILL"); } catch {} };
@@ -201,7 +196,3 @@ describe("a dead stdio reader does not kill the port's process", () => {
 // does this holder have", which is a number on the machine, not a shape in the
 // source. `openStandby` states the same identity rule twenty lines below and had
 // always followed it; this is the sibling that was missed in the same sweep.
-
-// LAST, so it cannot delete the dir out from under a sweep that reaps ports
-// after the cases: node runs root hooks in registration order.
-after(() => { try { rmSync(FILE_TMP, { recursive: true, force: true }); } catch { /* gone */ } });

--- a/test/tmp-isolation.test.mjs
+++ b/test/tmp-isolation.test.mjs
@@ -30,7 +30,12 @@ writeFileSync(join(tmpdir(), "mine"), "");
 spawnSync(process.execPath, ["-e", ${JSON.stringify(KID)}]);
 for (const m of ["mine", "kids"]) {
   if (!existsSync(join(tmpdir(), m))) { console.error("marker never written: " + m); process.exit(3); }
-}`;
+}
+// EVERY key, not just the one this platform reads first. The spawn below points
+// all three at the inherited directory, so a helper that moves only one leaves
+// the others naming it -- which is what a Windows os.tmpdir() would follow.
+const stray = ["TMPDIR", "TMP", "TEMP"].filter((k) => process.env[k] !== tmpdir());
+if (stray.length) { console.error("still on the inherited root: " + stray.join(",")); process.exit(4); }`;
 
 test("a process that imports it leaves the tmpdir it inherited empty", () => {
   const outer = mkdtempSync(join(tmpdir(), "ccf-tmpiso-"));
@@ -49,31 +54,6 @@ test("a process that imports it leaves the tmpdir it inherited empty", () => {
       "the process left scratch in the tmpdir it inherited — on a developer's box " +
       "that is the shared /tmp, where the launcher's records are named after ports " +
       "a live proxy may be serving");
-  } finally {
-    rmSync(outer, { recursive: true, force: true });
-  }
-});
-
-test("it redirects every key os.tmpdir() reads, not just this platform's", () => {
-  // os.tmpdir() reads TMPDIR on POSIX and TEMP then TMP on Windows. Setting only
-  // the one THIS platform happens to read leaves a Windows run writing to the
-  // shared root -- and the case above still passes there, because the inherited
-  // directory is empty for never having been used rather than for being isolated.
-  // That is the shape the brief calls out: a green suite proving the wrong path.
-  const PROBE_KEYS = `
-import ${JSON.stringify(MODULE)};
-import { tmpdir } from "node:os";
-const priv = tmpdir();
-const bad = ["TMPDIR", "TMP", "TEMP"].filter((k) => process.env[k] !== priv);
-if (bad.length) { console.error("still on the inherited root: " + bad.join(",")); process.exit(4); }
-`;
-  const outer = mkdtempSync(join(tmpdir(), "ccf-tmpkeys-"));
-  try {
-    const r = spawnSync(process.execPath, ["--input-type=module", "-e", PROBE_KEYS],
-                        { env: { ...process.env, TMPDIR: outer, TMP: outer, TEMP: outer },
-                          encoding: "utf8", timeout: 30_000 });
-    assert.equal(r.status, 0,
-      `a key os.tmpdir() can read was left on the inherited root: ${r.stderr.trim()}`);
   } finally {
     rmSync(outer, { recursive: true, force: true });
   }

--- a/test/tmp-isolation.test.mjs
+++ b/test/tmp-isolation.test.mjs
@@ -1,0 +1,51 @@
+// What file-tmpdir.mjs sells, measured through a real process boundary rather
+// than read off its source.
+//
+// The property is not "the file cleans up after itself". It is that the scratch
+// of the process AND of everything it spawns lands somewhere private that is
+// gone when the process exits — the launcher writes its port record under its
+// own os.tmpdir(), and on a box that is also RUNNING the product that record is
+// named after a port a live holder may be serving.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MODULE = join(dirname(fileURLToPath(import.meta.url)), "file-tmpdir.mjs");
+// The grandchild is the point: the launcher is a CHILD and reads its own
+// os.tmpdir(), so a redirection that does not cross the boundary isolates
+// nothing. Both markers are checked by the probe before it exits, because an
+// empty directory proves nothing if neither was ever written.
+const KID = 'require("node:fs").writeFileSync(require("node:path").join(require("node:os").tmpdir(), "kids"), "")';
+const PROBE = `
+import ${JSON.stringify(MODULE)};
+import { existsSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+writeFileSync(join(tmpdir(), "mine"), "");
+spawnSync(process.execPath, ["-e", ${JSON.stringify(KID)}]);
+for (const m of ["mine", "kids"]) {
+  if (!existsSync(join(tmpdir(), m))) { console.error("marker never written: " + m); process.exit(3); }
+}`;
+
+test("a process that imports it leaves the tmpdir it inherited empty", () => {
+  const outer = mkdtempSync(join(tmpdir(), "ccf-tmpiso-"));
+  try {
+    const r = spawnSync(process.execPath, ["--input-type=module", "-e", PROBE],
+                        { env: { ...process.env, TMPDIR: outer }, encoding: "utf8", timeout: 30_000 });
+    assert.equal(r.status, 0,
+      `the probe never got far enough to measure anything: ${r.error ?? ""} ${r.stderr}`);
+    // Red both ways: with no redirection the markers land here, and with no
+    // cleanup the private dir stays here holding them.
+    assert.deepEqual(readdirSync(outer), [],
+      "the process left scratch in the tmpdir it inherited — on a developer's box " +
+      "that is the shared /tmp, where the launcher's records are named after ports " +
+      "a live proxy may be serving");
+  } finally {
+    rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/test/tmp-isolation.test.mjs
+++ b/test/tmp-isolation.test.mjs
@@ -36,7 +36,11 @@ test("a process that imports it leaves the tmpdir it inherited empty", () => {
   const outer = mkdtempSync(join(tmpdir(), "ccf-tmpiso-"));
   try {
     const r = spawnSync(process.execPath, ["--input-type=module", "-e", PROBE],
-                        { env: { ...process.env, TMPDIR: outer }, encoding: "utf8", timeout: 30_000 });
+                        // Every key, for the reason the case below measures: on
+                        // Windows os.tmpdir() would ignore TMPDIR and this would
+                        // pass without the redirection ever being exercised.
+                        { env: { ...process.env, TMPDIR: outer, TMP: outer, TEMP: outer },
+                          encoding: "utf8", timeout: 30_000 });
     assert.equal(r.status, 0,
       `the probe never got far enough to measure anything: ${r.error ?? ""} ${r.stderr}`);
     // Red both ways: with no redirection the markers land here, and with no
@@ -45,6 +49,31 @@ test("a process that imports it leaves the tmpdir it inherited empty", () => {
       "the process left scratch in the tmpdir it inherited — on a developer's box " +
       "that is the shared /tmp, where the launcher's records are named after ports " +
       "a live proxy may be serving");
+  } finally {
+    rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("it redirects every key os.tmpdir() reads, not just this platform's", () => {
+  // os.tmpdir() reads TMPDIR on POSIX and TEMP then TMP on Windows. Setting only
+  // the one THIS platform happens to read leaves a Windows run writing to the
+  // shared root -- and the case above still passes there, because the inherited
+  // directory is empty for never having been used rather than for being isolated.
+  // That is the shape the brief calls out: a green suite proving the wrong path.
+  const PROBE_KEYS = `
+import ${JSON.stringify(MODULE)};
+import { tmpdir } from "node:os";
+const priv = tmpdir();
+const bad = ["TMPDIR", "TMP", "TEMP"].filter((k) => process.env[k] !== priv);
+if (bad.length) { console.error("still on the inherited root: " + bad.join(",")); process.exit(4); }
+`;
+  const outer = mkdtempSync(join(tmpdir(), "ccf-tmpkeys-"));
+  try {
+    const r = spawnSync(process.execPath, ["--input-type=module", "-e", PROBE_KEYS],
+                        { env: { ...process.env, TMPDIR: outer, TMP: outer, TEMP: outer },
+                          encoding: "utf8", timeout: 30_000 });
+    assert.equal(r.status, 0,
+      `a key os.tmpdir() can read was left on the inherited root: ${r.stderr.trim()}`);
   } finally {
     rmSync(outer, { recursive: true, force: true });
   }


### PR DESCRIPTION
## The shared /tmp is not the launcher's

Eight test files spawn the launcher, and the launcher writes under its **own** `os.tmpdir()` — `cache-fix-proxy-<port>.sha256` and a scratch CA. On a box that is also *running* the product, that record is named after a port a live holder may be serving, and the suite's copies land beside the real ones.

Each spawning file now gets a private temp directory, set at module scope before its body runs:

```js
import "./file-tmpdir.mjs";   // for side effect, first among its imports
```

The env var rather than a path threaded through each spawn: the launcher is a **child** and reads its own `os.tmpdir()`, so the redirection only reaches it by being inherited. `node:test` gives each file its own process, so one directory per file falls out of that.

## Every key `os.tmpdir()` reads, not just this platform's

Measured from node's own `os.tmpdir` source, and confirmed empirically on 18 / 20 / 24:

| platform | read order |
| --- | --- |
| POSIX | `TMPDIR` → `TMP` → `TEMP` → `/tmp` |
| Windows | `TEMP` → `TMP` → `SystemRoot\temp` |

Setting only `TMPDIR` left a Windows run writing to the shared root — and the smoke case could not report it, because it spawned its probe with `TMPDIR: outer` and asserted `outer` was empty. On Windows `outer` is empty because `os.tmpdir()` never looked at it, not because anything was isolated. A green suite proving the wrong path.

All three keys are set now, and the probe spawn points all three at the inherited directory so the redirect is actually exercised whatever the platform reads.

## Cleanup on `exit`, not `after()`

`process.on("exit")` runs after every hook, so it cannot delete the directory out from under a sweep that reaps ports once the cases are done, and it is armed before the importing file's body runs rather than at the end of it.

## Verification

The case drives a real child and checks **both** markers — its own and its grandchild's — before asserting the inherited directory is empty, because an empty directory proves nothing if neither was ever written.

| reverted | dies |
| --- | --- |
| the redirect removed entirely | `the process left scratch in the tmpdir it inherited` |
| `TMPDIR` alone, as it was | `still on the inherited root: TMP,TEMP` |
| the cleanup hook removed | `the process left scratch in the tmpdir it inherited` |

Three for three, from **one** case. An earlier revision split this across two and the second was green against a helper that redirects nothing — it asserted the three keys *agreed*, and with all three pointed at the inherited directory they agree whether or not anything moved. Agreement was never the property; movement is.

**8 files changed, +104.** New files: 2 (`test/file-tmpdir.mjs`, `test/tmp-isolation.test.mjs`). New exports, env vars: 0 — `TMPDIR`/`TMP`/`TEMP` are set, not introduced.

## Known, and not fixed here

- CI runs this suite on **Linux only** (`ubuntu-latest` ×3; the one macOS job is path-filtered to a shim and never runs `npm test`). The Windows half is reasoned from node's source and a resolution-order simulation, not from a Windows run.
- Four single-key `TMPDIR` overrides elsewhere in the suite stay Windows-blind (`proxy-wrapper.test.mjs:1143`, `:1338`, `:1343`; `proxy-held-port.test.mjs:1994`), and two launcher-spawning files do not import the helper (`proxy-probe-bounded.test.mjs:86`, `install-service.test.mjs:830`). Both measured leaving nothing behind today.
