### PR TITLE
fix(test): scratch git repos are not scratch under an exported GIT_DIR

### DIFF
--- a/test/absence-scan.test.mjs
+++ b/test/absence-scan.test.mjs
@@ -17,6 +17,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { SCRUBBED_GIT_ENV } from "./git-env.mjs";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -134,30 +135,8 @@ test("the allowlist covers the LEDGER watermark file and nothing else in the cor
 
 // --- CLI ---------------------------------------------------------------------
 
-// Git's own env overrides cwd, so a scratch repo built with `cwd: dir` and an
-// INHERITED environment is not scratch at all: under an exported GIT_DIR every
-// `git init` / `git config` below resolves to whatever repo the runner was
-// pointed at. Git exports exactly that into hooks — relative `.git` for a
-// main-tree push, ABSOLUTE for a worktree push — so this file, run from a
-// pre-push hook, wrote `user.name=t` / `user.email=t@t` into the REAL config,
-// and `git init` on a git-dir not named `.git` guesses bare-ness and added
-// `core.bare=true` on top. That is the 2026-08-05 incident, and it recurred
-// the same day from a plain `GIT_DIR=… node --test` invocation, which is the
-// evidence that hardening the pre-push hook alone was not the fix: the hazard
-// belongs to any runner with these set, so the scrub belongs HERE, at the
-// spawn, where no caller can forget it.
-//
-// Undefined, not empty string: `GIT_DIR=""` is still "set" to git.
-const SCRUBBED_GIT_ENV = {
-  ...process.env,
-  GIT_DIR: undefined,
-  GIT_WORK_TREE: undefined,
-  GIT_INDEX_FILE: undefined,
-  GIT_COMMON_DIR: undefined,
-  GIT_OBJECT_DIRECTORY: undefined,
-  GIT_ALTERNATE_OBJECT_DIRECTORIES: undefined,
-  GIT_CEILING_DIRECTORIES: undefined,
-};
+// The git-spawn environment lives in one place now — see test/git-env.mjs
+// for the incident that made it shared rather than per-file.
 
 const run = (args, cwd) =>
   spawnSync(process.execPath, [TOOL, ...args], { cwd, encoding: "utf-8", env: SCRUBBED_GIT_ENV });

--- a/test/git-env.mjs
+++ b/test/git-env.mjs
@@ -1,0 +1,39 @@
+// The environment a test must hand any `git` it spawns.
+//
+// One copy, because the two hand-rolled ones already cost an incident: the
+// scrub was written in the file that NOTICED the damage and never swept to the
+// file that produced it. The fixture identity named in that write-up —
+// `user.name=t`, `user.email=t@t` — is hook-worktree-edit-guard.test.mjs's, and
+// that file was still spawning git with an inherited environment months later.
+// A shared definition cannot drift from itself; two cannot stay in step.
+//
+// WHY IT IS NEEDED AT ALL. Git's own environment overrides cwd, so a scratch
+// repo built with `cwd: <tmpdir>` and an INHERITED environment is not scratch:
+// under an exported GIT_DIR every `git init` / `git config` / `git commit`
+// resolves to whatever repo the runner was pointed at. Git exports exactly that
+// into the hooks it runs — a relative `.git` for a main-tree operation, an
+// ABSOLUTE path for a worktree one — and an absolute GIT_DIR beats cwd-based
+// discovery everywhere.
+//
+// Measured 2026-08-05: run from a pre-push hook, a suite file wrote
+// `user.name=t` / `user.email=t@t` into the REAL repository config, and because
+// `git init` guesses bare-ness from a git-dir not named `.git`, it set
+// `core.bare=true` on top — which breaks every work-tree command in the real
+// clone. It recurred the same day from a plain `GIT_DIR=… node --test`
+// invocation, which is the evidence that hardening the pre-push hook alone was
+// not the fix: the hazard belongs to ANY runner with these set, so the scrub
+// belongs at the spawn, where no caller can forget it.
+//
+// UNDEFINED, NOT EMPTY STRING: `GIT_DIR=""` is still "set" as far as git is
+// concerned, so an empty-string scrub leaves the hazard in place while reading
+// as a fix.
+export const SCRUBBED_GIT_ENV = {
+  ...process.env,
+  GIT_DIR: undefined,
+  GIT_WORK_TREE: undefined,
+  GIT_INDEX_FILE: undefined,
+  GIT_COMMON_DIR: undefined,
+  GIT_OBJECT_DIRECTORY: undefined,
+  GIT_ALTERNATE_OBJECT_DIRECTORIES: undefined,
+  GIT_CEILING_DIRECTORIES: undefined,
+};

--- a/test/hook-worktree-edit-guard.test.mjs
+++ b/test/hook-worktree-edit-guard.test.mjs
@@ -5,18 +5,28 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync, symlinkSync, realpathSyn
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { SCRUBBED_GIT_ENV } from "./git-env.mjs";
 
 const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "..", "hooks", "examples", "worktree-edit-guard.py");
 
+// SCRUBBED, or none of the scratch repos below are scratch. `cwd` does not win
+// against an exported GIT_DIR, and makeRepo() runs exactly the operations that
+// damaged a real clone once — `git init`, then `user.email=t@t` / `user.name=t`
+// written straight into whatever config git resolved to. Those are this file's
+// fixture values; see test/git-env.mjs for the incident.
 function git(cwd, ...args) {
-  const r = spawnSync("git", args, { cwd, encoding: "utf8" });
+  const r = spawnSync("git", args, { cwd, encoding: "utf8", env: SCRUBBED_GIT_ENV });
   if (r.status !== 0) throw new Error(`git ${args.join(" ")} in ${cwd}: ${r.stderr}`);
   return r.stdout.trim();
 }
 
+// The hook under test shells out to `git rev-parse` itself, so it inherits what
+// it is handed. Unscrubbed, it answers about the RUNNER's repository instead of
+// the fixture, and every assertion below reads the wrong repo while passing —
+// the quiet direction of the same defect.
 function runHook({ toolName, toolInput, cwd }) {
   const payload = JSON.stringify({ tool_name: toolName, tool_input: toolInput, cwd });
-  const r = spawnSync(SCRIPT, [], { input: payload, encoding: "utf8" });
+  const r = spawnSync(SCRIPT, [], { input: payload, encoding: "utf8", env: SCRUBBED_GIT_ENV });
   return { code: r.status, stderr: r.stderr };
 }
 

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -931,6 +931,39 @@ test("no test file asks lsof who holds a port", () => {
     `filters the pid before it reaches process.kill():\n  ${bad.join("\n  ")}`);
 });
 
+test("no test file spawns git with the runner's own environment", () => {
+  // ASSEMBLED, so no needle appears whole in THIS file — which is itself one of
+  // the .test.mjs files swept below.
+  const VCS = "gi" + "t";
+  const SPAWNS = new RegExp(
+    String.raw`\b(?:execFileSync|execSync|spawnSync|spawn|exec)\s*\(\s*["'\x60]`
+    + VCS + String.raw`["'\x60]`);
+  const SCRUB = "SCRUBBED_" + "GIT_ENV";
+
+  // WHY A GUARD AND NOT JUST THE FIX. This is the second time: the scrub was
+  // written into the file that NOTICED the damage (absence-scan.test.mjs, after
+  // the 2026-08-05 incident) and never swept to the file that CAUSED it. The
+  // identity named in that write-up — user.name=t, user.email=t@t — belongs to
+  // hook-worktree-edit-guard.test.mjs, which was still spawning git with an
+  // inherited environment months later. A fix applied per-file is a fix that
+  // drifts; only a definition plus a sweep closes the class.
+  const shared = readFileSync(join(testDir, "git-env.mjs"), "utf8");
+  assert.ok(shared.includes(`export const ${SCRUB}`),
+    `test/git-env.mjs no longer exports ${SCRUB}, so this guard polices a name ` +
+    `nothing defines and its green means nothing`);
+
+  const bare = [];
+  for (const f of readdirSync(testDir).filter((n) => n.endsWith(".test.mjs"))) {
+    const src = stripComments(readFileSync(join(testDir, f), "utf8"));
+    if (SPAWNS.test(src) && !src.includes(SCRUB)) bare.push(f);
+  }
+  assert.deepEqual(bare, [],
+    `these files spawn git with the runner's environment inherited. cwd does NOT ` +
+    `win against an exported GIT_DIR, so their "scratch" repos resolve to whatever ` +
+    `repository the runner was pointed at — git init sets core.bare=true on it and ` +
+    `git config writes the fixture identity into it:\n  ${bare.join("\n  ")}`);
+});
+
 test("the suite derives its parallelism from the machine", () => {
   const script = JSON.parse(readFileSync(join(testDir, "..", "package.json"), "utf8")).scripts?.test ?? "";
   // Premise. A renamed or rewritten script must not let the assertion below


### PR DESCRIPTION
`test/hook-worktree-edit-guard.test.mjs` spawns git with the runner's
environment inherited:

```js
const r = spawnSync("git", args, { cwd, encoding: "utf8" });
```

`cwd` does not win against an exported `GIT_DIR`. So every `git init`,
`git config` and `git commit` in `makeRepo()` resolves to whatever repository
the runner was pointed at — and git exports exactly that into the hooks it runs
(a relative `.git` for a main-tree operation, an **absolute** path for a
worktree one, which beats cwd-based discovery everywhere).

## This is the second occurrence, and the first one is already written down

The scrub exists — in `test/absence-scan.test.mjs`, added after the 2026-08-05
incident. Its comment names the damage:

> "…wrote `user.name=t` / `user.email=t@t` into the REAL config, and `git init`
> on a git-dir not named `.git` guesses bare-ness and added `core.bare=true` on
> top."

Those are **this file's** fixture values, lines 26–27. The scrub landed in the
file that noticed the damage and never reached the file that caused it. That is
the whole reason part 3 below exists.

## Measured, both directions

`GIT_DIR` pointed at a throwaway decoy repository, same suite file, same
arrangement:

| | tests | decoy config |
|---|---|---|
| before | 3 pass / 17 fail | **modified** — `user.name=t`, `user.email=t@t` |
| after | **20 pass / 0 fail** | byte-identical, untouched |

The 20/20 deserves its own line. Scrubbing does not only stop the collateral
damage; it makes the file's own assertions true. Unscrubbed, the hook under test
answered about the *runner's* repository rather than the fixture — the quiet
direction of the same defect, and the direction that would have kept passing
forever.

## Three parts

1. **`test/git-env.mjs`** — one definition, carrying the incident and the reason
   the values must be `undefined` rather than `""` (an empty string is still
   "set" as far as git is concerned, so an empty-string scrub reads as a fix
   while leaving the hazard). `absence-scan.test.mjs` imports it instead of
   holding its own copy.

2. **Both spawns in the guard test scrubbed** — the `git()` helper *and*
   `runHook()`, because the hook shells out to `git rev-parse` itself and
   inherits whatever it is handed.

3. **A sweep in `suite-collection.test.mjs`.** A per-file fix is exactly what
   drifted here, so the class is closed by a check rather than by another
   careful edit. It matches every call form — `execFileSync`, `execSync`,
   `spawnSync`, `spawn`, `exec` — not one spelling, and requires any test file
   spawning git to carry the shared env. Needles are assembled so the guard
   cannot match its own source.

   Proven red against this tree before the fix, naming
   `hook-worktree-edit-guard.test.mjs` and nothing else; baseline after the fix
   is 57 pass, 0 fail across the three touched files.

## What was run

All of it, and I can say that here because none of these files signals a pid it
did not spawn: `suite-collection.test.mjs`, `absence-scan.test.mjs` and
`hook-worktree-edit-guard.test.mjs`, 57 tests, plus the before/after decoy
measurement above.

Unrelated but worth knowing if you are on Linux with a systemd user manager:
please do not run the *full* suite until #352 is in — see #351.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
