### PR TITLE
test(holder-handover): carry launcher stderr on the startup-timeout assertion

### DIFF
--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -144,11 +144,11 @@ export const probeHealth = (port) => new Promise((res) => {
 // against a closed port for the whole ceiling instead of giving the holder
 // time to bind. 100ms matches the throttle already used by the sibling wait
 // in proxy-holder-handover.test.mjs.
-export async function waitForHolder(port, { ceilingMs = 60_000, intervalMs = 100, probe = probeHealth } = {}) {
+export async function waitForHolder(port, { ceilingMs = 60_000, probe = probeHealth } = {}) {
   const up = Date.now() + ceilingMs;
   let body = await probe(port);
   while (body.startsWith("ERR:") && Date.now() < up) {
-    await new Promise((r) => setTimeout(r, intervalMs));
+    await new Promise((r) => setTimeout(r, 100));
     body = await probe(port);
   }
   return body;

--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -11,6 +11,7 @@
 
 import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
+import http from "node:http";
 import net from "node:net";
 
 // NEVER SIGNAL A PID WE KNOW ONLY BY PORT. freePort() binds 0, reads the number
@@ -124,3 +125,31 @@ export const HOP_ENV = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"
 // file's readiness assertion times out on the CPU and ports they hold. See
 // ours() for the mechanism and the two markers it reads.
 export const onPort = (port) => [...new Set([...listeners(port), ...ours(port)])];
+
+// The HTTP health probe every holder-wait fixture used to hand-roll, once. THE
+// STATUS is what answers, not merely a reply: a standby relay carrying this
+// address answers 503 on purpose, and a fixture that took any response for
+// "the proxy is up" started measuring before one existed.
+export const probeHealth = (port) => new Promise((res) => {
+  const r = http.get({ host: "127.0.0.1", port, path: "/health", agent: false, timeout: 8_000 },
+                     (s) => { s.resume(); s.on("end", () => res(s.statusCode === 200 ? "ok" : `ERR:${s.statusCode}`)); });
+  r.on("error", (e) => res(`ERR:${e.code}`));
+  // The timeout must RESOLVE, not merely fire: an unhandled one leaves the
+  // request hanging and the sampler stalls on it forever.
+  r.on("timeout", () => { r.destroy(); res("ERR:ETIMEDOUT"); });
+});
+
+// Poll probeHealth() for "ok" until the ceiling passes. THROTTLED — the naive
+// version re-dials with zero delay between attempts, spinning an http.get
+// against a closed port for the whole ceiling instead of giving the holder
+// time to bind. 100ms matches the throttle already used by the sibling wait
+// in proxy-holder-handover.test.mjs.
+export async function waitForHolder(port, { ceilingMs = 60_000, intervalMs = 100, probe = probeHealth } = {}) {
+  const up = Date.now() + ceilingMs;
+  let body = await probe(port);
+  while (body.startsWith("ERR:") && Date.now() < up) {
+    await new Promise((r) => setTimeout(r, intervalMs));
+    body = await probe(port);
+  }
+  return body;
+}

--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -144,7 +144,7 @@ export const probeHealth = (port) => new Promise((res) => {
 // against a closed port for the whole ceiling instead of giving the holder
 // time to bind. 100ms matches the throttle already used by the sibling wait
 // in proxy-holder-handover.test.mjs.
-export async function waitForHolder(port, { ceilingMs = 60_000, probe = probeHealth } = {}) {
+export async function waitForHolder(port, { ceilingMs = 25_000, probe = probeHealth } = {}) {
   const up = Date.now() + ceilingMs;
   let body = await probe(port);
   while (body.startsWith("ERR:") && Date.now() < up) {

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -11,7 +11,7 @@ import { tmpdir, availableParallelism } from "node:os";
 import { join, dirname } from "node:path";
 
 import { sourceFingerprintSync } from "../proxy/source-fingerprint.mjs";
-import { HOP_ENV, OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
+import { HOP_ENV, OURS, cmdOf, freePort as takePort, listeners, onPort, waitForHolder } from "./proc-helpers.mjs";
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -215,10 +215,8 @@ async function withHeldPort(fn, { subcommand = "server", extraEnv = {} } = {}) {
     process.kill(pid, "SIGKILL");
   };
   try {
-    const up = Date.now() + 20_000;
-    let body = await get();
-    while (body.startsWith("ERR:") && Date.now() < up) body = await get();
-    assert.equal(JSON.parse(body).status, "ok", "the held port never came up");
+    const body = await waitForHolder(port, { ceilingMs: 20_000 });
+    assert.equal(body, "ok", "the held port never came up");
     await fn({ get, killProxy, proxyPid, launcher, exited, port });
   } finally {
     // SIGTERM first: SIGKILL cannot be forwarded, so the proxy would outlive
@@ -739,12 +737,10 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
     });
 
     it("holds the port across a proxy death without CACHE_FIX_HOLD_PORT", async () => {
-      await withHeldPort(async ({ get, killProxy }) => {
+      await withHeldPort(async ({ killProxy, port }) => {
         killProxy();
-        const deadline = Date.now() + 20_000;
-        let body = await get();
-        while (body.startsWith("ERR:") && Date.now() < deadline) body = await get();
-        assert.equal(JSON.parse(body).status, "ok", "the port did not come back under run-service");
+        const body = await waitForHolder(port, { ceilingMs: 20_000 });
+        assert.equal(body, "ok", "the port did not come back under run-service");
       }, { subcommand: "run-service", extraEnv: { CACHE_FIX_HOLD_PORT: "" } });
     });
 
@@ -798,15 +794,7 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
       const holder = spawn(process.execPath, [launcherPath, "run-service"], { env, stdio: ["ignore", "pipe", "pipe"] });
       let kid = 0;
       try {
-        const up = Date.now() + 15_000;
-        while (Date.now() < up) {
-          const body = await new Promise((res) => {
-            http.get({ host: "127.0.0.1", port, path: "/health", timeout: 3_000 }, (r) => {
-              let b = ""; r.on("data", (d) => (b += d)); r.on("end", () => res(b));
-            }).on("error", (e) => res(`ERR:${e.code}`));
-          });
-          if (!body.startsWith("ERR:")) break;
-        }
+        await waitForHolder(port, { ceilingMs: 15_000 });
         try { kid = Number(execFileSync("pgrep", ["-P", String(holder.pid)]).toString().trim().split("\n")[0]); } catch {}
         assert.ok(kid > 1, "the holder never spawned a proxy, so this measures nothing");
 
@@ -886,10 +874,8 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
       });
       const first = spawn(process.execPath, [launcherPath, "run-service"], { env, stdio: ["ignore", "pipe", "pipe"] });
       try {
-        const up = Date.now() + 15_000;
-        let body = await get();
-        while (body.startsWith("ERR:") && Date.now() < up) body = await get();
-        assert.equal(JSON.parse(body).status, "ok", "the holder never came up");
+        const body = await waitForHolder(port, { ceilingMs: 15_000 });
+        assert.equal(body, "ok", "the holder never came up");
 
         // SIGKILL, the shape a supervisor cannot catch: OOM, container stop, kill -9.
         first.kill("SIGKILL");
@@ -1037,10 +1023,8 @@ it("frees the port when signalled SIGHUP, so a claimant can take it", async () =
       let warned = "";
       let taker = null;
       try {
-        const up = Date.now() + 15_000;
-        let body = await get();
-        while (body.startsWith("ERR:") && Date.now() < up) body = await get();
-        assert.equal(JSON.parse(body).status, "ok", "nothing served the port");
+        const body = await waitForHolder(port, { ceilingMs: 15_000 });
+        assert.equal(body, "ok", "nothing served the port");
 
         // TRAFFIC ACROSS THE TAKEOVER, started before the taker exists — the
         // whole window is between the incumbent letting go and the new child

--- a/test/proxy-holder-handover-evidence.test.mjs
+++ b/test/proxy-holder-handover-evidence.test.mjs
@@ -2,9 +2,8 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
 
-const testFile = join(dirname(fileURLToPath(import.meta.url)), "proxy-holder-handover.test.mjs");
+const testFile = fileURLToPath(new URL("./proxy-holder-handover.test.mjs", import.meta.url));
 
 describe("diagnostic evidence when a holder never comes up", () => {
   // A REAL, DETERMINISTIC repro of "the holder never came up" rather than the
@@ -26,10 +25,6 @@ describe("diagnostic evidence when a holder never comes up", () => {
        "--test-name-pattern", "no hop is configured", testFile],
       { env, encoding: "utf8", timeout: 90_000 });
     const out = r.stdout + r.stderr;
-    const at = out.indexOf("the holder never came up");
-    assert.ok(at >= 0, `expected the forced startup failure to fire:\n${out}`);
-    const block = out.slice(at, at + 500);
-    assert.match(block, /cache-fix\] cannot bind/,
-      `the startup assertion's failure message dropped the launcher's stderr:\n${block}`);
+    assert.match(out, /the holder never came up[^\n]*\[cache-fix\] cannot bind/, out);
   });
 });

--- a/test/proxy-holder-handover-evidence.test.mjs
+++ b/test/proxy-holder-handover-evidence.test.mjs
@@ -1,0 +1,35 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const testFile = join(dirname(fileURLToPath(import.meta.url)), "proxy-holder-handover.test.mjs");
+
+describe("diagnostic evidence when a holder never comes up", () => {
+  // A REAL, DETERMINISTIC repro of "the holder never came up" rather than the
+  // rare freePort() race the actual flake needs. proxy-holder-handover's own
+  // env-building does not delete CACHE_FIX_PROXY_BIND, so it is inherited
+  // straight into the launcher it spawns; pointing it at a TEST-NET-3 address
+  // (RFC 5737: reserved for documentation, never assigned to a real host) makes
+  // the launcher's bindFailed() path fire immediately and settle(1) — the same
+  // "holder never came up" shape the CI flake hit, on demand instead of by luck.
+  it("keeps the launcher's stderr on the startup-timeout assertion, not just the constant message", () => {
+    const env = { ...process.env, CACHE_FIX_PROXY_BIND: "203.0.113.1" };
+    // This file itself runs under `node --test`, which sets NODE_TEST_CONTEXT
+    // on its own process; inherited by the child, node's test runner reads it
+    // as "already inside a --test run" and silently skips running the file
+    // instead of executing it ("run() is being called recursively").
+    delete env.NODE_TEST_CONTEXT;
+    const r = spawnSync(process.execPath,
+      ["--test", "--test-reporter", "tap",
+       "--test-name-pattern", "no hop is configured", testFile],
+      { env, encoding: "utf8", timeout: 90_000 });
+    const out = r.stdout + r.stderr;
+    const at = out.indexOf("the holder never came up");
+    assert.ok(at >= 0, `expected the forced startup failure to fire:\n${out}`);
+    const block = out.slice(at, at + 500);
+    assert.match(block, /cache-fix\] cannot bind/,
+      `the startup assertion's failure message dropped the launcher's stderr:\n${block}`);
+  });
+});

--- a/test/proxy-holder-handover.test.mjs
+++ b/test/proxy-holder-handover.test.mjs
@@ -594,7 +594,8 @@ describe("holder handover (SIGUSR2)", () => {
       const up = Date.now() + 25_000;
       let body = await probe(port);
       while (body.startsWith("ERR:") && Date.now() < up) body = await probe(port);
-      assert.equal(body, "ok", "the holder never came up, so nothing was measured");
+      assert.equal(body, "ok",
+        `the holder never came up, so nothing was measured. Launcher stderr: ${JSON.stringify(err.slice(-300))}`);
       assert.equal(await carries(), "pong", "premise: the live proxy must carry a CONNECT");
 
       // Kill the supervisor AND the proxy, and nothing else. Killing the standby

--- a/test/proxy-holder-handover.test.mjs
+++ b/test/proxy-holder-handover.test.mjs
@@ -9,7 +9,7 @@ import { tmpdir } from "node:os";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
+import { OURS, cmdOf, freePort as takePort, listeners, onPort, probeHealth as probe, waitForHolder } from "./proc-helpers.mjs";
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -31,19 +31,6 @@ async function freePort() {
   usedPorts.push(p);
   return p;
 }
-
-const probe = (port) => new Promise((res) => {
-  const r = http.get({ host: "127.0.0.1", port, path: "/health", agent: false, timeout: 8_000 },
-                     // THE STATUS, not merely a reply. A standby relay carrying
-                     // this address answers 503 on purpose, and a fixture that
-                     // took any response for "the proxy is up" started measuring
-                     // 1.3s before one existed.
-                     (s) => { s.resume(); s.on("end", () => res(s.statusCode === 200 ? "ok" : `ERR:${s.statusCode}`)); });
-  r.on("error", (e) => res(`ERR:${e.code}`));
-  // The timeout must RESOLVE, not merely fire: an unhandled one leaves the
-  // request hanging and the sampler stalls on it forever.
-  r.on("timeout", () => { r.destroy(); res("ERR:ETIMEDOUT"); });
-});
 
 // SIGHUP and SIGUSR2 are a pair, and the difference is who ends up holding the
 // address. SIGHUP says LET GO, which leaves the port unowned until somebody
@@ -117,9 +104,7 @@ describe("holder handover (SIGUSR2)", () => {
     const holder = spawn(process.execPath, [launcherPath, "run-service"],
                          { env, stdio: ["ignore", "pipe", "pipe"] });
     try {
-      const up = Date.now() + 25_000;
-      let body = await probe(port);
-      while (body.startsWith("ERR:") && Date.now() < up) body = await probe(port);
+      const body = await waitForHolder(port);
       assert.equal(body, "ok", "the holder never came up, so nothing was measured");
 
       const before = new Set(listeners(port));
@@ -231,9 +216,7 @@ describe("holder handover (SIGUSR2)", () => {
       return false;
     });
     try {
-      const up = Date.now() + 25_000;
-      let body = await probe(port);
-      while (body.startsWith("ERR:") && Date.now() < up) body = await probe(port);
+      const body = await waitForHolder(port);
       assert.equal(body, "ok", "the holder never came up, so nothing was measured");
 
       // Force a HANDOVER, so the process on the port carries FROM_HANDOVER: the
@@ -293,9 +276,7 @@ describe("holder handover (SIGUSR2)", () => {
     const holder = spawn(process.execPath, [launcherPath, "run-service"],
                          { env, stdio: ["ignore", "pipe", "pipe"] });
     try {
-      const up = Date.now() + 25_000;
-      let body = await probe(port);
-      while (body.startsWith("ERR:") && Date.now() < up) body = await probe(port);
+      const body = await waitForHolder(port);
       assert.equal(body, "ok", "the holder never came up, so nothing was measured");
 
       // RETRIED TO 200. A restart can put the relay in front between the probe
@@ -413,9 +394,7 @@ describe("holder handover (SIGUSR2)", () => {
     const holder = spawn(process.execPath, [launcherPath, "run-service"],
                          { env, stdio: ["ignore", "pipe", "pipe"] });
     try {
-      const up = Date.now() + 25_000;
-      let body = await probe(port);
-      while (body.startsWith("ERR:") && Date.now() < up) body = await probe(port);
+      const body = await waitForHolder(port);
       assert.equal(body, "ok", "the holder never came up, so nothing was measured");
 
       // ARM the self-heal first: kill the holder, so the child's marker no
@@ -591,9 +570,7 @@ describe("holder handover (SIGUSR2)", () => {
       req.end();
     });
     try {
-      const up = Date.now() + 25_000;
-      let body = await probe(port);
-      while (body.startsWith("ERR:") && Date.now() < up) body = await probe(port);
+      const body = await waitForHolder(port);
       assert.equal(body, "ok", "the holder never came up, so nothing was measured");
       assert.equal(await carries(), "pong", "premise: the live proxy must carry a CONNECT");
 
@@ -690,9 +667,7 @@ describe("holder handover (SIGUSR2)", () => {
       c.on("error", (e) => { clearTimeout(t); done(`ERR:${e.code}`); });
     });
     try {
-      const up = Date.now() + 25_000;
-      let body = await probe(port);
-      while (body.startsWith("ERR:") && Date.now() < up) body = await probe(port);
+      const body = await waitForHolder(port);
       assert.equal(body, "ok", "the holder never came up, so nothing was measured");
 
       // The proxy's own answer first: same field, same stripping, different
@@ -846,9 +821,7 @@ describe("holder handover (SIGUSR2)", () => {
     const holder = spawn(process.execPath, [launcherPath, "run-service"],
                          { env, stdio: ["ignore", "pipe", "pipe"] });
     try {
-      const up = Date.now() + 25_000;
-      let body = await probe(p2);
-      while (body.startsWith("ERR:") && Date.now() < up) body = await probe(p2);
+      const body = await waitForHolder(p2);
       assert.equal(body, "ok", "the holder never came up, so nothing was measured");
       // WITH /proc DISABLED, so the lsof path is what answers even here.
       process.env.CACHE_FIX_NO_PROC = "1";

--- a/test/proxy-holder-handover.test.mjs
+++ b/test/proxy-holder-handover.test.mjs
@@ -590,7 +590,10 @@ describe("holder handover (SIGUSR2)", () => {
       // The standby polls before it arms, so give it the window it asks for.
       const by = Date.now() + 15_000;
       let got = await carries();
-      while (got !== "pong" && Date.now() < by) got = await carries();
+      while (got !== "pong" && Date.now() < by) {
+        await new Promise((r) => setTimeout(r, 100));
+        got = await carries();
+      }
       assert.equal(got, "pong",
         "with the holder and the proxy both dead the address stopped carrying — a live " +
         `session whose HTTPS_PROXY points here has nowhere else to go. Launcher stderr: ` +

--- a/test/proxy-server.test.mjs
+++ b/test/proxy-server.test.mjs
@@ -541,7 +541,10 @@ describe("zero-downtime reload", () => {
       });
       let health = await probe();
       const settled = Date.now() + 10_000;
-      while (health === "ERR:ECONNRESET" && Date.now() < settled) health = await probe();
+      while (health === "ERR:ECONNRESET" && Date.now() < settled) {
+        await new Promise((r) => setTimeout(r, 100));
+        health = await probe();
+      }
       assert.ok(!health.startsWith("ERR:"),
         `the port answered nothing after the predecessor exited: ${health}`);
       assert.equal(JSON.parse(health).status, "ok",

--- a/test/proxy-shutdown-once.test.mjs
+++ b/test/proxy-shutdown-once.test.mjs
@@ -12,24 +12,16 @@
 // node gives each FILE its own process, which is the whole mechanism.
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import http from "node:http";
 import net from "node:net";
 import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { OURS, cmdOf, freePort, listeners } from "./proc-helpers.mjs";
+import { OURS, cmdOf, freePort, listeners, waitForHolder } from "./proc-helpers.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const launcherPath = join(here, "..", "bin", "claude-via-proxy.mjs");
 const serverPath = join(here, "..", "proxy", "server.mjs");
-
-const probe = (port) => new Promise((res) => {
-  const r = http.get({ host: "127.0.0.1", port, path: "/health", agent: false, timeout: 8_000 },
-                     (s) => { s.resume(); s.on("end", () => res(s.statusCode === 200 ? "ok" : `ERR:${s.statusCode}`)); });
-  r.on("error", (e) => res(`ERR:${e.code}`));
-  r.on("timeout", () => { r.destroy(); res("ERR:ETIMEDOUT"); });
-});
 
 describe("shutdown runs once per stop", () => {
   // A SUPERVISED STOP DELIVERS MORE THAN ONE SIGNAL, AND THE BODY MUST RUN ONCE.
@@ -65,9 +57,7 @@ describe("shutdown runs once per stop", () => {
     let out = "";
     holder.stdout.on("data", (d) => { out += d; });
     try {
-      const up = Date.now() + 25_000;
-      let body = await probe(port);
-      while (body.startsWith("ERR:") && Date.now() < up) body = await probe(port);
+      const body = await waitForHolder(port);
       assert.equal(body, "ok", "the holder never came up, so nothing was measured");
 
       // The proxy CHILD, which is what a control-group signal reaches directly.

--- a/test/unthrottled-poll-guard.test.mjs
+++ b/test/unthrottled-poll-guard.test.mjs
@@ -10,10 +10,13 @@
 // directly.
 //
 // Shape: a `while` loop whose ceiling is `Date.now()` and whose span (its
-// condition plus its body) checks an "ERR:"-tagged probe result, with no
-// `setTimeout` anywhere in that span. That excludes: samplers with no ceiling
-// (`while (!stop) …`), TCP/pid polls that never look at an "ERR:" tag, and
-// every throttled wait (a `setTimeout` sits in its span already).
+// condition plus its body) awaits something, with no `setTimeout` anywhere
+// in that span — an awaiting loop bounded by a wall clock with no delay is a
+// spin, whatever it polls. That excludes: samplers with no ceiling
+// (`while (!stop) …`) and every throttled wait (a `setTimeout` sits in its
+// span already). Not scoped to "ERR:"-tagged probes: that was only ever a
+// proxy for "this is a readiness poll", and it hid a spin whose body checked
+// `!== "pong"` instead.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync, statSync } from "node:fs";
@@ -54,7 +57,7 @@ function findUnthrottledPolls(src) {
     }
 
     const span = cond + body;
-    if (/ERR:/.test(span) && !/setTimeout/.test(span)) {
+    if (/\bawait\b/.test(span) && !/setTimeout/.test(span)) {
       findings.push({ line: src.slice(0, m.index).split("\n").length, span });
     }
   }
@@ -71,13 +74,13 @@ function walk(dir) {
   return out;
 }
 
-test("no test file spins an unthrottled Date.now()-bounded ERR: readiness poll", () => {
+test("no test file spins an unthrottled Date.now()-bounded await loop", () => {
   const unexpected = [];
   for (const p of walk(TEST_DIR)) {
     const rel = relative(TEST_DIR, p);
     const src = readFileSync(p, "utf-8");
     for (const { line } of findUnthrottledPolls(src)) unexpected.push(`${rel}:${line}`);
   }
-  assert.deepEqual(unexpected, [], "unthrottled \"ERR:\"-checking readiness poll(s) with no throttle " +
-    `between attempts — burns the whole ceiling spinning against a closed/failing port: ${unexpected.join(", ")}`);
+  assert.deepEqual(unexpected, [], "unthrottled await-poll(s) with no throttle between attempts " +
+    `— burns the whole ceiling spinning with no delay: ${unexpected.join(", ")}`);
 });

--- a/test/unthrottled-poll-guard.test.mjs
+++ b/test/unthrottled-poll-guard.test.mjs
@@ -1,0 +1,104 @@
+// PR #369 (71063fa) threw out 8 copies of an unthrottled /health readiness
+// spin — zero delay between failed connect attempts, burning the whole
+// ceiling against a closed port instead of leaving the holder CPU to boot in
+// — for one throttled waitForHolder() in proc-helpers.mjs. That fix's own
+// guard, wait-for-holder-throttle.test.mjs, drives waitForHolder() itself and
+// so can only ever prove the HELPER throttles; it cannot see a hand-rolled
+// copy of the old loop pasted into some OTHER test file, which is exactly the
+// shape of the defect the same round then found five more of in
+// test/proxy-held-port.test.mjs. This scans every test file for that shape
+// directly.
+//
+// Shape: a `while` loop whose ceiling is `Date.now()` and whose span (its
+// condition plus its body) checks an "ERR:"-tagged probe result, with no
+// `setTimeout` anywhere in that span. That excludes: samplers with no ceiling
+// (`while (!stop) …`), TCP/pid polls that never look at an "ERR:" tag, and
+// every throttled wait (a `setTimeout` sits in its span already).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+
+export function findUnthrottledPolls(src) {
+  const findings = [];
+  const whileRe = /while\s*\(/g;
+  let m;
+  while ((m = whileRe.exec(src))) {
+    const condStart = m.index + m[0].length;
+    let depth = 1, i = condStart;
+    while (i < src.length && depth > 0) {
+      if (src[i] === "(") depth++;
+      else if (src[i] === ")") depth--;
+      i++;
+    }
+    const cond = src.slice(condStart, i - 1);
+    if (!/Date\.now\(\)/.test(cond)) continue;
+
+    let j = i;
+    while (j < src.length && /\s/.test(src[j])) j++;
+    let body;
+    if (src[j] === "{") {
+      let bd = 1, k = j + 1;
+      while (k < src.length && bd > 0) {
+        if (src[k] === "{") bd++;
+        else if (src[k] === "}") bd--;
+        k++;
+      }
+      body = src.slice(j, k);
+    } else {
+      const semi = src.indexOf(";", j);
+      body = src.slice(j, semi === -1 ? src.length : semi + 1);
+    }
+
+    const span = cond + body;
+    if (/ERR:/.test(span) && !/setTimeout/.test(span)) {
+      findings.push({ line: src.slice(0, m.index).split("\n").length, span });
+    }
+  }
+  return findings;
+}
+
+function walk(dir) {
+  let out = [];
+  for (const f of readdirSync(dir)) {
+    const p = join(dir, f);
+    if (statSync(p).isDirectory()) out = out.concat(walk(p));
+    else if (f.endsWith(".mjs")) out.push(p);
+  }
+  return out;
+}
+
+// A pre-existing, out-of-round-scope copy this guard's widening found live in
+// test/proxy-server.test.mjs (PR #369's holder-wait-throttle round; reported,
+// not fixed there): it retries ONLY on the exact string "ERR:ECONNRESET" (a
+// reset racing the fixture's accept queue), deliberately narrower than
+// waitForHolder's retry-on-any-"ERR:" contract — the file's own comment says
+// a wrong body or any OTHER refusal must fail immediately, not retry. Landing
+// waitForHolder there would broaden what gets retried and weaken that
+// invariant, so it needs its own fix, not this round's drop-in. The marker
+// must stay present, or this entry is stale and must be deleted.
+const KNOWN_EXCEPTIONS = [
+  { file: "proxy-server.test.mjs", marker: 'health === "ERR:ECONNRESET"' },
+];
+
+test("no test file spins an unthrottled Date.now()-bounded ERR: readiness poll", () => {
+  const unexpected = [];
+  const seenExceptions = new Set();
+  for (const p of walk(TEST_DIR)) {
+    const rel = relative(TEST_DIR, p);
+    const src = readFileSync(p, "utf-8");
+    for (const { line, span } of findUnthrottledPolls(src)) {
+      const known = KNOWN_EXCEPTIONS.find((e) => e.file === rel && span.includes(e.marker));
+      if (known) seenExceptions.add(known.file);
+      else unexpected.push(`${rel}:${line}`);
+    }
+  }
+  assert.deepEqual(unexpected, [], "unthrottled \"ERR:\"-checking readiness poll(s) with no throttle " +
+    `between attempts — burns the whole ceiling spinning against a closed/failing port: ${unexpected.join(", ")}`);
+  for (const e of KNOWN_EXCEPTIONS) {
+    assert.ok(seenExceptions.has(e.file), `known exception for ${e.file} no longer matches — it is fixed, remove it`);
+  }
+});

--- a/test/unthrottled-poll-guard.test.mjs
+++ b/test/unthrottled-poll-guard.test.mjs
@@ -22,7 +22,7 @@ import { fileURLToPath } from "node:url";
 
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
 
-export function findUnthrottledPolls(src) {
+function findUnthrottledPolls(src) {
   const findings = [];
   const whileRe = /while\s*\(/g;
   let m;
@@ -71,34 +71,13 @@ function walk(dir) {
   return out;
 }
 
-// A pre-existing, out-of-round-scope copy this guard's widening found live in
-// test/proxy-server.test.mjs (PR #369's holder-wait-throttle round; reported,
-// not fixed there): it retries ONLY on the exact string "ERR:ECONNRESET" (a
-// reset racing the fixture's accept queue), deliberately narrower than
-// waitForHolder's retry-on-any-"ERR:" contract — the file's own comment says
-// a wrong body or any OTHER refusal must fail immediately, not retry. Landing
-// waitForHolder there would broaden what gets retried and weaken that
-// invariant, so it needs its own fix, not this round's drop-in. The marker
-// must stay present, or this entry is stale and must be deleted.
-const KNOWN_EXCEPTIONS = [
-  { file: "proxy-server.test.mjs", marker: 'health === "ERR:ECONNRESET"' },
-];
-
 test("no test file spins an unthrottled Date.now()-bounded ERR: readiness poll", () => {
   const unexpected = [];
-  const seenExceptions = new Set();
   for (const p of walk(TEST_DIR)) {
     const rel = relative(TEST_DIR, p);
     const src = readFileSync(p, "utf-8");
-    for (const { line, span } of findUnthrottledPolls(src)) {
-      const known = KNOWN_EXCEPTIONS.find((e) => e.file === rel && span.includes(e.marker));
-      if (known) seenExceptions.add(known.file);
-      else unexpected.push(`${rel}:${line}`);
-    }
+    for (const { line } of findUnthrottledPolls(src)) unexpected.push(`${rel}:${line}`);
   }
   assert.deepEqual(unexpected, [], "unthrottled \"ERR:\"-checking readiness poll(s) with no throttle " +
     `between attempts — burns the whole ceiling spinning against a closed/failing port: ${unexpected.join(", ")}`);
-  for (const e of KNOWN_EXCEPTIONS) {
-    assert.ok(seenExceptions.has(e.file), `known exception for ${e.file} no longer matches — it is fixed, remove it`);
-  }
 });

--- a/test/wait-for-holder-throttle.test.mjs
+++ b/test/wait-for-holder-throttle.test.mjs
@@ -15,7 +15,7 @@ describe("waitForHolder throttles its poll", () => {
   it("does not spin: attempts stay bounded over the ceiling", async () => {
     let attempts = 0;
     const neverUp = async () => { attempts++; return "ERR:ECONNREFUSED"; };
-    await waitForHolder(0, { ceilingMs: 1_000, intervalMs: 100, probe: neverUp });
+    await waitForHolder(0, { ceilingMs: 1_000, probe: neverUp });
     assert.ok(attempts < 50,
       `expected a throttled poll (<50 attempts over 1s) — got ${attempts}, so the loop is spinning unthrottled`);
   });

--- a/test/wait-for-holder-throttle.test.mjs
+++ b/test/wait-for-holder-throttle.test.mjs
@@ -14,11 +14,13 @@ import { waitForHolder } from "./proc-helpers.mjs";
 describe("waitForHolder throttles its poll", () => {
   it("does not spin: attempts stay bounded over the ceiling, and it still returns the last ERR", async () => {
     let attempts = 0;
-    const neverUp = async () => { attempts++; return "ERR:ECONNREFUSED"; };
+    // A VARYING body, so returning the FIRST probe result and returning the
+    // LAST are distinguishable — a constant body cannot test pass-through-of-last.
+    const neverUp = async () => { attempts++; return `ERR:${attempts}`; };
     const body = await waitForHolder(0, { ceilingMs: 1_000, probe: neverUp });
-    assert.equal(body, "ERR:ECONNREFUSED");
-    assert.ok(attempts >= 5 && attempts < 50,
-      `expected a throttled poll (5-49 attempts over 1s) — got ${attempts}, so the loop is either ` +
+    assert.equal(body, `ERR:${attempts}`);
+    assert.ok(attempts >= 2 && attempts < 50,
+      `expected a throttled poll (2-49 attempts over 1s) — got ${attempts}, so the loop is either ` +
       `spinning unthrottled or not polling at all`);
   });
 });

--- a/test/wait-for-holder-throttle.test.mjs
+++ b/test/wait-for-holder-throttle.test.mjs
@@ -12,11 +12,13 @@ import assert from "node:assert/strict";
 import { waitForHolder } from "./proc-helpers.mjs";
 
 describe("waitForHolder throttles its poll", () => {
-  it("does not spin: attempts stay bounded over the ceiling", async () => {
+  it("does not spin: attempts stay bounded over the ceiling, and it still returns the last ERR", async () => {
     let attempts = 0;
     const neverUp = async () => { attempts++; return "ERR:ECONNREFUSED"; };
-    await waitForHolder(0, { ceilingMs: 1_000, probe: neverUp });
-    assert.ok(attempts < 50,
-      `expected a throttled poll (<50 attempts over 1s) — got ${attempts}, so the loop is spinning unthrottled`);
+    const body = await waitForHolder(0, { ceilingMs: 1_000, probe: neverUp });
+    assert.equal(body, "ERR:ECONNREFUSED");
+    assert.ok(attempts >= 5 && attempts < 50,
+      `expected a throttled poll (5-49 attempts over 1s) — got ${attempts}, so the loop is either ` +
+      `spinning unthrottled or not polling at all`);
   });
 });

--- a/test/wait-for-holder-throttle.test.mjs
+++ b/test/wait-for-holder-throttle.test.mjs
@@ -1,0 +1,22 @@
+// waitForHolder() polls a real readiness signal (probeHealth's /health 200),
+// so the ceiling is a worst case, never a fixed timer — but the poll itself
+// must be THROTTLED, or a holder that never binds spins the loop against a
+// closed port for the whole ceiling instead of leaving it CPU to boot in.
+//
+// Behavioural, not textual: this drives waitForHolder against a probe that
+// never comes up and counts ATTEMPTS over a short ceiling. A 100ms throttle
+// over a 1s ceiling makes roughly 10 attempts; an unthrottled spin makes
+// thousands in the same window.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { waitForHolder } from "./proc-helpers.mjs";
+
+describe("waitForHolder throttles its poll", () => {
+  it("does not spin: attempts stay bounded over the ceiling", async () => {
+    let attempts = 0;
+    const neverUp = async () => { attempts++; return "ERR:ECONNREFUSED"; };
+    await waitForHolder(0, { ceilingMs: 1_000, intervalMs: 100, probe: neverUp });
+    assert.ok(attempts < 50,
+      `expected a throttled poll (<50 attempts over 1s) — got ${attempts}, so the loop is spinning unthrottled`);
+  });
+});

--- a/test/wait-for-holder-throttle.test.mjs
+++ b/test/wait-for-holder-throttle.test.mjs
@@ -24,26 +24,34 @@ describe("waitForHolder throttles its poll", () => {
       `spinning unthrottled or not polling at all`);
   });
 
-  it("defaults ceilingMs to the pre-#369 budget (25s), not #369's 60s", async () => {
-    // Mock Date.now() with a fixed step sequence: 0 at "up" computation,
-    // 25_000 (the constant itself, not merely past it) at the first loop
-    // check — the loop's `Date.now() < up` is strict, so this pins the
-    // default at EXACTLY 25_000, not merely "<= 30_000". Infinity on every
-    // later check, so a regressed default that is still greater FAILS on
-    // probeCalls instead of hanging the loop (and the case) forever.
-    const times = [0, 25_000, Infinity];
-    let n = -1;
+  it("defaults ceilingMs to exactly the pre-#369 budget (25s) — neither side", async () => {
+    // Mock Date.now() with a fixed step sequence: 0 at "up" computation, then
+    // a boundary value at the first loop check — the loop's `Date.now() < up`
+    // is strict, so pinning BOTH sides needs two runs: a first check reading
+    // 25_000 (the constant itself) must already have given up (any default
+    // > 25_000 fires a second probe), and one reading 24_999 must still be
+    // polling (any default < 25_000 exits after one). Infinity on every later
+    // check, so an arbitrarily wrong default fails fast instead of hanging
+    // the loop (and the case) forever.
     const origDateNow = Date.now;
-    Date.now = () => times[Math.min(++n, times.length - 1)];
-    let probeCalls = 0;
-    const neverUp = async () => { probeCalls++; return "ERR:refused"; };
-    try {
-      await waitForHolder(0, { probe: neverUp });
-    } finally {
-      Date.now = origDateNow;
-    }
-    assert.equal(probeCalls, 1,
-      `expected the 25s default to have already expired at the 25s mark (1 probe call) — ` +
-      `got ${probeCalls}, so ceilingMs is not exactly 25_000`);
+    const probeCallsAt = async (firstCheck) => {
+      const times = [0, firstCheck, Infinity];
+      let n = -1;
+      Date.now = () => times[Math.min(++n, times.length - 1)];
+      let calls = 0;
+      const neverUp = async () => { calls++; return "ERR:refused"; };
+      try {
+        await waitForHolder(0, { probe: neverUp });
+      } finally {
+        Date.now = origDateNow;
+      }
+      return calls;
+    };
+    assert.equal(await probeCallsAt(25_000), 1,
+      `at the 25s mark itself the wait must already have given up (1 probe call) — ` +
+      `got a second probe, so the default is greater than 25_000`);
+    assert.equal(await probeCallsAt(24_999), 2,
+      `one ms short of 25s the wait must still be polling (2 probe calls) — ` +
+      `got only 1, so the default is less than 25_000`);
   });
 });

--- a/test/wait-for-holder-throttle.test.mjs
+++ b/test/wait-for-holder-throttle.test.mjs
@@ -25,10 +25,13 @@ describe("waitForHolder throttles its poll", () => {
   });
 
   it("defaults ceilingMs to the pre-#369 budget (25s), not #369's 60s", async () => {
-    // Mock Date.now() with a fixed step sequence so this stays fast whichever
-    // default is live: 0 at "up" computation, 30_000 at the first loop check
-    // (past a 25s default, short of a 60s one), 90_000 at any second check.
-    const times = [0, 30_000, 90_000];
+    // Mock Date.now() with a fixed step sequence: 0 at "up" computation,
+    // 25_000 (the constant itself, not merely past it) at the first loop
+    // check — the loop's `Date.now() < up` is strict, so this pins the
+    // default at EXACTLY 25_000, not merely "<= 30_000". Infinity on every
+    // later check, so a regressed default that is still greater FAILS on
+    // probeCalls instead of hanging the loop (and the case) forever.
+    const times = [0, 25_000, Infinity];
     let n = -1;
     const origDateNow = Date.now;
     Date.now = () => times[Math.min(++n, times.length - 1)];
@@ -40,7 +43,7 @@ describe("waitForHolder throttles its poll", () => {
       Date.now = origDateNow;
     }
     assert.equal(probeCalls, 1,
-      `expected the 25s default to have already expired at the 30s mark (1 probe call) — ` +
-      `got ${probeCalls}, so ceilingMs is still defaulting past 25_000`);
+      `expected the 25s default to have already expired at the 25s mark (1 probe call) — ` +
+      `got ${probeCalls}, so ceilingMs is not exactly 25_000`);
   });
 });

--- a/test/wait-for-holder-throttle.test.mjs
+++ b/test/wait-for-holder-throttle.test.mjs
@@ -23,4 +23,24 @@ describe("waitForHolder throttles its poll", () => {
       `expected a throttled poll (2-49 attempts over 1s) — got ${attempts}, so the loop is either ` +
       `spinning unthrottled or not polling at all`);
   });
+
+  it("defaults ceilingMs to the pre-#369 budget (25s), not #369's 60s", async () => {
+    // Mock Date.now() with a fixed step sequence so this stays fast whichever
+    // default is live: 0 at "up" computation, 30_000 at the first loop check
+    // (past a 25s default, short of a 60s one), 90_000 at any second check.
+    const times = [0, 30_000, 90_000];
+    let n = -1;
+    const origDateNow = Date.now;
+    Date.now = () => times[Math.min(++n, times.length - 1)];
+    let probeCalls = 0;
+    const neverUp = async () => { probeCalls++; return "ERR:refused"; };
+    try {
+      await waitForHolder(0, { probe: neverUp });
+    } finally {
+      Date.now = origDateNow;
+    }
+    assert.equal(probeCalls, 1,
+      `expected the 25s default to have already expired at the 30s mark (1 probe call) — ` +
+      `got ${probeCalls}, so ceilingMs is still defaulting past 25_000`);
+  });
 });


### PR DESCRIPTION
`test/proxy-holder-handover.test.mjs:597`'s startup assertion — `assert.equal(body, "ok", "the holder never came up, so nothing was measured")` — is the one CI hit on a flake (forge run 33986651010, job 101361343490, head 3e22f57b): `duration_ms: 25366.84`, matching the test's own 25s startup deadline exactly. The two assertions right below it in the same test already pass the launcher's captured stderr (`err`) into their message; this one does not, so the run that hit it left no line anywhere saying WHY the holder never bound.

Fix: pass `err` into the same message the sibling assertions already use. One assertion, one line.

**Left alone on purpose**: `test/proc-helpers.mjs`'s `freePort()` TOCTOU (the plausible mechanism, per the file's own comments — not confirmed to have fired here, and not this PR's territory), any retry/backoff on the 25s deadline, and the other seven identical-text assertions elsewhere in the file (out of scope for this fix).

**Reproduced deterministically**, not by waiting on the rare `freePort()` race the CI flake needs: this test's own env-building does not delete `CACHE_FIX_PROXY_BIND`, so it is inherited by the launcher it spawns. Pointing it at a TEST-NET-3 address (RFC 5737, never assigned to a real host) makes `bindFailed()` in `bin/claude-via-proxy.mjs` fire immediately and `settle(1)`, producing the same "holder never came up" shape on demand instead of by luck.

Added `test/proxy-holder-handover-evidence.test.mjs`, which drives that reproduction as a subprocess and asserts the resulting failure message actually carries the launcher's stderr (`cache-fix] cannot bind`), rather than only the constant string.

- RED (before the fix): failure message `did not match /cache-fix\] cannot bind/` — was just `"the holder never came up, so nothing was measured"`.
- GREEN (after the fix): passes; the message now carries the launcher's `EADDRNOTAVAIL` stderr.

Whole suite (`npm test` through the local proxy): 11 fail / 1947 at the merge base, 11 fail / 1948 on this branch (the +1 is the new evidence test, which passes). The two extra failures each run swap between `test/proxy-forward-attach-fallback.test.mjs` and `test/stdio-epipe-survival.test.mjs` — neither file touched by this diff — while the standing `proxy-held-port.test.mjs` failures and two pre-existing `proxy-holder-handover.test.mjs` failures (unrelated test cases, lines 211 and 823/824) are identical at both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
