### PR TITLE
Cap an orphaned proxy's self-heal at one successor; sweep a test file's whole lineage

### DIFF
--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -1491,13 +1491,20 @@ function exitWithParent() {
   // that legitimately changes on every handover.
   const heldBy = process.env.CACHE_FIX_HELD_BY;
   const advertised = process.env.CACHE_FIX_HELD_PORT;
-  setInterval(() => {
+  // THE HANDLE, so a successor already spawned can stop this tick from firing
+  // again. Unassigned before, this ran unclearable forever: a fast-dying
+  // successor (or one that just takes longer than the tick to come up) left
+  // us re-entering every tick while we were already spawning or waiting for
+  // it, and a KILLED holder produced a whole ladder of successors — measured,
+  // 2 "holder died; started a new one" lines from ONE orphan in 20s, and
+  // dozens more of the same orphan's children on a box left running for days.
+  const healTick = setInterval(() => {
     // Two facts, both free, and no probe: the marker outlives the holder
     // because it is our own environment, while our ppid moves to 1 the instant
     // the holder dies. The two disagreeing IS the orphaning. `born` is no
     // longer consulted — it could not tell a dead holder from a predecessor
     // that exited on purpose.
-    if (releasingPort) return;          // asked to let go: do not resurrect the lineage
+    if (releasingPort) { clearInterval(healTick); return; }  // asked to let go: do not resurrect the lineage
     if (!heldBy || heldBy === String(process.ppid)) return;
     // The holder is gone and every session on this box has HTTPS_PROXY baked at
     // exec — they cannot be re-pointed, so the address must get an owner back.
@@ -1544,6 +1551,11 @@ function exitWithParent() {
           env: { ...process.env, CACHE_FIX_PROXY_PORT: advertised,
                  CACHE_FIX_HELD_PORT: undefined, CACHE_FIX_HELD_BY: undefined },
         }).unref();
+        // ONE SUCCESSOR AT A TIME. Cleared here, not after the wait below: the
+        // wait can run past the next 1s tick, and a tick that fires while we
+        // are already waiting for THIS successor would spawn a second one
+        // before the first has even bound the port.
+        clearInterval(healTick);
         process.stderr.write(`[cache-fix] holder died; started a new one on ${advertised}\n`);
         // KEEP SERVING UNTIL THE SUCCESSOR IS UP. Exiting the instant we have
         // spawned a holder leaves the port with no owner for that holder's

--- a/test/gap-relay-chain.test.mjs
+++ b/test/gap-relay-chain.test.mjs
@@ -13,15 +13,20 @@
 // no-hop — their measurement is that closing there trades an invisible
 // fall-open for an invisible outage, and this tunnel is the most expensive
 // place to take one.
-import { test } from "node:test";
+import { after, test } from "node:test";
 import assert from "node:assert/strict";
 import net from "node:net";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { freePort } from "./proc-helpers.mjs";
+import { armLineage, freePort, reapStamped } from "./proc-helpers.mjs";
 
 const relayPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "gap-relay.mjs");
+// EVENT #348. Every relay here inherits this via {...process.env, ...}; see
+// proc-helpers.mjs's armLineage()/reapStamped() and proxy-held-port.test.mjs's
+// R3 fix, same shape.
+const lineage = armLineage("gap-relay-chain");
+after(async () => { await reapStamped(lineage); });
 
 // An endpoint that records being reached and answers a CONNECT. Every one of
 // them records, so a failure names which was touched instead of leaving an

--- a/test/install-service.test.mjs
+++ b/test/install-service.test.mjs
@@ -1,5 +1,5 @@
 import { createServer } from "node:net";
-import { test } from "node:test";
+import { after, test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, writeFile, rm, readdir, mkdir } from "node:fs/promises";
 import { tmpdir, platform } from "node:os";
@@ -7,6 +7,13 @@ import { join, dirname } from "node:path";
 import { execFile } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+
+import { armLineage, reapStamped } from "./proc-helpers.mjs";
+// EVENT #348. BIN's --proxy-port run below binds a real socket and opens a
+// standby the same way run-service/server do; see proc-helpers.mjs's
+// armLineage()/reapStamped() and proxy-held-port.test.mjs's R3 fix.
+const lineage = armLineage("install-service");
+after(async () => { await reapStamped(lineage); });
 
 import {
   renderSystemdTemplate,

--- a/test/orphan-lineage-sweep-harness.test.mjs
+++ b/test/orphan-lineage-sweep-harness.test.mjs
@@ -27,23 +27,34 @@ it("reaps the standby the lineage sweep in proxy-held-port.test.mjs is meant to 
     const env = { ...process.env, LEAK_PROBE_FILE: leakFile };
     delete env.NODE_TEST_CONTEXT;
     for (const k of HOP_ENV) delete env[k];
-    // 20s: ~20x the loaded single-case wall (~1s, measured at loadavg ~18 on
-    // 48 cores) and well under the 56.9s critical-path file
-    // (proxy-holder-handover.test.mjs), so a hang here can never become the
-    // suite's slowest file.
-    const NESTED_CEILING_MS = 20_000;
+    // 40s: above the WHOLE nested process's tolerated worst case, not the happy
+    // path, and not just the case's own budget — this timeout waits for
+    // after() too. The case (proxy-held-port.test.mjs) tolerates 15s to bind
+    // (:2386) + 5s relay wait (:2389) + 500ms settle (:2401) = 20.5s, and CI
+    // has hit that for real ("Proxy failed to start within 10s", :83-84). Its
+    // file-level after() (:2410) then runs two more retry loops before it can
+    // exit — a port sweep and reapStamped (proc-helpers.mjs:126), each up to
+    // 6 * 700ms — adding up to 8.4s more. ~29.9s tolerated end to end; 40s
+    // still leaves it well under the 56.9s critical-path file
+    // (proxy-holder-handover.test.mjs), so a genuine hang here still can't
+    // become the suite's slowest file.
+    const NESTED_CEILING_MS = 40_000;
     const r = spawnSync(process.execPath,
       ["--test", "--test-name-pattern", "leaves a standby for the file-level sweep", testFile],
       { env, encoding: "utf8", timeout: NESTED_CEILING_MS, killSignal: "SIGKILL" });
-    assert.ok(!r.error, `the nested run hit its ${NESTED_CEILING_MS / 1000}s ceiling: ${r.error}`);
-    assert.equal(r.status, 0, `the case itself failed:\n${r.stdout}\n${r.stderr}`);
 
+    // Read before asserting: a leak file the case wrote before a later hang
+    // must still reach `lineage`, or the timeout path we're bounding above
+    // skips the finally block's reapStamped and orphans the standby for real.
     let pids = [];
     try {
       const [markerLine, pidLine] = readFileSync(leakFile, "utf8").split("\n");
       lineage = markerLine;
       pids = (pidLine || "").trim().split(",").filter(Boolean);
     } catch { }
+
+    assert.ok(!r.error, `the nested run hit its ${NESTED_CEILING_MS / 1000}s ceiling: ${r.error}`);
+    assert.equal(r.status, 0, `the case itself failed:\n${r.stdout}\n${r.stderr}`);
     assert.ok(lineage && pids.length, "the case never recorded a lineage marker and standby pid — this measures nothing");
 
     for (const pid of pids) {

--- a/test/orphan-lineage-sweep-harness.test.mjs
+++ b/test/orphan-lineage-sweep-harness.test.mjs
@@ -34,7 +34,7 @@ it("reaps the standby the lineage sweep in proxy-held-port.test.mjs is meant to 
     // has hit that for real ("Proxy failed to start within 10s", :83-84). Its
     // file-level after() (:2410) then runs two more retry loops before it can
     // exit — a port sweep and reapStamped (proc-helpers.mjs:126), each up to
-    // 6 * 700ms — adding up to 8.4s more. ~29.9s tolerated end to end; 40s
+    // 6 * 700ms — adding up to 8.4s more. ~28.9s tolerated end to end; 40s
     // still leaves it well under the 56.9s critical-path file
     // (proxy-holder-handover.test.mjs), so a genuine hang here still can't
     // become the suite's slowest file.

--- a/test/orphan-lineage-sweep-harness.test.mjs
+++ b/test/orphan-lineage-sweep-harness.test.mjs
@@ -27,9 +27,16 @@ it("reaps the standby the lineage sweep in proxy-held-port.test.mjs is meant to 
     const env = { ...process.env, LEAK_PROBE_FILE: leakFile };
     delete env.NODE_TEST_CONTEXT;
     for (const k of HOP_ENV) delete env[k];
+    // 20s: ~20x the loaded single-case wall (~1s, measured at loadavg ~18 on
+    // 48 cores) and well under the 56.9s critical-path file
+    // (proxy-holder-handover.test.mjs), so a hang here can never become the
+    // suite's slowest file.
+    const NESTED_CEILING_MS = 20_000;
     const r = spawnSync(process.execPath,
       ["--test", "--test-name-pattern", "leaves a standby for the file-level sweep", testFile],
-      { env, encoding: "utf8", timeout: 120_000, killSignal: "SIGKILL" });
+      { env, encoding: "utf8", timeout: NESTED_CEILING_MS, killSignal: "SIGKILL" });
+    assert.ok(!r.error && r.signal !== "SIGKILL",
+      `the nested run hit its ${NESTED_CEILING_MS / 1000}s ceiling: ${r.error ?? `killed by ${r.signal}`}`);
     assert.equal(r.status, 0, `the case itself failed:\n${r.stdout}\n${r.stderr}`);
 
     let pids = [];

--- a/test/orphan-lineage-sweep-harness.test.mjs
+++ b/test/orphan-lineage-sweep-harness.test.mjs
@@ -35,8 +35,7 @@ it("reaps the standby the lineage sweep in proxy-held-port.test.mjs is meant to 
     const r = spawnSync(process.execPath,
       ["--test", "--test-name-pattern", "leaves a standby for the file-level sweep", testFile],
       { env, encoding: "utf8", timeout: NESTED_CEILING_MS, killSignal: "SIGKILL" });
-    assert.ok(!r.error && r.signal !== "SIGKILL",
-      `the nested run hit its ${NESTED_CEILING_MS / 1000}s ceiling: ${r.error ?? `killed by ${r.signal}`}`);
+    assert.ok(!r.error, `the nested run hit its ${NESTED_CEILING_MS / 1000}s ceiling: ${r.error}`);
     assert.equal(r.status, 0, `the case itself failed:\n${r.stdout}\n${r.stderr}`);
 
     let pids = [];

--- a/test/orphan-lineage-sweep-harness.test.mjs
+++ b/test/orphan-lineage-sweep-harness.test.mjs
@@ -5,17 +5,20 @@
 // after() included) to exit, then check every pid it recorded is gone.
 import { it } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 
+import { HOP_ENV, reapStamped, stamped } from "./proc-helpers.mjs";
+
 const testFile = join(dirname(fileURLToPath(import.meta.url)), "proxy-held-port.test.mjs");
 
-it("reaps the standby the lineage sweep in proxy-held-port.test.mjs is meant to catch", () => {
+it("reaps the standby the lineage sweep in proxy-held-port.test.mjs is meant to catch", async () => {
   const dir = mkdtempSync(join(tmpdir(), "leak-probe-"));
   const leakFile = join(dir, "pids");
+  let lineage;
   try {
     // NODE_TEST_CONTEXT, deleted rather than left to inherit: this harness is
     // itself a test file, so under `node --test test/` a nested `--test` here
@@ -23,23 +26,32 @@ it("reaps the standby the lineage sweep in proxy-held-port.test.mjs is meant to 
     // which would make every assertion below run against an empty leak file.
     const env = { ...process.env, LEAK_PROBE_FILE: leakFile };
     delete env.NODE_TEST_CONTEXT;
+    for (const k of HOP_ENV) delete env[k];
     const r = spawnSync(process.execPath,
       ["--test", "--test-name-pattern", "leaves a standby for the file-level sweep", testFile],
-      { env, encoding: "utf8" });
+      { env, encoding: "utf8", timeout: 120_000, killSignal: "SIGKILL" });
     assert.equal(r.status, 0, `the case itself failed:\n${r.stdout}\n${r.stderr}`);
 
     let pids = [];
-    try { pids = readFileSync(leakFile, "utf8").trim().split(",").filter(Boolean); } catch { }
-    assert.ok(pids.length, "the case never recorded a standby pid — this measures nothing");
+    try {
+      const [markerLine, pidLine] = readFileSync(leakFile, "utf8").split("\n");
+      lineage = markerLine;
+      pids = (pidLine || "").trim().split(",").filter(Boolean);
+    } catch { }
+    assert.ok(lineage && pids.length, "the case never recorded a lineage marker and standby pid — this measures nothing");
 
     for (const pid of pids) {
-      let alive = true;
-      try { execFileSync("kill", ["-0", pid], { stdio: "ignore" }); } catch { alive = false; }
+      const alive = stamped(lineage).includes(pid);
       assert.equal(alive, false,
         `pid ${pid} (a standby the case leaked on an unregistered port) is still alive after ` +
-        `the whole test file exited — the lineage sweep in its after() did not reap it`);
+        `the whole test file exited — the lineage sweep did not reap it`);
     }
   } finally {
+    // By marker, never a blind kill on the raw recorded pids: on the red path
+    // (the case's own file-level sweep did not run) this is what actually
+    // stops the leak from surviving the harness itself, and a recycled pid
+    // must still pass the marker+OURS filter before it is worth signalling.
+    if (lineage) await reapStamped(lineage);
     try { rmSync(dir, { recursive: true, force: true }); } catch { }
   }
 });

--- a/test/orphan-lineage-sweep-harness.test.mjs
+++ b/test/orphan-lineage-sweep-harness.test.mjs
@@ -31,13 +31,10 @@ it("reaps the standby the lineage sweep in proxy-held-port.test.mjs is meant to 
     // path, and not just the case's own budget — this timeout waits for
     // after() too. The case (proxy-held-port.test.mjs) tolerates 15s to bind
     // (:2386) + 5s relay wait (:2389) + 500ms settle (:2401) = 20.5s, and CI
-    // has hit that for real ("Proxy failed to start within 10s", :83-84). Its
-    // file-level after() (:2410) then runs two more retry loops before it can
-    // exit — a port sweep and reapStamped (proc-helpers.mjs:126), each up to
-    // 6 * 700ms — adding up to 8.4s more. ~28.9s tolerated end to end; 40s
-    // still leaves it well under the 56.9s critical-path file
-    // (proxy-holder-handover.test.mjs), so a genuine hang here still can't
-    // become the suite's slowest file.
+    // has really exceeded 10s on a boot (:83-84). Its file-level after()
+    // (:2410) then runs two more retry loops before it can exit — a port
+    // sweep and reapStamped (proc-helpers.mjs:126), each up to 6 * 700ms —
+    // adding up to 8.4s more. ~28.9s tolerated end to end.
     const NESTED_CEILING_MS = 40_000;
     const r = spawnSync(process.execPath,
       ["--test", "--test-name-pattern", "leaves a standby for the file-level sweep", testFile],
@@ -53,7 +50,7 @@ it("reaps the standby the lineage sweep in proxy-held-port.test.mjs is meant to 
       pids = (pidLine || "").trim().split(",").filter(Boolean);
     } catch { }
 
-    assert.ok(!r.error, `the nested run hit its ${NESTED_CEILING_MS / 1000}s ceiling: ${r.error}`);
+    assert.ok(!r.error, `the nested run did not complete within ${NESTED_CEILING_MS / 1000}s: ${r.error}`);
     assert.equal(r.status, 0, `the case itself failed:\n${r.stdout}\n${r.stderr}`);
     assert.ok(lineage && pids.length, "the case never recorded a lineage marker and standby pid — this measures nothing");
 

--- a/test/orphan-lineage-sweep-harness.test.mjs
+++ b/test/orphan-lineage-sweep-harness.test.mjs
@@ -1,0 +1,45 @@
+// EVENT #348, harness for the "leaves a standby for the file-level sweep to
+// find" case in proxy-held-port.test.mjs. That case only runs its body under
+// LEAK_PROBE_FILE — nothing else in the tree sets it, so this is what does:
+// run the file scoped to that one case, wait for the whole process (its
+// after() included) to exit, then check every pid it recorded is gone.
+import { it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+const testFile = join(dirname(fileURLToPath(import.meta.url)), "proxy-held-port.test.mjs");
+
+it("reaps the standby the lineage sweep in proxy-held-port.test.mjs is meant to catch", () => {
+  const dir = mkdtempSync(join(tmpdir(), "leak-probe-"));
+  const leakFile = join(dir, "pids");
+  try {
+    // NODE_TEST_CONTEXT, deleted rather than left to inherit: this harness is
+    // itself a test file, so under `node --test test/` a nested `--test` here
+    // sees it set and silently declines to run at all ("running recursively"),
+    // which would make every assertion below run against an empty leak file.
+    const env = { ...process.env, LEAK_PROBE_FILE: leakFile };
+    delete env.NODE_TEST_CONTEXT;
+    const r = spawnSync(process.execPath,
+      ["--test", "--test-name-pattern", "leaves a standby for the file-level sweep", testFile],
+      { env, encoding: "utf8" });
+    assert.equal(r.status, 0, `the case itself failed:\n${r.stdout}\n${r.stderr}`);
+
+    let pids = [];
+    try { pids = readFileSync(leakFile, "utf8").trim().split(",").filter(Boolean); } catch { }
+    assert.ok(pids.length, "the case never recorded a standby pid — this measures nothing");
+
+    for (const pid of pids) {
+      let alive = true;
+      try { execFileSync("kill", ["-0", pid], { stdio: "ignore" }); } catch { alive = false; }
+      assert.equal(alive, false,
+        `pid ${pid} (a standby the case leaked on an unregistered port) is still alive after ` +
+        `the whole test file exited — the lineage sweep in its after() did not reap it`);
+    }
+  } finally {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { }
+  }
+});

--- a/test/orphan-self-heal-cap.test.mjs
+++ b/test/orphan-self-heal-cap.test.mjs
@@ -27,22 +27,16 @@ import { execFileSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { HOP_ENV, freePort, reapStamped, stamped } from "./proc-helpers.mjs";
+import { HOP_ENV, armLineage, freePort, reapStamped } from "./proc-helpers.mjs";
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
-const lineage = `orphan-cap-${process.pid}-${Date.now()}`;
-process.env.CACHE_FIX_TEST_LINEAGE = lineage;
-
-// A SYNCHRONOUS BACKSTOP, same shape as proxy-held-port.test.mjs's: `after()`
-// (here, the case's own `finally`, since there is only one case) is async and
-// can be skipped by a crash before it runs; `exit` cannot await, so this is
-// SIGKILL directly rather than the SIGHUP-then-wait reapStamped() gets to do.
-process.on("exit", () => {
-  for (const p of stamped(lineage)) {
-    try { process.kill(Number(p), "SIGKILL"); } catch { /* best effort */ }
-  }
-});
+// EVENT #348. See proc-helpers.mjs's armLineage()/reapStamped() and
+// proxy-held-port.test.mjs's R3 fix, same shape. armLineage() also installs
+// the synchronous exit-time SIGKILL backstop `after()` gets elsewhere — here,
+// the case's own `finally` below is async and can be skipped by a crash
+// before it runs.
+const lineage = armLineage("orphan-cap");
 
 const get = (port) => new Promise((res) => {
   // 200 OR IT IS NOT THE PROXY. A standby relay carrying this address answers

--- a/test/orphan-self-heal-cap.test.mjs
+++ b/test/orphan-self-heal-cap.test.mjs
@@ -1,0 +1,95 @@
+// EVENT #348. An orphaned proxy/server.mjs (self-heal on) kept spawning a NEW
+// `run-service` successor every tick forever, because its guarding
+// `setInterval`'s handle was never assigned — nothing could `clearInterval` it,
+// so the next tick re-entered and spawned again even while the previous
+// successor was still booting or had already died fighting the orphan for the
+// port. Measured on lmd42: 17 orphaned `run-service` daemons and 85+ orphaned
+// `bin/gap-relay.mjs` standbys, some 4-11 days old, 0 connections, owner
+// sessions long dead.
+//
+// Reproduction shape lifted from `armc.sh` (analyzer 1, ledger #348): spawn one
+// holder with self-heal ON (CACHE_FIX_SELF_HEAL deleted, the default), let its
+// proxy child come up, SIGKILL the holder ONLY, then count how many times the
+// orphaned child announces "holder died; started a new one" in a fixed window
+// after the kill — analyzer 1 measured 2 in 20s from ONE orphan on a plain
+// 1000ms tick. A live successor here does not stay alive long enough to count
+// reliably (it loses the immediate port race against the orphan, which keeps
+// serving until IT decides a successor is up) — the announcement count is the
+// same signal analyzer 1 used and does not depend on that race's outcome.
+//
+// CACHE_FIX_SELF_HEAL_MS forces the tick down to 50ms — the code's own "test
+// seam" comment names this exact knob — so the re-entry window analyzer 1 saw
+// naturally at 16s is certain inside this test's budget instead of hoped for.
+import { it } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { execFileSync, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { freePort, stamped } from "./proc-helpers.mjs";
+
+const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
+
+const get = (port) => new Promise((res) => {
+  http.get({ host: "127.0.0.1", port, path: "/health", timeout: 3_000 }, (r) => {
+    let b = ""; r.on("data", (d) => (b += d)); r.on("end", () => res(b));
+  }).on("error", (e) => res(`ERR:${e.code}`));
+});
+
+it("announces a self-heal respawn at most once per orphan", async () => {
+  const lineage = `orphan-cap-${process.pid}-${Date.now()}`;
+  const port = await freePort();
+  const env = { ...process.env, CACHE_FIX_PROXY_PORT: String(port), CACHE_FIX_FORWARD_PROXY: "on",
+                CACHE_FIX_SELF_HEAL_MS: "50", CACHE_FIX_TEST_LINEAGE: lineage };
+  // Heal ON: no CACHE_FIX_SELF_HEAL in the child's env at all (the default).
+  for (const k of ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy",
+                    "CACHE_FIX_UPSTREAM_PROXY", "CACHE_FIX_REQUIRE_HOP", "CACHE_FIX_FALLBACK_PROXIES",
+                    "LISTEN_FDS", "LISTEN_PID", "CACHE_FIX_SELF_HEAL", "CACHE_FIX_WATCH_DEPLOY_MS"])
+    delete env[k];
+  const holder = spawn(process.execPath, [launcherPath, "run-service"], { env, stdio: ["ignore", "pipe", "pipe"] });
+  // The orphan's own self-heal message is written to ITS stderr, which is
+  // "inherit" from the launcher that spawned it (proxy/server.mjs's
+  // spawnWhenReady), so it arrives on this same pipe even after the holder
+  // that started the chain is gone.
+  let stderr = "";
+  holder.stderr.on("data", (d) => { stderr += d; });
+  let kid = 0;
+  try {
+    const up = Date.now() + 15_000;
+    while (Date.now() < up) {
+      const body = await get(port);
+      if (!body.startsWith("ERR:")) break;
+    }
+    try { kid = Number(execFileSync("pgrep", ["-P", String(holder.pid)]).toString().trim().split("\n")[0]); } catch {}
+    assert.ok(kid > 1, "the holder never spawned a proxy, so this measures nothing");
+
+    holder.kill("SIGKILL");
+
+    // A fixed window past the kill: long enough for several 50ms ticks to
+    // fire if the guard is missing, short enough to stay well under the
+    // orphan's own 30s exit ceiling so the count is not still climbing when
+    // we read it.
+    await new Promise((r) => setTimeout(r, 3_000));
+    const announcements = (stderr.match(/holder died; started a new one/g) || []).length;
+    assert.equal(announcements, 1,
+      `expected exactly one self-heal announcement from the orphan, saw ${announcements} ` +
+      `in 3s — the self-heal interval is re-firing on every tick instead of stopping after ` +
+      `the first successor\nstderr:\n${stderr}`);
+  } finally {
+    // Reap the whole stamped lineage: the orphaned server (child of the killed
+    // holder, which can still be alive waiting out its own exit ceiling), and
+    // any successor or standby a tick managed to spawn. `stamped()` finds them
+    // by env marker regardless of which port they ended up on or whether they
+    // are still fighting over the original one.
+    try { holder.kill("SIGKILL"); } catch {}
+    if (kid > 1) { try { process.kill(kid, "SIGKILL"); } catch {} }
+    for (let i = 0; i < 5; i++) {
+      const survivors = stamped(lineage);
+      if (!survivors.length) break;
+      for (const p of survivors) { try { process.kill(Number(p), "SIGHUP"); } catch {} }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    for (const p of stamped(lineage)) { try { process.kill(Number(p), "SIGKILL"); } catch {} }
+  }
+});

--- a/test/orphan-self-heal-cap.test.mjs
+++ b/test/orphan-self-heal-cap.test.mjs
@@ -3,7 +3,7 @@
 // `setInterval`'s handle was never assigned — nothing could `clearInterval` it,
 // so the next tick re-entered and spawned again even while the previous
 // successor was still booting or had already died fighting the orphan for the
-// port. Measured on lmd42: 17 orphaned `run-service` daemons and 85+ orphaned
+// port. Measured on <linux-host>: 17 orphaned `run-service` daemons and 85+ orphaned
 // `bin/gap-relay.mjs` standbys, some 4-11 days old, 0 connections, owner
 // sessions long dead.
 //
@@ -27,7 +27,7 @@ import { execFileSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { freePort, stamped } from "./proc-helpers.mjs";
+import { HOP_ENV, freePort, reapStamped } from "./proc-helpers.mjs";
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -43,9 +43,7 @@ it("announces a self-heal respawn at most once per orphan", async () => {
   const env = { ...process.env, CACHE_FIX_PROXY_PORT: String(port), CACHE_FIX_FORWARD_PROXY: "on",
                 CACHE_FIX_SELF_HEAL_MS: "50", CACHE_FIX_TEST_LINEAGE: lineage };
   // Heal ON: no CACHE_FIX_SELF_HEAL in the child's env at all (the default).
-  for (const k of ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy",
-                    "CACHE_FIX_UPSTREAM_PROXY", "CACHE_FIX_REQUIRE_HOP", "CACHE_FIX_FALLBACK_PROXIES",
-                    "LISTEN_FDS", "LISTEN_PID", "CACHE_FIX_SELF_HEAL", "CACHE_FIX_WATCH_DEPLOY_MS"])
+  for (const k of [...HOP_ENV, "LISTEN_FDS", "LISTEN_PID", "CACHE_FIX_SELF_HEAL", "CACHE_FIX_WATCH_DEPLOY_MS"])
     delete env[k];
   const holder = spawn(process.execPath, [launcherPath, "run-service"], { env, stdio: ["ignore", "pipe", "pipe"] });
   // The orphan's own self-heal message is written to ITS stderr, which is
@@ -60,6 +58,7 @@ it("announces a self-heal respawn at most once per orphan", async () => {
     while (Date.now() < up) {
       const body = await get(port);
       if (!body.startsWith("ERR:")) break;
+      await new Promise((r) => setTimeout(r, 100));
     }
     try { kid = Number(execFileSync("pgrep", ["-P", String(holder.pid)]).toString().trim().split("\n")[0]); } catch {}
     assert.ok(kid > 1, "the holder never spawned a proxy, so this measures nothing");
@@ -84,12 +83,6 @@ it("announces a self-heal respawn at most once per orphan", async () => {
     // are still fighting over the original one.
     try { holder.kill("SIGKILL"); } catch {}
     if (kid > 1) { try { process.kill(kid, "SIGKILL"); } catch {} }
-    for (let i = 0; i < 5; i++) {
-      const survivors = stamped(lineage);
-      if (!survivors.length) break;
-      for (const p of survivors) { try { process.kill(Number(p), "SIGHUP"); } catch {} }
-      await new Promise((r) => setTimeout(r, 500));
-    }
-    for (const p of stamped(lineage)) { try { process.kill(Number(p), "SIGKILL"); } catch {} }
+    await reapStamped(lineage);
   }
 });

--- a/test/orphan-self-heal-cap.test.mjs
+++ b/test/orphan-self-heal-cap.test.mjs
@@ -27,18 +27,39 @@ import { execFileSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { HOP_ENV, freePort, reapStamped } from "./proc-helpers.mjs";
+import { HOP_ENV, freePort, reapStamped, stamped } from "./proc-helpers.mjs";
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
+const lineage = `orphan-cap-${process.pid}-${Date.now()}`;
+process.env.CACHE_FIX_TEST_LINEAGE = lineage;
+
+// A SYNCHRONOUS BACKSTOP, same shape as proxy-held-port.test.mjs's: `after()`
+// (here, the case's own `finally`, since there is only one case) is async and
+// can be skipped by a crash before it runs; `exit` cannot await, so this is
+// SIGKILL directly rather than the SIGHUP-then-wait reapStamped() gets to do.
+process.on("exit", () => {
+  for (const p of stamped(lineage)) {
+    try { process.kill(Number(p), "SIGKILL"); } catch { /* best effort */ }
+  }
+});
+
 const get = (port) => new Promise((res) => {
-  http.get({ host: "127.0.0.1", port, path: "/health", timeout: 3_000 }, (r) => {
-    let b = ""; r.on("data", (d) => (b += d)); r.on("end", () => res(b));
-  }).on("error", (e) => res(`ERR:${e.code}`));
+  // 200 OR IT IS NOT THE PROXY. A standby relay carrying this address answers
+  // /health with a 503 and a JSON body of its own, and readiness on any body
+  // lets a loop finish against the relay instead of the real holder.
+  const r = http.get({ host: "127.0.0.1", port, path: "/health" }, (q) => {
+    let b = ""; q.on("data", (d) => (b += d));
+    q.on("end", () => res(q.statusCode === 200 ? b : `ERR:${q.statusCode} ${b.slice(0, 160)}`));
+  });
+  // `timeout:` in the options only EMITS 'timeout'; it does not destroy the
+  // request, so a standby holding an un-armed listen (completes the connect,
+  // never answers) leaves this promise unsettled forever.
+  r.setTimeout(3_000, () => { r.destroy(); res("ERR:HUNG"); });
+  r.on("error", (e) => res(`ERR:${e.code}`));
 });
 
 it("announces a self-heal respawn at most once per orphan", async () => {
-  const lineage = `orphan-cap-${process.pid}-${Date.now()}`;
   const port = await freePort();
   const env = { ...process.env, CACHE_FIX_PROXY_PORT: String(port), CACHE_FIX_FORWARD_PROXY: "on",
                 CACHE_FIX_SELF_HEAL_MS: "50", CACHE_FIX_TEST_LINEAGE: lineage };

--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -143,8 +143,7 @@ export async function reapStamped(marker) {
 // be skipped by a crash before teardown) and returns the marker so the
 // caller can also `await reapStamped(marker)` from its own async teardown.
 export function armLineage(name) {
-  process.env.CACHE_FIX_TEST_LINEAGE = `${name}-${process.pid}`;
-  const marker = process.env.CACHE_FIX_TEST_LINEAGE;
+  const marker = process.env.CACHE_FIX_TEST_LINEAGE = `${name}-${process.pid}`;
   process.on("exit", () => {
     for (const p of stamped(marker)) {
       try { process.kill(Number(p), "SIGKILL"); } catch { /* best effort */ }

--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -111,7 +111,11 @@ export function ours(port) {
 // unverified on macOS (no live box to measure this leg on) — a case there
 // still has the port sweep above as its floor, so nothing regresses.
 export function stamped(marker) {
-  return byEnv(new RegExp(`CACHE_FIX_TEST_LINEAGE=${marker}(?:\\s|$)`));
+  // Escaped: a marker built from a pid and Date.now() has no regex metachars
+  // today, but the marker is a caller-supplied string and `.` alone would
+  // silently widen the match to any single character in its place.
+  const safe = String(marker).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return byEnv(new RegExp(`CACHE_FIX_TEST_LINEAGE=${safe}(?:\\s|$)`));
 }
 
 // SIGHUP, THEN SIGKILL, BY LINEAGE. The shared shape of "reap what this run's

--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -133,16 +133,17 @@ export async function reapStamped(marker) {
   for (const p of stamped(marker)) { try { process.kill(Number(p), "SIGKILL"); } catch { /* gone already */ } }
 }
 
-// ARM A FILE'S LINEAGE, ONE CALL. `||=` rather than `=`: a caller that already
-// has a marker (a harness passing one in through the child's env) is honoured
-// instead of overwritten, so an outer probe and the file it drives can agree
-// on the same marker without the file having to know it is being probed.
-// Installs the synchronous exit-time SIGKILL backstop over it (see the note
-// this replaces in proxy-held-port.test.mjs: `after()` is async and can be
-// skipped by a crash before teardown) and returns the marker so the caller
-// can also `await reapStamped(marker)` from its own async teardown.
+// ARM A FILE'S LINEAGE, ONE CALL. `=`, not `||=`: nothing calls this with
+// CACHE_FIX_TEST_LINEAGE already set in ITS OWN env (a harness passes a
+// marker back through LEAK_PROBE_FILE, never through env), so `||=` here
+// would only ever pick up an AMBIENT value the process inherited from
+// whatever started it — widening the sweep to a marker this file never
+// chose. Installs the synchronous exit-time SIGKILL backstop over it (see the
+// note this replaces in proxy-held-port.test.mjs: `after()` is async and can
+// be skipped by a crash before teardown) and returns the marker so the
+// caller can also `await reapStamped(marker)` from its own async teardown.
 export function armLineage(name) {
-  process.env.CACHE_FIX_TEST_LINEAGE ||= `${name}-${process.pid}`;
+  process.env.CACHE_FIX_TEST_LINEAGE = `${name}-${process.pid}`;
   const marker = process.env.CACHE_FIX_TEST_LINEAGE;
   process.on("exit", () => {
     for (const p of stamped(marker)) {

--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -133,6 +133,25 @@ export async function reapStamped(marker) {
   for (const p of stamped(marker)) { try { process.kill(Number(p), "SIGKILL"); } catch { /* gone already */ } }
 }
 
+// ARM A FILE'S LINEAGE, ONE CALL. `||=` rather than `=`: a caller that already
+// has a marker (a harness passing one in through the child's env) is honoured
+// instead of overwritten, so an outer probe and the file it drives can agree
+// on the same marker without the file having to know it is being probed.
+// Installs the synchronous exit-time SIGKILL backstop over it (see the note
+// this replaces in proxy-held-port.test.mjs: `after()` is async and can be
+// skipped by a crash before teardown) and returns the marker so the caller
+// can also `await reapStamped(marker)` from its own async teardown.
+export function armLineage(name) {
+  process.env.CACHE_FIX_TEST_LINEAGE ||= `${name}-${process.pid}`;
+  const marker = process.env.CACHE_FIX_TEST_LINEAGE;
+  process.on("exit", () => {
+    for (const p of stamped(marker)) {
+      try { process.kill(Number(p), "SIGKILL"); } catch { /* best effort */ }
+    }
+  });
+  return marker;
+}
+
 // A port nobody is listening on RIGHT NOW. It is released before the caller
 // uses it — see the OURS note above for what that costs and how it is bounded.
 export async function freePort() {

--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -71,8 +71,10 @@ export function listeners(port) {
 //
 // Still filtered by OURS, for the same reason listeners() is: a port number is
 // not ownership, and freePort() hands the same number to neighbouring files.
-export function ours(port) {
-  const want = new RegExp(`CACHE_FIX_(?:HELD|PROXY)_PORT=${Number(port)}(?:\\s|$)`);
+// EVERY PID WHOSE ENVIRON MATCHES `want`, filtered by OURS. Shared by ours()
+// (keyed on a registered port) and stamped() (keyed on a lineage marker) —
+// same two platforms, same two markers to read, only the regex differs.
+function byEnv(want) {
   const out = [];
   try {
     // Linux: /proc is authoritative and needs no shell-out.
@@ -96,6 +98,10 @@ export function ours(port) {
   return out;
 }
 
+export function ours(port) {
+  return byEnv(new RegExp(`CACHE_FIX_(?:HELD|PROXY)_PORT=${Number(port)}(?:\\s|$)`));
+}
+
 // EVERY PROCESS DESCENDED FROM ONE TEST FILE'S RUN, by env marker rather than
 // by the port it ends up on. onPort()/ours() need a registered port; a
 // self-heal successor or a standby relay a case never asked freePort() for
@@ -105,26 +111,22 @@ export function ours(port) {
 // unverified on macOS (no live box to measure this leg on) — a case there
 // still has the port sweep above as its floor, so nothing regresses.
 export function stamped(marker) {
-  const want = new RegExp(`CACHE_FIX_TEST_LINEAGE=${marker}(?:\\s|$)`);
-  const out = [];
-  try {
-    for (const pid of readdirSync("/proc")) {
-      if (!/^\d+$/.test(pid)) continue;
-      let env = "";
-      try { env = readFileSync(`/proc/${pid}/environ`, "utf8").replace(/\0/g, " "); } catch { continue; }
-      if (want.test(env) && OURS.test(cmdOf(pid))) out.push(pid);
-    }
-    return out;
-  } catch { /* no /proc: ask ps below */ }
-  try {
-    const rows = execFileSync("ps", ["-wwEo", "pid=,command="],
-                              { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
-    for (const line of rows.split("\n")) {
-      const m = /^\s*(\d+)\s+(.*)$/.exec(line);
-      if (m && want.test(m[2]) && OURS.test(m[2])) out.push(m[1]);
-    }
-  } catch { /* no ps either */ }
-  return out;
+  return byEnv(new RegExp(`CACHE_FIX_TEST_LINEAGE=${marker}(?:\\s|$)`));
+}
+
+// SIGHUP, THEN SIGKILL, BY LINEAGE. The shared shape of "reap what this run's
+// lineage left behind": SIGHUP is the graceful release a standby only stands
+// down on (see bin/claude-via-proxy.mjs's forward()), tried a few times, then
+// whatever is still alive gets forced. Two callers had this loop hand-copied;
+// one copy is what stays in sync.
+export async function reapStamped(marker) {
+  for (let i = 0; i < 6; i++) {
+    const survivors = stamped(marker);
+    if (!survivors.length) break;
+    for (const p of survivors) { try { process.kill(Number(p), "SIGHUP"); } catch { /* gone already */ } }
+    await new Promise((r) => setTimeout(r, 700));
+  }
+  for (const p of stamped(marker)) { try { process.kill(Number(p), "SIGKILL"); } catch { /* gone already */ } }
 }
 
 // A port nobody is listening on RIGHT NOW. It is released before the caller

--- a/test/proc-helpers.mjs
+++ b/test/proc-helpers.mjs
@@ -96,6 +96,37 @@ export function ours(port) {
   return out;
 }
 
+// EVERY PROCESS DESCENDED FROM ONE TEST FILE'S RUN, by env marker rather than
+// by the port it ends up on. onPort()/ours() need a registered port; a
+// self-heal successor or a standby relay a case never asked freePort() for
+// (born on a kernel-picked port nobody recorded) is still ours to find here,
+// because every spawn in this tree forwards `{...process.env, ...}` and so
+// inherits whatever the top of the file stamped. Same two platforms as ours();
+// unverified on macOS (no live box to measure this leg on) — a case there
+// still has the port sweep above as its floor, so nothing regresses.
+export function stamped(marker) {
+  const want = new RegExp(`CACHE_FIX_TEST_LINEAGE=${marker}(?:\\s|$)`);
+  const out = [];
+  try {
+    for (const pid of readdirSync("/proc")) {
+      if (!/^\d+$/.test(pid)) continue;
+      let env = "";
+      try { env = readFileSync(`/proc/${pid}/environ`, "utf8").replace(/\0/g, " "); } catch { continue; }
+      if (want.test(env) && OURS.test(cmdOf(pid))) out.push(pid);
+    }
+    return out;
+  } catch { /* no /proc: ask ps below */ }
+  try {
+    const rows = execFileSync("ps", ["-wwEo", "pid=,command="],
+                              { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    for (const line of rows.split("\n")) {
+      const m = /^\s*(\d+)\s+(.*)$/.exec(line);
+      if (m && want.test(m[2]) && OURS.test(m[2])) out.push(m[1]);
+    }
+  } catch { /* no ps either */ }
+  return out;
+}
+
 // A port nobody is listening on RIGHT NOW. It is released before the caller
 // uses it — see the OURS note above for what that costs and how it is bounded.
 export async function freePort() {

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -2402,7 +2402,10 @@ it("leaves a standby for the file-level sweep to find, on a port it never regist
     if (!relays.length) await new Promise((r) => setTimeout(r, 200));
   }
   assert.ok(relays.length, "the holder never opened a standby — this measures nothing");
-  writeFileSync(process.env.LEAK_PROBE_FILE, relays.join(","));
+  // The lineage rides along with the pids: a harness that only has the pids
+  // can do no better than a blind kill, and a recycled pid must still pass
+  // the marker+OURS filter before anything signals it.
+  writeFileSync(process.env.LEAK_PROBE_FILE, `${lineage}\n${relays.join(",")}`);
   holder.kill("SIGKILL");        // bypasses every handler, including closeStandby()
   await new Promise((r) => setTimeout(r, 500));
 });

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -11,7 +11,7 @@ import { tmpdir, availableParallelism } from "node:os";
 import { join, dirname } from "node:path";
 
 import { sourceFingerprintSync } from "../proxy/source-fingerprint.mjs";
-import { HOP_ENV, OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
+import { HOP_ENV, OURS, cmdOf, freePort as takePort, listeners, onPort, stamped } from "./proc-helpers.mjs";
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -60,6 +60,29 @@ async function freePort() {
   usedPorts.push(p);
   return p;
 }
+
+// EVENT #348. usedPorts only ever catches a port a case HANDED OUT — the
+// "asked for an ephemeral one" case below gets its port back from the kernel
+// via CACHE_FIX_PROXY_PORT=0 and never registers it, so onPort() at the bottom
+// of this file was never even asked about it, and a survivor there (measured:
+// one `bin/gap-relay.mjs` standby, ppid 1, 10s after the runner exited) went
+// unreaped. Stamped by env instead: every spawn in this tree forwards
+// `{...process.env, ...}`, so setting this once, here, before any case spawns
+// anything, marks the whole lineage any case in this file can cause —
+// self-heal successor, standby, or a kernel-picked port nobody registered —
+// regardless of which port it ends up on. See stamped() in proc-helpers.mjs.
+process.env.CACHE_FIX_TEST_LINEAGE = `proxy-held-port-${process.pid}`;
+
+// A SYNCHRONOUS BACKSTOP. `after()` is async and can be skipped entirely by a
+// crash before the runner reaches teardown -- the file-level sweep below is
+// the normal path, this is what still runs if that path is never taken.
+// `exit` cannot await, so this is SIGKILL directly rather than the
+// SIGHUP-then-wait the async sweep gets to do.
+process.on("exit", () => {
+  for (const p of stamped(process.env.CACHE_FIX_TEST_LINEAGE)) {
+    try { process.kill(Number(p), "SIGKILL"); } catch { /* best effort */ }
+  }
+});
 
 // Its own file: every case here drives a REAL launcher holding a REAL port, so
 // a mis-signalled pid or a stuck child aborts the whole runner process. Node
@@ -2348,6 +2371,42 @@ describe("deploy watcher (CACHE_FIX_WATCH_DEPLOY_MS)", () => {
 });
 });
 
+// EVENT #348, the gap-relay half (analyzer 2). This case never calls this
+// file's freePort() — CACHE_FIX_PROXY_PORT="0" hands the address back from the
+// kernel, exactly like "hands the BOUND port downstream" above, and a case
+// that never registers its port is invisible to the file-level after() sweep
+// below UNLESS it is found by lineage instead. It deliberately does NOT reap
+// what it leaks: that is the file-level sweep's job, and the point of this
+// case is to prove the sweep does it, not to do it twice. SIGKILL, not SIGHUP,
+// because closeStandby() only runs on SIGHUP by design (see forward() in the
+// launcher) — a plain kill leaves the standby up every time, not on a timing
+// race, so this reproduces deterministically. Recorded to
+// LEAK_PROBE_FILE, read by the harness AFTER this whole file's process exits
+// (i.e. after after() has had its turn), which is the only vantage point that
+// can tell whether the sweep actually ran.
+it("leaves a standby for the file-level sweep to find, on a port it never registered", async () => {
+  if (!process.env.LEAK_PROBE_FILE) return;   // only meaningful under the harness below
+  const lineage = process.env.CACHE_FIX_TEST_LINEAGE;
+  const env = { ...process.env, CACHE_FIX_PROXY_PORT: "0" };
+  for (const k of [...HOP_ENV, "LISTEN_FDS", "LISTEN_PID"]) delete env[k];
+  const holder = spawn(process.execPath, [launcherPath, "run-service"], { env, stdio: ["ignore", "pipe", "ignore"] });
+  let out = "";
+  holder.stdout.on("data", (d) => { out += d; });
+  const up = Date.now() + 15_000;
+  while (!/listening on/.test(out) && Date.now() < up) await new Promise((r) => setTimeout(r, 100));
+  assert.ok(/listening on/.test(out), "the holder never bound a port — this measures nothing");
+  const untilRelay = Date.now() + 5_000;
+  let relays = [];
+  while (!relays.length && Date.now() < untilRelay) {
+    relays = stamped(lineage).filter((p) => /gap-relay\.mjs/.test(cmdOf(p)));
+    if (!relays.length) await new Promise((r) => setTimeout(r, 200));
+  }
+  assert.ok(relays.length, "the holder never opened a standby — this measures nothing");
+  writeFileSync(process.env.LEAK_PROBE_FILE, relays.join(","));
+  holder.kill("SIGKILL");        // bypasses every handler, including closeStandby()
+  await new Promise((r) => setTimeout(r, 500));
+});
+
 // ONE SWEEP FOR THE FILE, over the ports it handed out and nobody else's. A
 // standby relay outlives a holder that was killed rather than released — that
 // is the point of it — and while it has not armed yet it holds a socket nobody
@@ -2365,4 +2424,19 @@ after(async () => {
     if (!any && i) break;
     await new Promise((r) => setTimeout(r, 700));
   }
+
+  // A SECOND SWEEP, BY LINEAGE RATHER THAN BY PORT. EVENT #348: the "asked for
+  // an ephemeral one" case gets its bound port back from the kernel and never
+  // registers it in usedPorts, so the loop above never asks onPort() about it
+  // and a standby it left behind (measured: one, ppid 1, 10s after this file's
+  // runner exited) was never swept. stamped() finds the whole lineage this
+  // file caused by env marker instead, whatever port it landed on.
+  const lineage = process.env.CACHE_FIX_TEST_LINEAGE;
+  for (let i = 0; i < 6; i++) {
+    const survivors = stamped(lineage);
+    if (!survivors.length) break;
+    for (const p of survivors) { try { process.kill(Number(p), "SIGHUP"); } catch { } }
+    await new Promise((r) => setTimeout(r, 700));
+  }
+  for (const p of stamped(lineage)) { try { process.kill(Number(p), "SIGKILL"); } catch { } }
 });

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -11,7 +11,7 @@ import { tmpdir, availableParallelism } from "node:os";
 import { join, dirname } from "node:path";
 
 import { sourceFingerprintSync } from "../proxy/source-fingerprint.mjs";
-import { HOP_ENV, OURS, cmdOf, freePort as takePort, listeners, onPort, stamped } from "./proc-helpers.mjs";
+import { HOP_ENV, OURS, cmdOf, freePort as takePort, listeners, onPort, reapStamped, stamped } from "./proc-helpers.mjs";
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -2431,12 +2431,5 @@ after(async () => {
   // and a standby it left behind (measured: one, ppid 1, 10s after this file's
   // runner exited) was never swept. stamped() finds the whole lineage this
   // file caused by env marker instead, whatever port it landed on.
-  const lineage = process.env.CACHE_FIX_TEST_LINEAGE;
-  for (let i = 0; i < 6; i++) {
-    const survivors = stamped(lineage);
-    if (!survivors.length) break;
-    for (const p of survivors) { try { process.kill(Number(p), "SIGHUP"); } catch { } }
-    await new Promise((r) => setTimeout(r, 700));
-  }
-  for (const p of stamped(lineage)) { try { process.kill(Number(p), "SIGKILL"); } catch { } }
+  await reapStamped(process.env.CACHE_FIX_TEST_LINEAGE);
 });

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -183,7 +183,7 @@ async function withHeldPort(fn, { subcommand = "server", extraEnv = {} } = {}) {
   // measured, an exported WATCH_DEPLOY_MS turns "is off unless asked for"
   // into a failure about the shell rather than about the code.
   const env = { ...process.env };
-  for (const k of [...HOP_ENV, "LISTEN_FDS", "LISTEN_PID", "CACHE_FIX_WATCH_DEPLOY_MS", "CACHE_FIX_SELF_HEAL"]) delete env[k];
+  for (const k of [...HOP_ENV, "LISTEN_FDS", "LISTEN_PID", "CACHE_FIX_WATCH_DEPLOY_MS"]) delete env[k];
   Object.assign(env, { CACHE_FIX_HOLD_PORT: "on", CACHE_FIX_PROXY_PORT: String(port),
                        CACHE_FIX_SELF_HEAL: "off",
                        // A SIGKILLed runner runs no cleanup, so ask the holder to

--- a/test/proxy-held-port.test.mjs
+++ b/test/proxy-held-port.test.mjs
@@ -11,7 +11,7 @@ import { tmpdir, availableParallelism } from "node:os";
 import { join, dirname } from "node:path";
 
 import { sourceFingerprintSync } from "../proxy/source-fingerprint.mjs";
-import { HOP_ENV, OURS, cmdOf, freePort as takePort, listeners, onPort, reapStamped, stamped } from "./proc-helpers.mjs";
+import { HOP_ENV, OURS, armLineage, cmdOf, freePort as takePort, listeners, onPort, reapStamped, stamped } from "./proc-helpers.mjs";
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
 
@@ -70,19 +70,10 @@ async function freePort() {
 // `{...process.env, ...}`, so setting this once, here, before any case spawns
 // anything, marks the whole lineage any case in this file can cause —
 // self-heal successor, standby, or a kernel-picked port nobody registered —
-// regardless of which port it ends up on. See stamped() in proc-helpers.mjs.
-process.env.CACHE_FIX_TEST_LINEAGE = `proxy-held-port-${process.pid}`;
-
-// A SYNCHRONOUS BACKSTOP. `after()` is async and can be skipped entirely by a
-// crash before the runner reaches teardown -- the file-level sweep below is
-// the normal path, this is what still runs if that path is never taken.
-// `exit` cannot await, so this is SIGKILL directly rather than the
-// SIGHUP-then-wait the async sweep gets to do.
-process.on("exit", () => {
-  for (const p of stamped(process.env.CACHE_FIX_TEST_LINEAGE)) {
-    try { process.kill(Number(p), "SIGKILL"); } catch { /* best effort */ }
-  }
-});
+// regardless of which port it ends up on. armLineage() (proc-helpers.mjs)
+// also installs the synchronous exit-time backstop: `after()` below is async
+// and can be skipped entirely by a crash before the runner reaches teardown.
+armLineage("proxy-held-port");
 
 // Its own file: every case here drives a REAL launcher holding a REAL port, so
 // a mis-signalled pid or a stuck child aborts the whole runner process. Node

--- a/test/proxy-holder-handover.test.mjs
+++ b/test/proxy-holder-handover.test.mjs
@@ -9,9 +9,12 @@ import { tmpdir } from "node:os";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
+import { OURS, armLineage, cmdOf, freePort as takePort, listeners, onPort, reapStamped } from "./proc-helpers.mjs";
 
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
+// EVENT #348. See proc-helpers.mjs's armLineage()/reapStamped() and
+// proxy-held-port.test.mjs's R3 fix, same shape.
+const lineage = armLineage("proxy-holder-handover");
 
 // Its own file, and that is the point rather than tidiness. This case samples a
 // live port while a holder is replaced, so it is sensitive to how much else is
@@ -106,6 +109,7 @@ describe("holder handover (SIGUSR2)", () => {
       if (!any && i) break;
       await new Promise((r) => setTimeout(r, 700));
     }
+    await reapStamped(lineage);
   });
   it("hands the port to a successor without refusing a request", async () => {
     const port = await freePort();

--- a/test/proxy-integration.test.mjs
+++ b/test/proxy-integration.test.mjs
@@ -2,6 +2,11 @@ import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { exitWithin } from "./child-deadline.mjs";
 import http from "node:http";
+import { armLineage, reapStamped } from "./proc-helpers.mjs";
+
+// See proc-helpers.mjs's armLineage()/reapStamped(): the spawn below inherits
+// the marker through `{...process.env}`.
+const lineage = armLineage("proxy-integration");
 
 let proxyPort;
 let proxyProcess;
@@ -101,6 +106,7 @@ describe("proxy integration with extensions", () => {
     }
     delete process.env.CACHE_FIX_PROXY_PORT;
     delete process.env.CACHE_FIX_PROXY_UPSTREAM;
+    await reapStamped(lineage);
   });
 
   it("health check returns ok", async () => {

--- a/test/proxy-log-cap.test.mjs
+++ b/test/proxy-log-cap.test.mjs
@@ -20,7 +20,7 @@
 //     ftruncateSync(2)  works, and later writes land at 0
 // So a tail cannot be preserved and the cap is a truncate. It keeps the NEWEST
 // lines, which is the half worth keeping.
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import net from "node:net";
 import { spawn } from "node:child_process";
@@ -30,8 +30,14 @@ import { tmpdir } from "node:os";
 import {
   closeSync, fstatSync, mkdtempSync, openSync, readFileSync, rmSync, statSync, writeFileSync,
 } from "node:fs";
+import { armLineage, reapStamped } from "./proc-helpers.mjs";
 
 const serverPath = join(fileURLToPath(new URL(".", import.meta.url)), "..", "proxy", "server.mjs");
+// See proc-helpers.mjs's armLineage()/reapStamped() and
+// stdio-epipe-survival.test.mjs's note, same shape: the spawn below inherits
+// the marker through `{...process.env}`.
+const lineage = armLineage("proxy-log-cap");
+after(async () => { await reapStamped(lineage); });
 
 describe("log cap", () => {
   it("truncates its own log when it is over the cap, and says so", async () => {

--- a/test/proxy-probe-bounded.test.mjs
+++ b/test/proxy-probe-bounded.test.mjs
@@ -15,7 +15,7 @@
 //
 // This test replaces `lsof` with one that never returns and asserts the
 // launcher still finishes. Without a timeout on the probe it hangs forever.
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import net from "node:net";
 import { spawn } from "node:child_process";
@@ -24,7 +24,13 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 
+import { armLineage, reapStamped } from "./proc-helpers.mjs";
+
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
+// EVENT #348. See proc-helpers.mjs's armLineage()/reapStamped() and
+// proxy-held-port.test.mjs's R3 fix, same shape.
+const lineage = armLineage("proxy-probe-bounded");
+after(async () => { await reapStamped(lineage); });
 
 describe("probe bounding", () => {
   // ONE CASE PER HANGING COMMAND, because they sit at different depths of the

--- a/test/proxy-server.test.mjs
+++ b/test/proxy-server.test.mjs
@@ -11,10 +11,13 @@ import { join, dirname } from "node:path";
 import { startProxy, upstreamPointsAtSelf } from "../proxy/server.mjs";
 import { startWatcher } from "../proxy/watcher.mjs";
 import { loadExtensions, getRegistry } from "../proxy/pipeline.mjs";
-import { OURS, cmdOf, freePort as takePort, listeners, onPort } from "./proc-helpers.mjs";
+import { OURS, armLineage, cmdOf, freePort as takePort, listeners, onPort, reapStamped } from "./proc-helpers.mjs";
 
 const serverPath = join(dirname(fileURLToPath(import.meta.url)), "..", "proxy", "server.mjs");
 const launcherPath = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "claude-via-proxy.mjs");
+// EVENT #348. See proc-helpers.mjs's armLineage()/reapStamped() and
+// proxy-held-port.test.mjs's R3 fix, same shape.
+const lineage = armLineage("proxy-server");
 
 const usedPorts = [];
 // The shared allocator plus this file's own cleanup registry — the registry is
@@ -848,6 +851,7 @@ after(async () => {
     if (!any && i) break;
     await new Promise((r) => setTimeout(r, 700));
   }
+  await reapStamped(lineage);
 });
 
 // close() MUST RESOLVE AFTER shutdown() HAS ALREADY UNBOUND.

--- a/test/proxy-shutdown-once.test.mjs
+++ b/test/proxy-shutdown-once.test.mjs
@@ -10,7 +10,7 @@
 // mutation-checked; it needed isolating, not deleting.
 //
 // node gives each FILE its own process, which is the whole mechanism.
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
 import net from "node:net";
@@ -18,11 +18,15 @@ import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { OURS, cmdOf, freePort, listeners } from "./proc-helpers.mjs";
+import { OURS, armLineage, cmdOf, freePort, listeners, reapStamped } from "./proc-helpers.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const launcherPath = join(here, "..", "bin", "claude-via-proxy.mjs");
 const serverPath = join(here, "..", "proxy", "server.mjs");
+// EVENT #348. See proc-helpers.mjs's armLineage()/reapStamped() and
+// proxy-held-port.test.mjs's R3 fix, same shape.
+const lineage = armLineage("proxy-shutdown-once");
+after(async () => { await reapStamped(lineage); });
 
 const probe = (port) => new Promise((res) => {
   const r = http.get({ host: "127.0.0.1", port, path: "/health", agent: false, timeout: 8_000 },

--- a/test/proxy-update-sweep.test.mjs
+++ b/test/proxy-update-sweep.test.mjs
@@ -8,7 +8,7 @@
 // Driven as a real process, not by importing the function: the sweep is armed
 // from the script-entry path and reads its inputs from the environment, so an
 // in-process call would test neither.
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { exitWithin } from "./child-deadline.mjs";
 import http from "node:http";
@@ -17,10 +17,15 @@ import { fileURLToPath } from "node:url";
 import { mkdtempSync, writeFileSync, existsSync, mkdirSync, symlinkSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
-import { freePort } from "./proc-helpers.mjs";
+import { armLineage, freePort, reapStamped } from "./proc-helpers.mjs";
 
 const serverPath = join(dirname(fileURLToPath(import.meta.url)), "..", "proxy", "server.mjs");
 const DELAY_MS = 300;
+// See proc-helpers.mjs's armLineage()/reapStamped() and
+// stdio-epipe-survival.test.mjs's note, same shape: both spawns below inherit
+// the marker through `{...process.env}`.
+const lineage = armLineage("proxy-update-sweep");
+after(async () => { await reapStamped(lineage); });
 
 // A stand-in release channel, so the test never depends on the network or on
 // what the real channel happens to say today.

--- a/test/proxy-wrapper.test.mjs
+++ b/test/proxy-wrapper.test.mjs
@@ -8,6 +8,7 @@ import { tmpdir, availableParallelism } from "node:os";
 import { chmodSync, closeSync, existsSync, fstatSync, mkdirSync, mkdtempSync, openSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import http from "node:http";
 import tls from "node:tls";
+import { armLineage, reapStamped } from "./proc-helpers.mjs";
 
 // The keep-the-merge branch needs a census that can say YES, and
 // `tls.getCACertificates` arrived in v22.15 while `engines` allows >=18. Below
@@ -21,6 +22,11 @@ import { bundleUsable } from "../bin/ca-trust.mjs";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WRAPPER_PATH = resolve(__dirname, "../bin/claude-via-proxy.mjs");
 const SERVER_PATH = resolve(__dirname, "../proxy/server.mjs");
+
+// EVENT #348. See proc-helpers.mjs's armLineage()/reapStamped() and
+// proxy-held-port.test.mjs's R3 fix, same shape.
+const lineage = armLineage("proxy-wrapper");
+after(async () => { await reapStamped(lineage); });
 
 // Every temp dir this file makes, removed once at the end.
 //

--- a/test/shutdown-exit-code.test.mjs
+++ b/test/shutdown-exit-code.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { withDeadline } from "./child-deadline.mjs";
 import net from "node:net";
@@ -8,8 +8,15 @@ import { readFileSync } from "node:fs";
 import { forcedCloseLine } from "../proxy/server.mjs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { armLineage, reapStamped } from "./proc-helpers.mjs";
 
 const serverPath = join(dirname(fileURLToPath(import.meta.url)), "..", "proxy", "server.mjs");
+// See proc-helpers.mjs's armLineage()/reapStamped() and this file's own
+// comment above startProxyWithBadFd3(): the whole reason that spawn is
+// `detached: true` is a successor that outlives the group kill, and that
+// successor still inherits this marker through `{...process.env}`.
+const lineage = armLineage("shutdown-exit-code");
+after(async () => { await reapStamped(lineage); });
 
 // A supervised stop must exit 0 whichever path it takes. server.close() waits
 // for in-flight requests, and a live session always has one (the streaming

--- a/test/stdio-epipe-survival.test.mjs
+++ b/test/stdio-epipe-survival.test.mjs
@@ -22,7 +22,7 @@
 // mode, and the holder through BOTH of its dispatch doors — `server` with
 // CACHE_FIX_HOLD_PORT=on was the one an earlier fix missed while the other
 // passed, so a single holder row would have called that fixed.
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import net from "node:net";
 import { spawn } from "node:child_process";
@@ -31,7 +31,18 @@ import { withDeadline } from "./child-deadline.mjs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
+import { armLineage, reapStamped } from "./proc-helpers.mjs";
+
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+// EVENT #348. `reap()` below kills the holder's own process GROUP, but
+// openStandby() (bin/claude-via-proxy.mjs) spawns its standby `detached:
+// true` too — Node's detach starts a NEW session, so the standby is never IN
+// that group, and a SIGKILLed holder never runs closeStandby() either. The
+// two `run-service`/`server` cases just past this point are exactly the door
+// that leaves one behind (measured: two `bin/gap-relay.mjs`, ppid 1,
+// STANDBY_PARENT already dead, after a whole-suite run). Same class as
+// proxy-held-port.test.mjs's R3 fix, different file.
+const lineage = armLineage("stdio-epipe-survival");
 const reap = (p) => { try { process.kill(-p.pid, "SIGKILL"); } catch {} try { p.kill("SIGKILL"); } catch {} };
 const cleanEnv = () => {
   const env = { ...process.env };
@@ -192,3 +203,10 @@ describe("a dead stdio reader does not kill the port's process", () => {
 // does this holder have", which is a number on the machine, not a shape in the
 // source. `openStandby` states the same identity rule twenty lines below and had
 // always followed it; this is the sibling that was missed in the same sweep.
+
+// ONE SWEEP FOR THE FILE, by lineage: this file had none before, so a standby
+// `reap()`'s process-group kill cannot reach (detached: true starts a new
+// session) rode past every case's own cleanup. See proc-helpers.mjs's
+// armLineage()/reapStamped() and proxy-held-port.test.mjs's R3 fix, same
+// shape.
+after(async () => { await reapStamped(lineage); });

--- a/test/stdio-epipe-survival.test.mjs
+++ b/test/stdio-epipe-survival.test.mjs
@@ -46,9 +46,15 @@ const lineage = armLineage("stdio-epipe-survival");
 const reap = (p) => { try { process.kill(-p.pid, "SIGKILL"); } catch {} try { p.kill("SIGKILL"); } catch {} };
 const cleanEnv = () => {
   const env = { ...process.env };
+  // CACHE_FIX_SELF_HEAL too: the holder cases below run with PROXY_PORT=0,
+  // which arms exitWithParent() (proxy/server.mjs) — left on, a SIGKILLed
+  // stamped holder spawns a stamped SUCCESSOR after this file's exit backstop
+  // has already taken its snapshot, so it survives the backstop even though
+  // it carries the marker. proxy-held-port.test.mjs:186/:471 scrub it for the
+  // same reason.
   for (const k of ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy",
                    "ALL_PROXY", "all_proxy", "CACHE_FIX_UPSTREAM_PROXY", "CACHE_FIX_REQUIRE_HOP",
-                   "CACHE_FIX_STANDBY", "LISTEN_FDS", "LISTEN_PID"]) delete env[k];
+                   "CACHE_FIX_STANDBY", "CACHE_FIX_SELF_HEAL", "LISTEN_FDS", "LISTEN_PID"]) delete env[k];
   return env;
 };
 const settle = (ms) => new Promise((r) => setTimeout(r, ms));

--- a/test/stdio-epipe-survival.test.mjs
+++ b/test/stdio-epipe-survival.test.mjs
@@ -46,20 +46,35 @@ const lineage = armLineage("stdio-epipe-survival");
 const reap = (p) => { try { process.kill(-p.pid, "SIGKILL"); } catch {} try { p.kill("SIGKILL"); } catch {} };
 const cleanEnv = () => {
   const env = { ...process.env };
-  // CACHE_FIX_SELF_HEAL too: the holder cases below run with PROXY_PORT=0,
-  // which arms exitWithParent() (proxy/server.mjs) — left on, a SIGKILLed
-  // stamped holder spawns a stamped SUCCESSOR after this file's exit backstop
-  // has already taken its snapshot, so it survives the backstop even though
-  // it carries the marker. proxy-held-port.test.mjs:186/:471 scrub it for the
-  // same reason.
   for (const k of ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy",
                    "ALL_PROXY", "all_proxy", "CACHE_FIX_UPSTREAM_PROXY", "CACHE_FIX_REQUIRE_HOP",
-                   "CACHE_FIX_STANDBY", "CACHE_FIX_SELF_HEAL", "LISTEN_FDS", "LISTEN_PID"]) delete env[k];
+                   "CACHE_FIX_STANDBY", "LISTEN_FDS", "LISTEN_PID"]) delete env[k];
+  // ASSIGNED, not deleted: proxy/server.mjs:1519 gates on `!== "off"`, so an
+  // absent var reads as self-heal ON. A delete only clears an ambient value —
+  // where the shell already had CACHE_FIX_SELF_HEAL=off, deleting it would
+  // have turned self-heal back ON, the opposite of this file's premise.
+  Object.assign(env, { CACHE_FIX_SELF_HEAL: "off" });
   return env;
 };
 const settle = (ms) => new Promise((r) => setTimeout(r, ms));
 
 describe("a dead stdio reader does not kill the port's process", () => {
+  // cleanEnv() DELETES CACHE_FIX_SELF_HEAL rather than forcing it "off", but
+  // proxy/server.mjs:1519 gates on `!== "off"` — so where the ambient shell
+  // already exported CACHE_FIX_SELF_HEAL=off, the delete REMOVES that "off"
+  // and self-heal ends up ON, the opposite of what this file's own comment
+  // above cleanEnv() claims.
+  it("cleanEnv() forces self-heal off even when the ambient shell already set it off", () => {
+    const had = "CACHE_FIX_SELF_HEAL" in process.env;
+    const prior = process.env.CACHE_FIX_SELF_HEAL;
+    process.env.CACHE_FIX_SELF_HEAL = "off";
+    try {
+      assert.equal(cleanEnv().CACHE_FIX_SELF_HEAL, "off");
+    } finally {
+      if (had) process.env.CACHE_FIX_SELF_HEAL = prior; else delete process.env.CACHE_FIX_SELF_HEAL;
+    }
+  });
+
   // The relay is the last line of defence: if it dies the address is gone. It
   // needs a REAL socket on fd 3 — handed a pipe it exits 1 by design, which
   // would read as "killed by EPIPE" and prove nothing.

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -126,6 +126,53 @@ test("a test that SIGKILLs a holder reaps the successor, holder first", () => {
     "that a live holder immediately replaces");
 });
 
+// EVENT #348, ROUND 4. The fix for one file (test/stdio-epipe-survival.test.mjs,
+// ledger #348 round 3) shipped with no check that keeps it — the whole class
+// (a detached standby that outlives a SIGKILLed holder) can come back the same
+// way it arrived: a new file spawns the launcher or relay and nobody notices it
+// never called armLineage()/reapStamped() (proc-helpers.mjs).
+//
+// Static, for the same reason the reaper guard above is: the sweep is cleanup
+// code, so nothing fails when a file skips it. FILE-WIDE rather than one named
+// case, because the next file to need this is not the one this guard was
+// written to watch.
+//
+// "Spawns the launcher or relay" is read off the SAME path-construction shape
+// every real spawn site in this tree uses -- `join(..., "bin", "X.mjs")` or a
+// single `"…/bin/X.mjs"` string -- with any readFileSync(...) call blanked
+// first, because two files (this one, and proxy-hop-fallback.test.mjs) name
+// that path only to read the BINARY'S OWN source as text, never to spawn it.
+test("every test file that spawns the launcher or relay carries a lineage marker", () => {
+  // Files that mention the binaries' paths but never spawn them, with why:
+  const EXEMPT = {
+    "fixture-reaping.test.mjs": "spawns a synthetic fixture script; never the real launcher or relay",
+    "proxy-hop-fallback.test.mjs": "reads gap-relay.mjs's source as text (a portOf() regex extraction); never spawns the real binary",
+  };
+  const spawnsOurs = /"bin"\s*,\s*"(?:claude-via-proxy|gap-relay)\.mjs"|["'`][./]*bin\/(?:claude-via-proxy|gap-relay)\.mjs["'`]/;
+  // Line comments blanked before every check below, mention or call alike:
+  // this guard's own added comments say "armLineage()/reapStamped()" in
+  // prose, in every file it arms, and a naive text match on the raw source
+  // cannot tell that from the real call it is standing next to. Not a full
+  // parse (a `//` inside a string survives as a false comment start, same
+  // known gap as everywhere else in this tree that does not reach for
+  // suite-collection.test.mjs's own stripComments()) — good enough for a
+  // guard whose subject never puts one there.
+  const decomment = (s) => s.split("\n").map((l) => l.replace(/\/\/.*$/, "")).join("\n");
+  const files = readdirSync(testDir).filter((f) => f.endsWith(".test.mjs"));
+  const missing = [];
+  for (const f of files) {
+    if (EXEMPT[f]) continue;
+    const code = decomment(readFileSync(join(testDir, f), "utf8"));
+    const stripped = code.replace(/readFileSync\([^)]*\)/g, "");
+    if (!spawnsOurs.test(stripped)) continue;
+    if (!/armLineage\(/.test(code) || !/reapStamped\(/.test(code)) missing.push(f);
+  }
+  assert.deepEqual(missing, [],
+    `these files spawn the launcher or relay but never call armLineage()/reapStamped() ` +
+    `(proc-helpers.mjs) -- a standby a case leaves behind (detached, outlives a SIGKILLed ` +
+    `holder) has nothing to reap it: ${missing.join(", ")}`);
+});
+
 // A FAILURE MESSAGE IS PUBLISHED OUTPUT. proxy-held-port's probes append the
 // 503 body to what they assert on, and the gap relay's 503 body carries the hop
 // it would forward to — so an env var that gives a child a hop and is not

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -180,10 +180,15 @@ const reapsItsLineage = (code) => REAP_SPELLINGS.some(([arm, reap]) => arm.test(
 test("every test file that spawns the launcher or relay carries a lineage marker", () => {
   // Files that mention the binaries' paths but never spawn them, with why:
   const EXEMPT = {
-    "fixture-reaping.test.mjs": "spawns a synthetic fixture script; never the real launcher or relay",
     "proxy-hop-fallback.test.mjs": "reads gap-relay.mjs's source as text (a portOf() regex extraction); never spawns the real binary",
   };
-  const spawnsOurs = /"bin"\s*,\s*"(?:claude-via-proxy|gap-relay)\.mjs"|["'`][./]*bin\/(?:claude-via-proxy|gap-relay)\.mjs["'`]/;
+  // A THIRD BINARY SPAWNS detached:true TOO: proxy/server.mjs. It is also an
+  // importable module (startProxy, capOwnLog, ...), so a bare path-text match
+  // would enrol every file that only imports it and never spawns it. Scoped
+  // to the actual spawn call instead, the same shape every real spawner here
+  // uses: `spawn(process.execPath, [<target>], ...)` with the target either
+  // the literal path or the file's own `serverPath` variable.
+  const spawnsOurs = /"bin"\s*,\s*"(?:claude-via-proxy|gap-relay)\.mjs"|["'`][./]*bin\/(?:claude-via-proxy|gap-relay)\.mjs["'`]|spawn\(\s*process\.execPath,\s*\[\s*(?:serverPath|["'`][./]*proxy\/server\.mjs["'`])\s*\]/;
   // Line comments blanked before every check below, mention or call alike:
   // this guard's own added comments say "armLineage()/reapStamped()" in
   // prose, in every file it arms, and a naive text match on the raw source

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -159,13 +159,23 @@ test("a test that SIGKILLs a holder reaps the successor, holder first", () => {
 // NAMED FUNCTION; separating that from a decoy needs a parser, not a regex.
 //
 // Hoisted out of the sweep so the case below can put code through it directly:
-// widening this into a predicate that is always true, or loosening either `&&`,
-// would look exactly like a pass.
-const REAP_SPELLINGS = 'armLineage() with reapStamped() (proc-helpers.mjs), or ' +
-                       'process.on("exit", ...) with process.kill(...)';
-const reapsItsLineage = (code) =>
-  (/armLineage\(/.test(code) && /reapStamped\(/.test(code))
-  || (/process\.on\("exit"/.test(code) && /process\.kill\(/.test(code));
+// widening this into a predicate that is always true, loosening a pairing, or
+// appending a third one, would all look exactly like a pass.
+//
+// ONE SOURCE OF TRUTH, and the message is DERIVED rather than kept in step: a
+// prose copy of the accept-set drifts the moment a pattern is tightened, and CI
+// then names a file for lacking a spelling it has -- which is the false
+// positive this guard was widened to remove, wearing the message's clothes.
+//
+// The exit hook is matched the tolerant way this file already uses at :88:
+// `process.on('exit'` and `process.on( "exit"` reap exactly as well as the
+// double-quoted, tight-spaced form, and reddening a file over its quoting is
+// the same false positive in a narrower dress.
+const REAP_SPELLINGS = [
+  [/armLineage\(/, /reapStamped\(/],
+  [/process\.on\(\s*["']exit["']/, /process\.kill\(/],
+];
+const reapsItsLineage = (code) => REAP_SPELLINGS.some(([arm, reap]) => arm.test(code) && reap.test(code));
 
 test("every test file that spawns the launcher or relay carries a lineage marker", () => {
   // Files that mention the binaries' paths but never spawn them, with why:
@@ -193,9 +203,21 @@ test("every test file that spawns the launcher or relay carries a lineage marker
     if (!reapsItsLineage(code)) missing.push(f);
   }
   assert.deepEqual(missing, [],
-    `these files spawn the launcher or relay and carry neither spelling of the reap ` +
-    `-- ${REAP_SPELLINGS} -- so a standby a case leaves behind (detached, outlives a ` +
-    `SIGKILLed holder) has nothing to reap it: ${missing.join(", ")}`);
+    `these files spawn the launcher or relay and carry none of the reap spellings ` +
+    `-- ${REAP_SPELLINGS.map(([arm, reap]) => `${arm.source} with ${reap.source}`).join("; or ")} ` +
+    `-- so a standby a case leaves behind (detached, outlives a SIGKILLed holder) has ` +
+    `nothing to reap it: ${missing.join(", ")}`);
+
+  // THIS FILE MUST NOT ENROL ITSELF IN THE SWEEP IT RUNS. The predicate's case
+  // below carries every reap token as a decoy literal, so enrolment stopped
+  // being impossible and became merely absent: a future fixture that spells a
+  // bin path would enrol this file and PASS on decoys, silently. 993a2fc is
+  // this going wrong once already, caught by inspection rather than by a check.
+  const self = decomment(readFileSync(join(testDir, "suite-collection.test.mjs"), "utf8"));
+  assert.equal(spawnsOurs.test(self.replace(/readFileSync\([^)]*\)/g, "")), false,
+    "a fixture in this file now spells a launcher or relay path, so the sweep above " +
+    "counts this file as one that spawns them -- it spawns nothing, and it would pass " +
+    "on the decoy reap tokens its own predicate case carries");
 });
 
 // A WIDENED GUARD THAT CATCHES NOTHING IS THE REGRESSION, and it is invisible:
@@ -206,26 +228,38 @@ test("every test file that spawns the launcher or relay carries a lineage marker
 // above (measured: it did, and 993a2fc took it back out).
 //
 // HALF OF EACH PAIRING IS A NEGATIVE, because "not always true" is all a
-// no-op injection proves: loosening either `&&` to `||` leaves every positive
-// below green, and only these four say so.
-test("the lineage predicate rejects code with no reap, and neither half alone", () => {
+// no-op injection proves: loosening a pairing to an `||` leaves every positive
+// below green, and only the negatives say so.
+//
+// AND ONE NEGATIVE BELONGS TO NO PAIRING, because the ones that do cannot see a
+// THIRD entry appended to the list. `[/spawn\(/, /SIGKILL/]` passes every other
+// assert here -- the no-reap fixture has `spawn(` without SIGKILL, the kill
+// fixture has SIGKILL without `spawn(` -- while accepting a file that spawns a
+// launcher and SIGKILLs a holder and reaps nothing, which is the whole class.
+test("the lineage predicate rejects code with no reap, and no half of a pairing alone", () => {
   assert.equal(reapsItsLineage("const h = spawn(process.execPath, [launcherPath]);"), false,
     "code that never reaps now passes the lineage guard -- the predicate was widened " +
     "into a no-op and the sweep above is decoration");
+  assert.equal(reapsItsLineage('spawn(launcherPath); process.kill(pid, "SIGKILL");'), false,
+    "spawning a launcher and killing it counts as reaping its lineage -- a pairing was " +
+    "appended that is satisfied by the defect this guard exists to catch");
 
   assert.equal(reapsItsLineage('armLineage("f"); reapStamped("f");'), true,
     "the shared proc-helpers spelling stopped counting as a reap");
   assert.equal(reapsItsLineage('armLineage("f");'), false,
-    "arming a lineage nobody reaps counts as a reap -- the first `&&` was loosened");
+    "arming a lineage nobody reaps counts as a reap -- the first pairing was loosened");
   assert.equal(reapsItsLineage('reapStamped("f");'), false,
-    "reaping a lineage nobody armed counts as a reap -- the first `&&` was loosened");
+    "reaping a lineage nobody armed counts as a reap -- the first pairing was loosened");
 
   assert.equal(reapsItsLineage('process.on("exit", r);\nprocess.kill(q, "SIGKILL");'), true,
     "a file's own exit-time reap stopped counting -- this is the widening itself");
+  assert.equal(reapsItsLineage("process.on( 'exit', r);\nprocess.kill(q, 'SIGKILL');"), true,
+    "the exit hook is matched by exact spelling again -- a file that quotes or spaces it " +
+    "differently reds while genuinely reaping, the false positive in a narrower dress");
   assert.equal(reapsItsLineage('process.on("exit", r);'), false,
-    "an exit hook that kills nothing counts as a reap -- the second `&&` was loosened");
+    "an exit hook that kills nothing counts as a reap -- the second pairing was loosened");
   assert.equal(reapsItsLineage('process.kill(q, "SIGKILL");'), false,
-    "a kill with no exit-time hook counts as a reap -- the second `&&` was loosened");
+    "a kill with no exit-time hook counts as a reap -- the second pairing was loosened");
 });
 
 // A FAILURE MESSAGE IS PUBLISHED OUTPUT. proxy-held-port's probes append the

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -142,6 +142,22 @@ test("a test that SIGKILLs a holder reaps the successor, holder first", () => {
 // single `"…/bin/X.mjs"` string -- with any readFileSync(...) call blanked
 // first, because two files (this one, and proxy-hop-fallback.test.mjs) name
 // that path only to read the BINARY'S OWN source as text, never to spawn it.
+// ANY SPELLING OF THE SWEEP COUNTS, exactly as the port-sweep guard does with
+// onPort()/listeners()/process.kill(-) -- what is required is that the file
+// reaps what it spawned, not that it reaches for one helper. Measured
+// 2026-09-08 on the integrated build: proxy-holder-stop-in-flight.test.mjs was
+// named here while genuinely reaping (its exit hook removed, one gap-relay.mjs
+// survived at +20s; intact, none did), and the helpers it was told to call are
+// on this branch only, so the file could not have called them. A guard that
+// reds a file which does the thing is a guard people route around.
+//
+// Hoisted out of the sweep so the case below can put a bare spawner through it:
+// widening this into a predicate that is always true would look exactly like a
+// pass.
+const reapsItsLineage = (code) =>
+  (/armLineage\(/.test(code) && /reapStamped\(/.test(code))
+  || (/process\.on\("exit"/.test(code) && /process\.kill\(/.test(code));
+
 test("every test file that spawns the launcher or relay carries a lineage marker", () => {
   // Files that mention the binaries' paths but never spawn them, with why:
   const EXEMPT = {
@@ -165,12 +181,27 @@ test("every test file that spawns the launcher or relay carries a lineage marker
     const code = decomment(readFileSync(join(testDir, f), "utf8"));
     const stripped = code.replace(/readFileSync\([^)]*\)/g, "");
     if (!spawnsOurs.test(stripped)) continue;
-    if (!/armLineage\(/.test(code) || !/reapStamped\(/.test(code)) missing.push(f);
+    if (!reapsItsLineage(code)) missing.push(f);
   }
   assert.deepEqual(missing, [],
-    `these files spawn the launcher or relay but never call armLineage()/reapStamped() ` +
-    `(proc-helpers.mjs) -- a standby a case leaves behind (detached, outlives a SIGKILLed ` +
-    `holder) has nothing to reap it: ${missing.join(", ")}`);
+    `these files spawn the launcher or relay and reap it by no spelling -- neither ` +
+    `armLineage()/reapStamped() (proc-helpers.mjs) nor an exit-time reap of their own, so ` +
+    `a standby a case leaves behind (detached, outlives a SIGKILLed holder) has nothing ` +
+    `to reap it: ${missing.join(", ")}`);
+});
+
+// A WIDENED GUARD THAT CATCHES NOTHING IS THE REGRESSION, and it is invisible:
+// the sweep above goes green either way. So the predicate is exercised directly
+// on a file that spawns the launcher and reaps by no spelling at all.
+test("the lineage predicate still catches a spawner that reaps by no spelling", () => {
+  const bare = 'const h = spawn(process.execPath, [join(d, "bin", "claude-via-proxy.mjs"), "run-service"]);';
+  assert.equal(reapsItsLineage(bare), false,
+    "a file that spawns the launcher and never reaps now passes the lineage guard -- " +
+    "the predicate was widened into a no-op and the sweep above is decoration");
+  assert.equal(reapsItsLineage(bare + '\narmLineage("f"); reapStamped("f");'), true,
+    "the shared proc-helpers spelling stopped counting as a reap");
+  assert.equal(reapsItsLineage(bare + '\nprocess.on("exit", r);\nprocess.kill(q, "SIGKILL");'), true,
+    "a file's own exit-time reap stopped counting -- this is the widening itself");
 });
 
 // A FAILURE MESSAGE IS PUBLISHED OUTPUT. proxy-held-port's probes append the

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -194,7 +194,11 @@ test("every test file that spawns the launcher or relay carries a lineage marker
 // the sweep above goes green either way. So the predicate is exercised directly
 // on a file that spawns the launcher and reaps by no spelling at all.
 test("the lineage predicate still catches a spawner that reaps by no spelling", () => {
-  const bare = 'const h = spawn(process.execPath, [join(d, "bin", "claude-via-proxy.mjs"), "run-service"]);';
+  // The launcher path is a variable, not spelled out: a fixture carrying the
+  // literal would enrol THIS file in the sweep above, which spawns nothing. The
+  // predicate never reads the path -- the sweep decides who is asked, this
+  // decides what the answer is.
+  const bare = 'const h = spawn(process.execPath, [launcherPath, "run-service"]);';
   assert.equal(reapsItsLineage(bare), false,
     "a file that spawns the launcher and never reaps now passes the lineage guard -- " +
     "the predicate was widened into a no-op and the sweep above is decoration");

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -142,18 +142,27 @@ test("a test that SIGKILLs a holder reaps the successor, holder first", () => {
 // single `"…/bin/X.mjs"` string -- with any readFileSync(...) call blanked
 // first, because two files (this one, and proxy-hop-fallback.test.mjs) name
 // that path only to read the BINARY'S OWN source as text, never to spawn it.
-// ANY SPELLING OF THE SWEEP COUNTS, exactly as the port-sweep guard does with
-// onPort()/listeners()/process.kill(-) -- what is required is that the file
-// reaps what it spawned, not that it reaches for one helper. Measured
-// 2026-09-08 on the integrated build: proxy-holder-stop-in-flight.test.mjs was
-// named here while genuinely reaping (its exit hook removed, one gap-relay.mjs
-// survived at +20s; intact, none did), and the helpers it was told to call are
-// on this branch only, so the file could not have called them. A guard that
-// reds a file which does the thing is a guard people route around.
+// ANY SPELLING OF THE SWEEP COUNTS -- what is required is that the file reaps
+// what it spawned, not that it reaches for one helper. Exactly two spellings,
+// stated in REAP_SPELLINGS below and nowhere else, because the failure message
+// is the only description of this predicate anyone reads. Measured 2026-09-08
+// on the integrated build: proxy-holder-stop-in-flight.test.mjs was named here
+// while genuinely reaping (its exit hook removed, one gap-relay.mjs survived at
+// +20s; intact, none did), and the helpers it was told to call are on this
+// branch only, so the file could not have called them. A guard that reds a file
+// which does the thing is a guard people route around.
 //
-// Hoisted out of the sweep so the case below can put a bare spawner through it:
-// widening this into a predicate that is always true would look exactly like a
-// pass.
+// KNOWN LIMIT, recorded rather than closed: this tests CO-OCCURRENCE, not
+// containment -- the kill may sit anywhere in the file rather than inside the
+// exit handler. Requiring containment would red this guard's own subject again,
+// which spells it `process.on("exit", reapStandbys)` with the kill inside the
+// NAMED FUNCTION; separating that from a decoy needs a parser, not a regex.
+//
+// Hoisted out of the sweep so the case below can put code through it directly:
+// widening this into a predicate that is always true, or loosening either `&&`,
+// would look exactly like a pass.
+const REAP_SPELLINGS = 'armLineage() with reapStamped() (proc-helpers.mjs), or ' +
+                       'process.on("exit", ...) with process.kill(...)';
 const reapsItsLineage = (code) =>
   (/armLineage\(/.test(code) && /reapStamped\(/.test(code))
   || (/process\.on\("exit"/.test(code) && /process\.kill\(/.test(code));
@@ -184,28 +193,39 @@ test("every test file that spawns the launcher or relay carries a lineage marker
     if (!reapsItsLineage(code)) missing.push(f);
   }
   assert.deepEqual(missing, [],
-    `these files spawn the launcher or relay and reap it by no spelling -- neither ` +
-    `armLineage()/reapStamped() (proc-helpers.mjs) nor an exit-time reap of their own, so ` +
-    `a standby a case leaves behind (detached, outlives a SIGKILLed holder) has nothing ` +
-    `to reap it: ${missing.join(", ")}`);
+    `these files spawn the launcher or relay and carry neither spelling of the reap ` +
+    `-- ${REAP_SPELLINGS} -- so a standby a case leaves behind (detached, outlives a ` +
+    `SIGKILLed holder) has nothing to reap it: ${missing.join(", ")}`);
 });
 
 // A WIDENED GUARD THAT CATCHES NOTHING IS THE REGRESSION, and it is invisible:
-// the sweep above goes green either way. So the predicate is exercised directly
-// on a file that spawns the launcher and reaps by no spelling at all.
-test("the lineage predicate still catches a spawner that reaps by no spelling", () => {
-  // The launcher path is a variable, not spelled out: a fixture carrying the
-  // literal would enrol THIS file in the sweep above, which spawns nothing. The
-  // predicate never reads the path -- the sweep decides who is asked, this
-  // decides what the answer is.
-  const bare = 'const h = spawn(process.execPath, [launcherPath, "run-service"]);';
-  assert.equal(reapsItsLineage(bare), false,
-    "a file that spawns the launcher and never reaps now passes the lineage guard -- " +
-    "the predicate was widened into a no-op and the sweep above is decoration");
-  assert.equal(reapsItsLineage(bare + '\narmLineage("f"); reapStamped("f");'), true,
+// the sweep above goes green either way, so the predicate is exercised here
+// directly. The fixtures are the reap spellings and nothing else -- the
+// predicate never reads whether the code around them looks like a spawner, and
+// a fixture that spelled a launcher path out would enrol THIS file in the sweep
+// above (measured: it did, and 993a2fc took it back out).
+//
+// HALF OF EACH PAIRING IS A NEGATIVE, because "not always true" is all a
+// no-op injection proves: loosening either `&&` to `||` leaves every positive
+// below green, and only these four say so.
+test("the lineage predicate rejects code with no reap, and neither half alone", () => {
+  assert.equal(reapsItsLineage("const h = spawn(process.execPath, [launcherPath]);"), false,
+    "code that never reaps now passes the lineage guard -- the predicate was widened " +
+    "into a no-op and the sweep above is decoration");
+
+  assert.equal(reapsItsLineage('armLineage("f"); reapStamped("f");'), true,
     "the shared proc-helpers spelling stopped counting as a reap");
-  assert.equal(reapsItsLineage(bare + '\nprocess.on("exit", r);\nprocess.kill(q, "SIGKILL");'), true,
+  assert.equal(reapsItsLineage('armLineage("f");'), false,
+    "arming a lineage nobody reaps counts as a reap -- the first `&&` was loosened");
+  assert.equal(reapsItsLineage('reapStamped("f");'), false,
+    "reaping a lineage nobody armed counts as a reap -- the first `&&` was loosened");
+
+  assert.equal(reapsItsLineage('process.on("exit", r);\nprocess.kill(q, "SIGKILL");'), true,
     "a file's own exit-time reap stopped counting -- this is the widening itself");
+  assert.equal(reapsItsLineage('process.on("exit", r);'), false,
+    "an exit hook that kills nothing counts as a reap -- the second `&&` was loosened");
+  assert.equal(reapsItsLineage('process.kill(q, "SIGKILL");'), false,
+    "a kill with no exit-time hook counts as a reap -- the second `&&` was loosened");
 });
 
 // A FAILURE MESSAGE IS PUBLISHED OUTPUT. proxy-held-port's probes append the

--- a/test/suite-collection.test.mjs
+++ b/test/suite-collection.test.mjs
@@ -195,10 +195,12 @@ test("every test file that spawns the launcher or relay carries a lineage marker
   const decomment = (s) => s.split("\n").map((l) => l.replace(/\/\/.*$/, "")).join("\n");
   const files = readdirSync(testDir).filter((f) => f.endsWith(".test.mjs"));
   const missing = [];
+  let selfEnrolled;
   for (const f of files) {
     if (EXEMPT[f]) continue;
     const code = decomment(readFileSync(join(testDir, f), "utf8"));
     const stripped = code.replace(/readFileSync\([^)]*\)/g, "");
+    if (f === "suite-collection.test.mjs") selfEnrolled = spawnsOurs.test(stripped);
     if (!spawnsOurs.test(stripped)) continue;
     if (!reapsItsLineage(code)) missing.push(f);
   }
@@ -213,11 +215,18 @@ test("every test file that spawns the launcher or relay carries a lineage marker
   // being impossible and became merely absent: a future fixture that spells a
   // bin path would enrol this file and PASS on decoys, silently. 993a2fc is
   // this going wrong once already, caught by inspection rather than by a check.
-  const self = decomment(readFileSync(join(testDir, "suite-collection.test.mjs"), "utf8"));
-  assert.equal(spawnsOurs.test(self.replace(/readFileSync\([^)]*\)/g, "")), false,
+  //
+  // Read off the LOOP'S OWN verdict rather than recomputed. A second copy of
+  // "what counts as spawning" would go quiet, not red, the day the blanking
+  // above changes: the sweep would enrol under the new rule while this asserted
+  // under the old. `undefined` if the loop never reached this file at all, which
+  // is not `false` -- so a rename or an EXEMPT entry reds here instead of
+  // disarming the pin.
+  assert.equal(selfEnrolled, false,
     "a fixture in this file now spells a launcher or relay path, so the sweep above " +
     "counts this file as one that spawns them -- it spawns nothing, and it would pass " +
-    "on the decoy reap tokens its own predicate case carries");
+    "on the decoy reap tokens its own predicate case carries (undefined here means the " +
+    "sweep never reached this file, so the pin was reading nothing)");
 });
 
 // A WIDENED GUARD THAT CATCHES NOTHING IS THE REGRESSION, and it is invisible:
@@ -237,6 +246,15 @@ test("every test file that spawns the launcher or relay carries a lineage marker
 // fixture has SIGKILL without `spawn(` -- while accepting a file that spawns a
 // launcher and SIGKILLs a holder and reaps nothing, which is the whole class.
 test("the lineage predicate rejects code with no reap, and no half of a pairing alone", () => {
+  // THE LIST ITSELF, because no number of fixtures can bound an open-ended one:
+  // `[/detached/, /kill\(/]` and `[/afterEach\(/, /kill/]` both pass every
+  // assertion below while accepting a file that spawns detached, kills
+  // something, and reaps nothing. Same contract this file puts on the
+  // CONCURRENCY roster at :1084 -- a new one is fine, add it HERE, deliberately.
+  assert.equal(REAP_SPELLINGS.length, 2,
+    "a reap spelling was added or dropped without a fixture pair to say what it accepts " +
+    "-- a new one is fine, add it here with a positive and a negative for each half");
+
   assert.equal(reapsItsLineage("const h = spawn(process.execPath, [launcherPath]);"), false,
     "code that never reaps now passes the lineage guard -- the predicate was widened " +
     "into a no-op and the sweep above is decoration");


### PR DESCRIPTION
## What a test run left behind

Two classes of process outlived their test runs on a Linux dev box for 4-11 days: 17 `claude-via-proxy.mjs run-service` holders (each owning a `proxy/server.mjs` and a `bin/gap-relay.mjs`) and 85+ orphaned `bin/gap-relay.mjs` standbys. Both were measured to a line.

### Root cause 1: an orphaned proxy re-spawns its holder on every tick

`proxy/server.mjs` `exitWithParent()` never assigned its self-heal `setInterval` handle, so once a `run-service` holder was SIGKILLed (the "holder crash is survivable" cases in `test/proxy-held-port.test.mjs`) the orphaned server spawned a detached successor on every 1 s tick for as long as it lived: 2 successors in 20 s from one orphan when measured in isolation, and 14 holders born inside 7 s in the incident, each on its own port, each with its own server and standby.

Fix: hold the handle and clear it after the one spawn (and on `releasingPort`). One successor per orphan. `test/orphan-self-heal-cap.test.mjs` spawns a holder the way the SIGKILL cases do, kills it, and asserts exactly one self-heal announcement (red before: "saw 3 in 3s" at `CACHE_FIX_SELF_HEAL_MS=50`).

### Root cause 2: the file-level sweep only knew the ports it had registered

`test/proxy-held-port.test.mjs`'s `after()` reaped by `usedPorts`, which only `freePort()` fills. The case that asks for an ephemeral port (`CACHE_FIX_PROXY_PORT: "0"`) never registered the kernel-picked port, so its standby (detached at birth, yields only on SIGHUP by design) outlived the run.

Fix: stamp the file's lineage with one inherited env var before any spawn (every spawn site spreads `process.env`), and have `after()` plus a `process.on("exit")` backstop reap every stamped survivor (`stamped()`/`reapStamped()` in `test/proc-helpers.mjs`, sharing `byEnv()` with `ours()`). A new case leaks a standby on an unregistered port on purpose, and `test/orphan-lineage-sweep-harness.test.mjs` runs the file from outside and asserts the pid is gone (red with the sweep disabled).

### Test plan

- `node --test test/orphan-self-heal-cap.test.mjs`
- `node --test test/orphan-lineage-sweep-harness.test.mjs`
- `node --test --test-name-pattern "leaves a standby" test/proxy-held-port.test.mjs`
- `npm test`
