### PR TITLE
fix(test): classify() must survive a probe that answers with a status code

### DIFF
--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -45,6 +45,13 @@ const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", 
 // them, so the body is tested before the code.
 const OUTAGE = { REFUSED: "refused", RESET: "reset", DEGRADED: "degraded" };
 function classify(body) {
+  // A NUMBER IS NOT AN OUTAGE, AND MUST NOT BE A TypeError EITHER. Six of this
+  // file's seven probes resolve `ERR:${e.code}`; the seventh resolves a bare
+  // statusCode on success, and its caller filters out 200 and hands the rest
+  // here. Measured on CI Node 22: one 502 reached this line and the case died
+  // as `body.startsWith is not a function` — a crash where the answer is
+  // simply "that was a reply, not an outage".
+  if (typeof body !== "string") return null;
   if (!body.startsWith("ERR:")) return null;
   if (/"carrying"\s*:\s*"gap-relay"/.test(body)) return null;
   if (/"status"\s*:\s*"degraded"/.test(body)) return OUTAGE.DEGRADED;
@@ -124,6 +131,20 @@ async function freePort() {
 const CONCURRENCY = Math.max(1, Math.floor(availableParallelism() / 2));
 
 describe("held port (CACHE_FIX_HOLD_PORT)", { concurrency: CONCURRENCY }, () => {
+
+  // THE SEVENTH PROBE RESOLVES A NUMBER. Six of this file's probes resolve
+  // `ERR:${e.code}`; the one at the forced-kill case resolves a bare statusCode
+  // on success, and its caller filters out 200 and hands the rest to classify().
+  // A 502 therefore reaches it as a Number. Pinned as a unit case because the
+  // path only opens when a non-200 is actually observed — CI Node 22 saw one and
+  // the case died as `body.startsWith is not a function`, three runners apart
+  // from where it was introduced.
+  it("classify survives a probe that answers with a status code", () => {
+    assert.equal(classify(502), null, "a status code is a reply, not an outage");
+    assert.equal(classify(200), null);
+    assert.equal(classify("ERR:ECONNREFUSED"), OUTAGE.REFUSED);
+    assert.equal(classify("ECONNRESET"), null, "no ERR: prefix means it is not ours to classify");
+  });
 // The default is declared in proxy/config.mjs and repeated in the launcher.
 // If they drift, an unset CACHE_FIX_PROXY_PORT binds one port while callers
 // dial the other.


### PR DESCRIPTION
## The failure

CI red on Node 22, in `refuses nothing when the proxy under it dies`:

```
error: 'body.startsWith is not a function'
name: 'TypeError'
```

## The cause

`test/proxy-held-port.test.mjs` has seven inline health probes. **Six** resolve `` `ERR:${e.code}` `` — a string carrying the prefix `classify()` tests for:

```js
}).on("error", (e) => res(`ERR:${e.code}`));      // ×6
```

The **seventh**, at the forced-kill case, resolves a bare status code on success and a bare error code on failure:

```js
r.resume(); r.on("end", () => res(r.statusCode));   // a Number
}).on("error", (e) => res(e.code));                 // a string, no prefix
```

Its caller filters out 200 and hands everything else straight to `classify()`:

```js
const cut = seen.filter((c) => c !== 200);
const refused = cut.filter((c) => classify(c) === OUTAGE.REFUSED);
```

So a 502 arrives as a `Number` and `classify()` dies on `.startsWith`, in a place where the correct answer is simply *that was a reply, not an outage*.

## Why it took this long to surface

The path only opens when a non-200 is **actually observed** during that forced kill. Every local run and three CI matrices had none. That is also why it must be pinned by a unit case rather than left to the integration case that happens to reach it.

## The change

```js
if (typeof body !== "string") return null;
```

plus a unit case fixing the four answers:

| input | classify |
|---|---|
| `502` | `null` — a status code is a reply, not an outage |
| `200` | `null` |
| `"ERR:ECONNREFUSED"` | `OUTAGE.REFUSED` |
| `"ECONNRESET"` | `null` — no `ERR:` prefix, not ours to classify |

**Measured:** removing the type guard reds that unit case with the exact CI message, `body.startsWith is not a function`. Full file 35/35 with the guard.

## Scope

Not caused by the branch that surfaced it — that branch touches neither this file nor `classify()`. Sent on its own so it can land independently.

Left alone deliberately: the seventh probe still resolves a different shape from the other six. Normalising it to `` `ERR:${e.code}` `` would change what the forced-kill case's `seen.filter((c) => c !== 200)` compares against, and that comparison is load-bearing for the assertion below it. The guard fixes the crash without moving that.

— Proxy Builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
