### PR TITLE
fix(test): stop the suite signalling pids it does not own — SIGKILL kills `systemd --user`, SIGTERM logs you out

### DIFF
--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -26,6 +26,35 @@ import net from "node:net";
 // binaries have.
 export const OURS = /\/(?:bin|proxy)\/[\w.-]+\.mjs\b/;
 
+// AND THE SUITE'S OWN STAND-INS, which that predicate cannot see. Cases here
+// write a fake proxy into a fresh temp dir and run it — a real process, ours by
+// construction, whose path contains neither `bin/` nor `proxy/`. The launcher
+// stand-in escaped only by accident of LOCATION: its copy lands in `bin/`, so it
+// matched, while its server did not. Measured as five reds in CI run
+// 32409699496, every one of them killOurs() refusing to signal a fake proxy the
+// case had spawned itself moments earlier — a guard firing on legitimate work,
+// which is the failure that trains the `catch {}` this guard forbids.
+//
+// The evidence here is STRONGER than a path segment, not weaker, which is what
+// makes this a widening rather than a softening. Stand-in names are built from
+// `${process.pid}-${++fakeSeq}` (proxy-held-port.test.mjs), so a command line
+// carrying OUR pid inside a filename WE generated cannot belong to a stranger.
+// A bare `scratch-fake-server-` match could, and is deliberately not what this
+// does. Rebuilt per call rather than frozen at import, so a forked runner cannot
+// inherit its parent's claim.
+//
+// Scope, so the next reader does not widen further by analogy: this reaches
+// killOurs() ONLY. listeners() and ours() answer "which PROXY holds this port",
+// where a stand-in is not wanted, and every case needing its own stand-in
+// already finds it from the launcher it spawned.
+const scratchOurs = () =>
+  new RegExp(`\\bscratch-(?:launcher|fake-server)-${process.pid}-\\d+\\.mjs\\b`);
+
+/** Is this command line one of ours — our binaries, or our own stand-ins? */
+export function isOurs(cmd) {
+  return OURS.test(cmd) || scratchOurs().test(cmd);
+}
+
 // The command line of a pid, or "" if it is gone. Every case has to tell a
 // holder from a proxy from a standby relay, and they are only distinguishable
 // by what they are running.
@@ -156,11 +185,12 @@ export function killOurs(pid, signal = "SIGKILL") {
   if (!cmd) return false;
   // ALIVE AND NOT OURS IS THE DEFECT, and it is LOUD by design: a silent skip
   // is what let this run four times before anyone knew where it came from.
-  if (!OURS.test(cmd)) {
+  if (!isOurs(cmd)) {
     throw new Error(`refusing to ${signal} pid ${n}: it is alive and its command ` +
                     `line is not one of ours.\n` +
                     `  command: ${cmd}\n` +
                     `  ours:    ${OURS}\n` +
+                    `  or our own stand-ins: ${scratchOurs()}\n` +
                     `This is the guard that exists because this suite SIGKILLed the ` +
                     `session manager and took the desktop down with it. Filter the ` +
                     `pid at its source; do not catch this.`);

--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -118,6 +118,57 @@ export const HOP_ENV = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"
                         "CACHE_FIX_UPSTREAM_PROXY", "CACHE_FIX_REQUIRE_HOP",
                         "CACHE_FIX_FALLBACK_PROXIES"];
 
+// THE ONLY WAY THIS SUITE MAY SIGNAL A PID IT DID NOT SPAWN.
+//
+// A raw `process.kill(n, "SIGKILL")` over a pid list is one bad list away from
+// killing something that is not ours, and the machine gives no second chance:
+// a run here SIGKILLed `systemd --user`, which made PID 1 tear down the whole
+// session cgroup — every editor, browser and terminal on the desktop, four
+// times in one afternoon. The kernel audit record named the sender as this
+// suite's own runner; which call site passed the pid is STILL UNKNOWN, and
+// that is exactly why the check belongs at the choke point rather than at the
+// site someone suspects.
+//
+// THROWS rather than skipping, because a silent skip would have hidden this
+// for another four collapses. The throw carries the pid and its command line,
+// so the next occurrence is a red test naming the offender instead of a lost
+// desktop. `child.kill()` on a handle this process spawned is unaffected — it
+// cannot name a stranger — and needs no guard.
+export function killOurs(pid, signal = "SIGKILL") {
+  const n = Number(pid);
+  // NEGATIVE FIRST, or this branch is unreachable: every negative also fails
+  // `n <= 1`, so ordering it second made it dead code that read as a guard.
+  // Caught by the two-sided probe that proved this function, not by review.
+  if (Number.isInteger(n) && n < 0) {
+    throw new Error(`refusing to signal ${n}: a negative pid is a process-GROUP kill, ` +
+                    `and the group id is not ours to assume. Signal the members.`);
+  }
+  if (!Number.isInteger(n) || n <= 1) {
+    throw new Error(`refusing to signal pid ${JSON.stringify(pid)}: ` +
+                    `not a pid. Number("") and Number(undefined) are both 0, and ` +
+                    `process.kill(0, …) signals this runner's entire process group.`);
+  }
+  // GONE IS NOT AN OFFENCE. A cleanup sweep races the processes it reaps, so
+  // an empty command line means the pid died on its own — return false and let
+  // the loop continue. Throwing here would make every ordinary sweep red and
+  // train the `catch {}` that silences the real case below.
+  const cmd = cmdOf(n).trim();
+  if (!cmd) return false;
+  // ALIVE AND NOT OURS IS THE DEFECT, and it is LOUD by design: a silent skip
+  // is what let this run four times before anyone knew where it came from.
+  if (!OURS.test(cmd)) {
+    throw new Error(`refusing to ${signal} pid ${n}: it is alive and its command ` +
+                    `line is not one of ours.\n` +
+                    `  command: ${cmd}\n` +
+                    `  ours:    ${OURS}\n` +
+                    `This is the guard that exists because this suite SIGKILLed the ` +
+                    `session manager and took the desktop down with it. Filter the ` +
+                    `pid at its source; do not catch this.`);
+  }
+  process.kill(n, signal);
+  return true;
+}
+
 // THE CLEANUP SET: everything on this port, listening or not. listeners() alone
 // misses a standby that has handed its listen on — measured, ten such orphans at
 // once, the oldest 788 s, accumulating across files and runs until a later

--- a/test/proc-helpers.test.mjs
+++ b/test/proc-helpers.test.mjs
@@ -1,0 +1,80 @@
+// proc-helpers — the ownership predicate, which is the whole safety property of
+// this branch and had no test of its own until it shipped red.
+//
+// DEFINITION, written before the assertions. killOurs() exists to answer one
+// question: may this process signal that pid? It must answer YES for processes
+// this suite owns and NO for everything else, and BOTH directions are load
+// bearing:
+//
+//   a NO that should be YES is a guard firing on legitimate work. That is not
+//   a safe failure — it trains the `catch {}` around killOurs() that the guard
+//   itself forbids, and it is what happened: five reds in CI run 32409699496,
+//   every one of them refusing to signal a fake proxy the case had spawned
+//   itself moments earlier.
+//
+//   a YES that should be NO is the original outage: SIGKILL to `systemd --user`
+//   tears down the session cgroup, SIGTERM to it starts exit.target. Four
+//   desktops on 2026-08-20, one more on 2026-08-22.
+//
+// So the arms come in pairs and the negatives are not decoration. The one that
+// carries the most weight is "a DIFFERENT runner's stand-in": it has the exact
+// shape of one of ours and must still be refused, which is what separates
+// ownership evidence from a name that merely looks familiar. Without it, a bare
+// `scratch-fake-server-` match would pass every other arm here.
+//
+// The first case is the real command line from that CI run, with this process's
+// pid substituted for the runner's — a case known to carry the property, taken
+// from the failure rather than constructed to pass.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isOurs, OURS } from "./proc-helpers.mjs";
+
+const P = process.pid;
+
+const CASES = [
+  [`/opt/hostedtoolcache/node/22.23.2/x64/bin/node /tmp/ccf-fake-proxy-${P}-3-PDRL3r/scratch-fake-server-${P}-3.mjs`,
+   true, "our own fake proxy — the command line behind all five CI reds"],
+  [`/usr/bin/node /home/x/repo/bin/scratch-launcher-${P}-3.mjs`,
+   true, "our own launcher stand-in (matched before only by accident of living in bin/)"],
+  [`/usr/bin/node /home/x/repo/proxy/server.mjs`,
+   true, "the real proxy — OURS, and this must not have changed"],
+  [`/usr/bin/node /home/x/repo/bin/gap-relay.mjs`,
+   true, "a real bin/ helper — OURS, unchanged"],
+  [`/usr/bin/node /tmp/ccf-fake-proxy-${P + 1}-3-xx/scratch-fake-server-${P + 1}-3.mjs`,
+   false, "a DIFFERENT runner's stand-in — same shape, not ours"],
+  [`/usr/lib/systemd/systemd --user`,
+   false, "systemd --user — the process whose death takes the desktop with it"],
+  [`/usr/bin/node /home/x/other/tools/harvest.mjs`,
+   false, "an unrelated node process"],
+  [`node`,
+   false, "a bare interpreter claims nothing"],
+];
+
+test("the ownership predicate admits ours and refuses everything else", () => {
+  for (const [cmd, want, why] of CASES) {
+    assert.equal(isOurs(cmd), want, `${why}\n  command: ${cmd}`);
+  }
+});
+
+test("the stand-in claim is keyed to THIS process, not to the name", () => {
+  // The same file name under another runner's pid must not be claimable — this
+  // is the property that makes the widening ownership evidence rather than a
+  // softer pattern. Stated separately from the table so it cannot be lost in a
+  // future edit that "simplifies" the list.
+  const mine = `/usr/bin/node /tmp/d/scratch-fake-server-${P}-1.mjs`;
+  const theirs = `/usr/bin/node /tmp/d/scratch-fake-server-${P + 1}-1.mjs`;
+  assert.equal(isOurs(mine), true, "our own stand-in must be claimable");
+  assert.equal(isOurs(theirs), false, "another runner's stand-in must not be");
+  assert.notEqual(isOurs(mine), isOurs(theirs),
+    "the two must DIFFER — equal answers here mean the pid is not being read");
+});
+
+test("OURS itself is unchanged: it still refuses what it always refused", () => {
+  // isOurs() is a union, so a regression that widened OURS would be invisible
+  // in the table above. Assert on OURS directly.
+  assert.equal(OURS.test("/usr/lib/systemd/systemd --user"), false);
+  assert.equal(OURS.test(`/usr/bin/node /tmp/d/scratch-fake-server-${P}-1.mjs`), false,
+    "the stand-in must be admitted by the stand-in clause, never by OURS");
+  assert.equal(OURS.test("/usr/bin/node /home/x/repo/proxy/server.mjs"), true);
+});

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -973,7 +973,24 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
             try { target = Number(execFileSync("ps", ["-o", "ppid=", "-p", String(pid)],
                                                { encoding: "utf8" }).trim()) || pid; } catch {}
             if (target <= 1) target = pid;
-            try { process.kill(target, "SIGTERM"); } catch {}
+            // THE PARENT IS NOT COVERED BY listeners(). That filter established
+            // that the LISTENER is ours; `ps -o ppid=` then walks to a pid
+            // nothing has checked, and `target <= 1` tests liveness, not
+            // ownership. On a machine whose orphans reparent to a systemd USER
+            // manager — a child subreaper — a detached fixture's parent IS that
+            // manager.
+            //
+            // SIGTERM there is not a stop, it is a LOGOUT. systemd(1): "systemd
+            // user managers will start the exit.target unit when this signal is
+            // received. This is mostly equivalent to systemctl --user start
+            // exit.target". Measured 2026-08-20: a desktop session went down
+            // five seconds into a suite run, the journal showing "Activating
+            // special unit Exit the Session", and the kernel audit held no
+            // record — a rule armed for SIGKILL cannot see a SIGTERM.
+            //
+            // NOT wrapped in try/catch: the throw IS the mechanism. Catching it
+            // here restores the silence that let this run unattributed.
+            killOurs(target, "SIGTERM");
           }
           await new Promise((r) => setTimeout(r, 800));
         }
@@ -1205,7 +1222,24 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
             try { target = Number(execFileSync("ps", ["-o", "ppid=", "-p", String(pid)],
                                                { encoding: "utf8" }).trim()) || pid; } catch {}
             if (target <= 1) target = pid;
-            try { process.kill(target, "SIGTERM"); } catch {}
+            // THE PARENT IS NOT COVERED BY listeners(). That filter established
+            // that the LISTENER is ours; `ps -o ppid=` then walks to a pid
+            // nothing has checked, and `target <= 1` tests liveness, not
+            // ownership. On a machine whose orphans reparent to a systemd USER
+            // manager — a child subreaper — a detached fixture's parent IS that
+            // manager.
+            //
+            // SIGTERM there is not a stop, it is a LOGOUT. systemd(1): "systemd
+            // user managers will start the exit.target unit when this signal is
+            // received. This is mostly equivalent to systemctl --user start
+            // exit.target". Measured 2026-08-20: a desktop session went down
+            // five seconds into a suite run, the journal showing "Activating
+            // special unit Exit the Session", and the kernel audit held no
+            // record — a rule armed for SIGKILL cannot see a SIGTERM.
+            //
+            // NOT wrapped in try/catch: the throw IS the mechanism. Catching it
+            // here restores the silence that let this run unattributed.
+            killOurs(target, "SIGTERM");
           }
           await new Promise((r) => setTimeout(r, 800));
         }

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -11,7 +11,7 @@ import { tmpdir, availableParallelism } from "node:os";
 import { join, dirname } from "node:path";
 
 import { sourceFingerprintSync } from "../proxy/source-fingerprint.mjs";
-import { HOP_ENV, OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
+import { HOP_ENV, OURS, cmdOf, freePort as takePort, killOurs, listeners, onPort } from "./proc-helpers.mjs";
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -212,7 +212,7 @@ async function withHeldPort(fn, { subcommand = "server", extraEnv = {} } = {}) {
   const killProxy = () => {
     const pid = proxyPid();
     assert.ok(pid, "no proxy child to kill, so nothing was restarted");
-    process.kill(pid, "SIGKILL");
+    killOurs(pid);
   };
   try {
     const up = Date.now() + 20_000;
@@ -580,7 +580,7 @@ it("keeps the port and backs off when a proxy that had served stops starting", a
       const kid = Number(out.trim().split("\n").filter(Boolean)
         .find((q) => /scratch-fake-server-/.test(cmdOf(q))));
       assert.ok(Number.isInteger(kid) && kid > 1, "the fake proxy never started, so this measures nothing");
-      process.kill(kid, "SIGKILL");
+      killOurs(kid);
       // Long enough for an UNBACKED-OFF loop to blow the ceiling: at the 25ms
       // base the ladder tops out at 500ms, so ~1.2s admits at most a handful of
       // tries and a spinner would land dozens. Measured both ways below.
@@ -820,7 +820,7 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
           `ephemeral port nothing will reclaim`);
       } finally {
         try { holder.kill("SIGKILL"); } catch {}
-        if (kid > 1) { try { process.kill(kid, "SIGKILL"); } catch {} }
+        if (kid > 1) killOurs(kid);   // `> 1` is not ownership — see killOurs()
         // THE SUCCESSOR THIS CASE CAUSED. A child whose holder dies does not
         // simply exit — it spawns a DETACHED replacement on the advertised port,
         // which is the whole point of the self-heal. That successor is nobody's
@@ -849,11 +849,22 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
             // The holder is the listener's parent when there is one; killing it
             // first stops the ladder that would replace what we are about to
             // kill.
+            // `parent > 1` IS NOT AN OWNERSHIP TEST, and this is the line that
+            // killed a developer's desktop four times in one afternoon. An
+            // orphan does NOT reparent to pid 1 on a machine running a systemd
+            // USER manager: that manager is a child subreaper, so it inherits
+            // the orphan and `ps -o ppid=` returns ITS pid — 63 live processes
+            // here name it as their parent, this repo's own proxy among them.
+            // SIGKILLing it makes pid 1 tear down the whole session cgroup:
+            // every editor, browser and terminal, mid-work. CI never saw it
+            // because a container really does reparent to 1, which is why the
+            // assumption survived. Ownership is the command line, never the
+            // position in the tree.
             let parent = 0;
             try { parent = Number(execFileSync("ps", ["-p", pid, "-o", "ppid="],
                     { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim()); } catch {}
-            if (parent > 1) { try { process.kill(parent, "SIGKILL"); } catch {} }
-            try { process.kill(Number(pid), "SIGKILL"); } catch {}
+            if (parent > 1) killOurs(parent);
+            killOurs(pid);
           }
           await new Promise((r) => setTimeout(r, 200));
         }
@@ -1274,7 +1285,7 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
             try { kid = Number(execFileSync("pgrep", ["-P", String(launcher.pid)], { encoding: "utf8" })
                                 .trim().split("\n").filter(Boolean)
                                 .find((q) => /scratch-fake-server-/.test(cmdOf(q)))); } catch {}
-            if (kid > 1) { try { process.kill(kid, "SIGKILL"); } catch {} }
+            if (kid > 1) killOurs(kid);   // `> 1` is not ownership — see killOurs()
           }, 250);
           await hammer;
 
@@ -2230,7 +2241,7 @@ describe("deploy watcher (CACHE_FIX_WATCH_DEPLOY_MS)", () => {
       assert.ok(before, "the stand-in proxy never started, so this measures nothing");
       // The race made deterministic: the child goes at the moment the new bytes
       // land, so the respawn re-reads the file it is supposed to be announcing.
-      try { process.kill(before, "SIGKILL"); } catch { }
+      killOurs(before);
       await writeFile(serverFile, serving + "\n// deployed mid-restart\n");
       assert.ok(await saidWithin(stderr, 30_000),
         "a deploy landed while the proxy was restarting and nothing said so. The new " +
@@ -2254,7 +2265,7 @@ describe("deploy watcher (CACHE_FIX_WATCH_DEPLOY_MS)", () => {
     await withFakeProxy(serving, async ({ launcher, stderr }) => {
       const before = await settleFor(launcher, 0, 8_000);
       assert.ok(before, "the stand-in proxy never started");
-      try { process.kill(before, "SIGKILL"); } catch { }
+      killOurs(before);
       const after = await settleFor(launcher, before, 8_000);
       assert.ok(after && after !== before,
         "no respawn happened, so this measured nothing — the case needs a real restart");
@@ -2321,7 +2332,7 @@ describe("deploy watcher (CACHE_FIX_WATCH_DEPLOY_MS)", () => {
       const before = await settleFor(launcher, 0, 8_000);
       assert.ok(before, "the stand-in proxy never started");
       await writeFile(serverFile, serving + "\n// operator is editing\n");
-      try { process.kill(before, "SIGKILL"); } catch { }
+      killOurs(before);
       const after = await settleFor(launcher, before, 8_000);
       assert.ok(after && after !== before,
         "no respawn happened, so this measured nothing — the case needs a real restart");

--- a/test/proxy-holder-handover.test.mjs
+++ b/test/proxy-holder-handover.test.mjs
@@ -9,7 +9,7 @@ import { tmpdir } from "node:os";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
+import { OURS, cmdOf, freePort as takePort, killOurs, listeners, onPort } from "./proc-helpers.mjs";
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -165,7 +165,7 @@ describe("holder handover (SIGUSR2)", () => {
         `${relays.length} standby relays hold the port after a handover; one is the contract, ` +
         `two both arm when the lineage dies and take turns dropping connections`);
       for (const p of listeners(port).filter((q) => /\brun-service\b|server\.mjs/.test(cmdOf(q)))) {
-        try { process.kill(Number(p), "SIGKILL"); } catch { }
+        killOurs(p);
       }
       const by = Date.now() + 15_000;
       let after = await probe(port);
@@ -608,7 +608,7 @@ describe("holder handover (SIGUSR2)", () => {
       assert.ok(listeners(port).some((p) => /gap-relay/.test(cmdOf(p))),
         `no standby relay is on the port before the kill, so nothing could survive it. ` +
         `Launcher stderr: ${JSON.stringify(err.slice(-300))}`);
-      for (const p of doomed) { try { process.kill(Number(p), "SIGKILL"); } catch { } }
+      for (const p of doomed) { killOurs(p); }
 
       // The standby polls before it arms, so give it the window it asks for.
       const by = Date.now() + 15_000;

--- a/test/stdio-epipe-survival.test.mjs
+++ b/test/stdio-epipe-survival.test.mjs
@@ -162,15 +162,21 @@ describe("a dead stdio reader does not kill the port's process", () => {
       // of a machine whose process table was in trouble. An unbounded wait here
       // hangs the whole run instead of failing — the suite's own static guard
       // caught this one, which is the guard doing exactly its job.
-      const listeners = spawn("lsof", ["-nP", "-t", `-iTCP:${port}`, "-sTCP:LISTEN"], { stdio: ["ignore", "pipe", "ignore"] });
+      // LOOPBACK-SCOPED, matching proc-helpers.mjs. `-iTCP:<port>` matches a
+      // listener on ANY interface, so the answer could name a process that has
+      // nothing to do with this fixture and merely holds the same port number
+      // on another address. The fixture binds 127.0.0.1, so the narrower query
+      // is the correct one and the wider one was never intended.
+      const listeners = spawn("lsof", ["-nP", "-t", `-iTCP@127.0.0.1:${port}`, "-sTCP:LISTEN"], { stdio: ["ignore", "pipe", "ignore"] });
       let pids = ""; listeners.stdout.on("data", (d) => (pids += d));
       await withDeadline(new Promise((r) => listeners.on("exit", r)), 10_000, listeners,
                          "lsof never returned while looking for the proxy child");
       // THROUGH killOurs(), which is where the ours-only predicate lives. This
       // lsof is raw — it is not the shared `listeners()` helper despite the
-      // local name, and `-iTCP:` without `@127.0.0.1` matches a listener on ANY
-      // interface — so `n > 1 && n !== holder.pid` was the only thing standing
-      // between this loop and a stranger's pid.
+      // local name — so `n > 1 && n !== holder.pid` was the only thing standing
+      // between this loop and a stranger's pid. The raw call is kept for its
+      // DEADLINE (see above); what it lost was the filter, and that is restored
+      // here rather than by giving up the bound.
       for (const pid of pids.trim().split("\n").map(Number).filter((n) => n > 1 && n !== holder.pid)) {
         killOurs(pid);
       }

--- a/test/stdio-epipe-survival.test.mjs
+++ b/test/stdio-epipe-survival.test.mjs
@@ -28,6 +28,7 @@ import net from "node:net";
 import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { withDeadline } from "./child-deadline.mjs";
+import { killOurs } from "./proc-helpers.mjs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -165,8 +166,13 @@ describe("a dead stdio reader does not kill the port's process", () => {
       let pids = ""; listeners.stdout.on("data", (d) => (pids += d));
       await withDeadline(new Promise((r) => listeners.on("exit", r)), 10_000, listeners,
                          "lsof never returned while looking for the proxy child");
+      // THROUGH killOurs(), which is where the ours-only predicate lives. This
+      // lsof is raw — it is not the shared `listeners()` helper despite the
+      // local name, and `-iTCP:` without `@127.0.0.1` matches a listener on ANY
+      // interface — so `n > 1 && n !== holder.pid` was the only thing standing
+      // between this loop and a stranger's pid.
       for (const pid of pids.trim().split("\n").map(Number).filter((n) => n > 1 && n !== holder.pid)) {
-        try { process.kill(pid, "SIGKILL"); } catch {}
+        killOurs(pid);
       }
       await settle(1500);
       assert.equal(holder.exitCode, null,

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -907,28 +907,54 @@ test("the launcher parses a child-ready line from any address family", () => {
     `never marks the child served:\n  ${bad.join("\n  ")}`);
 });
 
-test("no test file asks lsof who holds a port", () => {
-  // ASSEMBLED, so the needle never appears whole in THIS file. Spelled out, the
-  // detector matched its own source and reported the guard as the violation.
-  const NEEDLE = 'execFileSync("' + 'lsof"';
-  // The ONE legitimate call lives in proc-helpers.mjs, which is not a .test.mjs
-  // — so any hit here is a cleanup that went around listeners() and its OURS
-  // filter. Four files did exactly that once, and two of them then walked UP to
-  // the listener's parent and sent SIGTERM; a stranger's parent is this runner.
-  //
-  // This used to also pin a copy of the OURS regex in every file that had one.
-  // There are no copies now: one definition cannot drift from itself, so the
-  // only thing left to police is a NEW inline call.
+test("no test file asks lsof who holds a port without filtering the answer", () => {
+  // ASSEMBLED, so no needle appears whole in THIS file — which is itself one of
+  // the .test.mjs files swept below. Spelled out, the detector matched its own
+  // source and reported the guard as the violation.
+  const TOOL = "ls" + "of";
+  // EVERY CALL FORM, not one spelling of one. The previous version matched the
+  // literal `execFileSync("` + tool, and a second inline call written with
+  // `spawn(` sat in this tree reading as clean. The guard's NAME claimed the
+  // class while its predicate covered a single spelling — so the one file that
+  // had gone around listeners() was invisible to the guard written for exactly
+  // that, and the comment below said the class was closed.
+  const ASKS = new RegExp(
+    String.raw`\b(?:execFileSync|execSync|spawnSync|spawn|exec)\s*\(\s*["'\x60]`
+    + TOOL + String.raw`["'\x60]`);
+  // A PORT IS NOT OWNERSHIP. lsof answers with whoever holds the number, and
+  // freePort() hands the same number to a neighbouring file. So a raw call is
+  // permitted only where every pid it yields reaches killOurs(), which resolves
+  // the command line and refuses anything that is not one of ours. The raw call
+  // itself is legitimate where a DEADLINE is wanted, which the shared helper's
+  // execFileSync cannot give — what must never be skipped is the filter.
+  const FILTER = "kill" + "Ours(";
+  // And loopback-scoped: `-iTCP:<port>` matches ANY interface, so the answer can
+  // name a process that merely holds the same port number on another address.
+  const SCOPED = "@127.0.0.1:";
+  // The ONE shared call lives in proc-helpers.mjs, which is not a .test.mjs.
+  // Four files went around it once, and two of them then walked UP to the
+  // listener's parent and signalled it. That walk is the reason this guard
+  // exists: on a host whose orphans reparent to a systemd USER manager, the
+  // parent of one of our own listeners IS that manager, and SIGTERM there is a
+  // logout, not a stop (systemd(1), exit.target). Measured 2026-08-20.
   const helper = stripComments(readFileSync(join(testDir, "proc-helpers.mjs"), "utf8"));
-  assert.ok(helper.includes(NEEDLE) && helper.split(NEEDLE).length - 1 === 1,
-    "proc-helpers.mjs no longer holds the single lsof call — either it moved, in " +
-    "which case this guard now polices nothing, or the detector broke");
+  assert.equal((helper.match(new RegExp(ASKS, "g")) || []).length, 1,
+    "proc-helpers.mjs no longer holds exactly one shared lsof call — either it " +
+    "moved, in which case this guard now polices nothing, or the detector broke");
 
-  const bad = readdirSync(testDir).filter((f) => f.endsWith(".test.mjs"))
-    .filter((f) => stripComments(readFileSync(join(testDir, f), "utf8")).includes(NEEDLE));
-  assert.deepEqual(bad, [],
-    `these files ask lsof directly instead of going through listeners(), so nothing ` +
-    `filters the pid before it reaches process.kill():\n  ${bad.join("\n  ")}`);
+  const unfiltered = [], unscoped = [];
+  for (const f of readdirSync(testDir).filter((n) => n.endsWith(".test.mjs"))) {
+    const src = stripComments(readFileSync(join(testDir, f), "utf8"));
+    if (!ASKS.test(src)) continue;
+    if (!src.includes(FILTER)) unfiltered.push(f);
+    if (!src.includes(SCOPED)) unscoped.push(f);
+  }
+  assert.deepEqual(unfiltered, [],
+    `these files ask lsof directly and never reach killOurs(), so nothing filters ` +
+    `the pid before it is signalled:\n  ${unfiltered.join("\n  ")}`);
+  assert.deepEqual(unscoped, [],
+    `these files ask lsof without ${SCOPED}, so the answer can name a listener on ` +
+    `another interface that merely shares the port number:\n  ${unscoped.join("\n  ")}`);
 });
 
 test("the suite derives its parallelism from the machine", () => {


### PR DESCRIPTION
Four times in one afternoon, running this suite took my whole desktop down.
The kernel audit subsystem named the sender: a node test-runner process
SIGKILLed `systemd --user`, and pid 1 then tore down the session cgroup —
shell, editors, browser, terminals, mid-work.

Full write-up, evidence and the audit recipe: #351

## The defect

`test/proxy-held-port.test.mjs`, the holder sweep:

```js
let parent = Number(execFileSync("ps", ["-p", pid, "-o", "ppid="], …).trim());
if (parent > 1) process.kill(parent, "SIGKILL");
```

`parent > 1` is a liveness test wearing an ownership test's clothes. An orphan
does **not** reparent to pid 1 on a machine running a systemd *user* manager:
that manager sets `PR_SET_CHILD_SUBREAPER`, so it inherits the orphan and
`ps -o ppid=` returns its pid. The sweep reads that as a parent it created.

CI never saw it because a container really does reparent to pid 1 — which is
exactly why the assumption survived review.

## The fix

A choke point, not a patch at the site that fired. Every signal to a pid this
process did not spawn now goes through `killOurs()` in `test/proc-helpers.mjs`,
beside the existing `OURS` predicate that `listeners()` and `ours()` already
use. It resolves the target's command line and refuses anything that is not one
of this repo's own binaries.

Three outcomes, each proven against real processes before this landed:

| target | behaviour |
|---|---|
| alive, not ours | **throws**, naming the pid and its command line |
| already gone | returns `false` quietly — reaping races stay green |
| alive and ours | signalled exactly as before |

The middle row is what keeps the guard from being the next bug: a guard that
over-fires would have broken the suite instead of the desktop. The first row
throws rather than skipping because a silent skip is what let this run four
times before anyone knew where it came from.

Also routed through the choke point in this change:

- `test/stdio-epipe-survival.test.mjs` — an `lsof -nP -t -iTCP:<port> -sTCP:LISTEN`
  sweep with **no** ownership filter and no `@127.0.0.1`, so it matched listeners
  on any interface; `n > 1 && n !== holder.pid` was the only thing between that
  loop and a stranger's pid. (Its local variable is named `listeners`, which
  reads like the shared helper of that name but is a raw `lsof` — worth a look
  if you'd prefer it renamed.)
- `test/proxy-holder-handover.test.mjs` — two double-filtered kill sites.
- The remaining SIGKILL-by-number sites in `proxy-held-port.test.mjs`.

## Deliberately not changed

The two negative-pgid reaps on self-spawned handles
(`stdio-epipe-survival.test.mjs`, `shutdown-exit-code.test.mjs`). They signal a
group id this process did not necessarily create — the same class of
assumption — but changing cleanup semantics without being able to run the suite
would be an unverified fix stacked on a verified one. Flagged here rather than
silently touched.

## Verification, and its honest limit

- every touched file parses (`node --check`)
- `killOurs()` exercised on all three outcomes against real processes, including
  the actual `systemd --user` pid — it refuses it loudly
- static sweep confirms no unguarded SIGKILL-by-number remains in `test/`

**The suite itself was not run.** Running it is what breaks the machine, and it
should not be run on a systemd-user desktop until this is in. The confirmation I
can offer afterwards is the audit rule: a run followed by `ausearch -k sigkill9`
showing no record whose target is `ocomm=systemd`. Nothing weaker proves it, and
I'd rather say so than claim a green I don't have. CI will exercise the changed
paths normally, since containers were never affected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
