### PR TITLE
test: cap suite concurrency at 8, because the tests starve each other

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node --test",
+    "test": "node --test --test-concurrency=8",
     "postinstall": "node postinstall.js"
   },
   "dependencies": {


### PR DESCRIPTION
## The symptom

The suite reds a **different case on almost every full run**. Measured over five interleaved rounds on a 48-core box, six distinct cases failed and **not one repeated**:

- `announces its release exactly once, however many stop signals arrive`
- `shutdown runs once per stop`
- `reverse mode: absolute-form keeps the 404 contract (no relay)`
- `stops when signalled between the proxy's death and its respawn`
- `still says a deploy landed when the proxy restarted into it`
- `fails loudly when the bind address can never work, rather than exiting 0`

A branch that is actually broken reds the *same* case. A wandering red is a different animal.

## The cause

`node --test` runs `cpus - 1` files concurrently — **47** here. Fifteen of those files spawn launchers, **40 spawn sites** in total:

```
proxy-held-port          11      stdio-epipe-survival      3
proxy-holder-handover    10      gap-relay-chain           2
proxy-forward-ca          2      shutdown-exit-code        2
proxy-update-sweep        2      …and eight more with 1 each
```

Each launcher is a holder **plus** a child proxy **plus** a standby gap-relay. A full run can put well over a hundred processes on 48 cores. **The tests are the load.**

## Measured, changing nothing but the flag

One commit, three settings:

| concurrency | runs | failures | wall |
|---|---|---|---|
| `4` | 4 | **0** | 82 s |
| `8` | 4 | **0** | 52 s |
| default (47) | 5 | **3** | — |

Eight is both stabler **and faster** than the default. Past that the launchers spend the box's cores waiting on each other rather than doing work.

## What this replaces

An earlier commit on this branch widened `settleFor`'s window from 8 s to 30 s. That was a symptom fix and it is reverted here.

The restart ladder it waits out is `base * 2 ** min(failures, 5)` capped at `base * 20`, and the file sets base to 25 ms — so the backoff tops out at **500 ms**. An 8 s window was never too small for the ladder, only too small for a starved box. Widening it would have papered over the one case that happened to fail that way and left the other five untouched.

## Scope

One line in `package.json`. No test file changes.

— Proxy Builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
